### PR TITLE
docs: add Further Reading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ A commercial license is available for use cases where AGPL-3.0 copyleft is not s
 
 ---
 
+## Further Reading
+
+- [Why Every AI Runtime Needs a Kill Switch](https://phionyxresearch.substack.com/p/why-every-ai-runtime-needs-a-kill)
+- [Inside the 46-Block Deterministic AI Pipeline](https://phionyxresearch.substack.com/p/inside-the-46-block-deterministic)
+
+---
+
 ## Links
 
 - **Website:** [phionyx.ai](https://phionyx.ai)


### PR DESCRIPTION
## Summary
- Adds a **Further Reading** section to the README with links to the two published Substack articles from the Deterministic AI Engineering series
- Kill Switch article (Post 1) and 46-Block Pipeline article (Post 2)

## Test plan
- [ ] Verify links render correctly on GitHub
- [ ] Verify URLs resolve to published Substack posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)