### PR TITLE
ci: pytest matrix (3.10/3.11/3.12) + build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs when a new commit is pushed to the same PR / branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package + dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Show resolved versions
+        run: |
+          python --version
+          pip --version
+          pip list | grep -E "^(phionyx-core|pydantic|numpy|PyYAML)" || true
+
+      - name: Smoke import
+        run: |
+          python -c "import phionyx_core; print('phionyx_core', phionyx_core.__version__)"
+          python -c "from phionyx_core import EchoState2, calculate_phi_v2_1, PipelineBlock"
+          python -c "from phionyx_core.governance.kill_switch import KillSwitch; print('kill switch', KillSwitch().state.value)"
+
+      - name: Run pytest (tests/core)
+        run: pytest tests/core -q --tb=short
+
+      - name: Run pytest (tests/benchmarks)
+        run: pytest tests/benchmarks -q --tb=short
+
+  build:
+    name: build sdist + wheel
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Twine check
+        run: python -m twine check dist/*
+
+      # Mirrors what a user gets from `pip install phionyx-core` once the
+      # wheel is on PyPI. Catches packaging mistakes that an editable
+      # install (used in the test job above) cannot surface.
+      - name: Smoke install + import from built wheel
+        run: |
+          python -m venv /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install --quiet dist/phionyx_core-*.whl
+          /tmp/wheel-smoke/bin/python -c "
+          import phionyx_core
+          from phionyx_core import EchoState2, calculate_phi_v2_1
+          from phionyx_core.governance.kill_switch import KillSwitch
+          from phionyx_core.contracts.telemetry import get_canonical_blocks
+          assert phionyx_core.__version__ == '0.2.0'
+          assert len(get_canonical_blocks()) == 46
+          s = EchoState2(A=0.5, V=0.3, H=0.4)
+          r = calculate_phi_v2_1(valence=s.V, arousal=s.A, amplitude=5.0,
+              time_delta=0.1, gamma=0.15, stability=s.stability,
+              entropy=s.H, w_c=0.6, w_p=0.4)
+          assert r['phi'] > 0
+          assert KillSwitch().state.value == 'armed'
+          print('wheel smoke: ok')
+          "
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 **Deterministic AI runtime that treats LLM outputs as sensor measurements, not decisions.**
 
+[![CI](https://github.com/halvrenofviryel/phionyx-research/actions/workflows/ci.yml/badge.svg)](https://github.com/halvrenofviryel/phionyx-research/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/halvrenofviryel/phionyx-research)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-2%2C571%20pass-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-1%2C013%20pass-brightgreen.svg)](tests/)
 
 Most AI frameworks let the LLM decide. Phionyx doesn't. Every LLM response passes through a 46-block deterministic pipeline with safety gates, ethics checks, and physics-based state tracking — before it reaches the user.
 


### PR DESCRIPTION
## Summary

Adds the first GitHub Actions workflow for this repository. Targets PR #19 as the base so the diff is just CI; once #19 merges, this auto-rebases against \`main\`.

### What runs

\`\`\`
on:
  push:    { branches: [main] }
  pull_request: { branches: [main] }
\`\`\`

**\`test\` job** — matrix over Python 3.10 / 3.11 / 3.12:

1. Checkout
2. Setup Python with pip cache
3. \`pip install -e ".[dev]"\`
4. Smoke import: \`phionyx_core\`, \`EchoState2\`, \`calculate_phi_v2_1\`, \`KillSwitch\`
5. \`pytest tests/core -q --tb=short\`

**\`build\` job** — runs after \`test\` passes:

1. \`python -m build\` (sdist + wheel)
2. \`twine check dist/*\`
3. Upload \`dist/\` as a 7-day artifact so a release can grab it without rebuilding

\`concurrency\` cancels superseded runs on the same PR / branch.

## README

- New **CI** badge at the top of the badge row.
- Test-count badge corrected from \"2,571 pass\" (the monorepo number, not what this repo actually runs) to \"1,013 pass\" — the real \`tests/core\` count on a clean clone after #19 lands.

## Why a separate PR from #19

The CI workflow only passes once #19 lands (yaml + numpy in required deps + the \`test_mind_loop_validator\` fix). Branching off \`packaging/pypi-readiness\` means this PR's diff against \`main\` carries those fixes too — so when #19 merges, this rebases without conflict and the \`main\` CI run is green.

If you want a single combined PR instead, say so and I'll fold them.

## Test plan

- [x] Workflow YAML lints clean (\`actions/setup-python@v5\` + \`actions/checkout@v4\` are current major versions)
- [x] \`pytest tests/core -q\` passes 1,013 / 0 failed locally on Python 3.12 (post-#19)
- [x] \`python -m build\` produces sdist + wheel cleanly
- [x] \`python -m twine check dist/*\` PASSED
- [ ] First CI run on this PR will be the live verification — flag any failure and I'll iterate