### PR TITLE
tests/contract: skip monorepo-only deps + run in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run pytest (tests/core)
         run: pytest tests/core -q --tb=short
 
+      - name: Run pytest (tests/contract)
+        run: pytest tests/contract -q --tb=short
+
       - name: Run pytest (tests/benchmarks)
         run: pytest tests/benchmarks -q --tb=short
 

--- a/tests/contract/test_block_determinism.py
+++ b/tests/contract/test_block_determinism.py
@@ -80,6 +80,12 @@ def test_matrix_doc_in_sync():
     """Running ``generate_determinism_matrix.py --check`` must succeed,
     proving the committed matrix doc matches the current code."""
     script = REPO_ROOT / "scripts" / "active" / "generate_determinism_matrix.py"
+    if not script.exists():
+        pytest.skip(
+            "generate_determinism_matrix.py is monorepo-only and not "
+            "shipped on the public SDK release. The doc is regenerated "
+            "in the monorepo and committed manually here."
+        )
     result = subprocess.run(
         [sys.executable, str(script), "--check"],
         capture_output=True,

--- a/tests/contract/test_product_registry.py
+++ b/tests/contract/test_product_registry.py
@@ -28,9 +28,17 @@ from pathlib import Path
 import pytest
 import yaml
 
-from phionyx_products.config_loader import ProductConfigLoader
-from phionyx_products.product_manager import DevelopmentStage
-from phionyx_products.product_registry import ProductRegistry
+# `phionyx_products` is monorepo-only — it ships in the founder's
+# internal repo but not in this public SDK release. Skip the whole
+# module on a clean clone so the rest of `tests/contract` can run.
+pytest.importorskip(
+    "phionyx_products",
+    reason="phionyx_products is monorepo-only; this contract test skips on the public SDK release",
+)
+
+from phionyx_products.config_loader import ProductConfigLoader  # noqa: E402
+from phionyx_products.product_manager import DevelopmentStage  # noqa: E402
+from phionyx_products.product_registry import ProductRegistry  # noqa: E402
 
 
 PRODUCTS_DIR = Path(__file__).resolve().parents[2] / "phionyx_products" / "products"


### PR DESCRIPTION
Two tests in tests/contract fail on a clean clone because they reference monorepo-only artifacts:

1. **test_product_registry.py** imports from phionyx_products. That package is monorepo-only (internal product configs), not shipped here. Now uses pytest.importorskip at module level so the file cleanly skips on a public clone, runs as before inside the monorepo.

2. **test_block_determinism.py::test_matrix_doc_in_sync** invokes scripts/active/generate_determinism_matrix.py --check. That script lives only in the monorepo. The test now skips with a clear reason if the script is absent. The committed DETERMINISM_MATRIX.md is regenerated in the monorepo and copied here at release time.

## Result

```
$ pytest tests/contract -q
107 passed, 2 skipped, 0 failed in 3.96s
```

CI workflow updated to run `tests/contract` alongside `tests/core` and `tests/benchmarks`. Total clean-clone test count rises from 1,013 to **1,230** (1013 core + 107 contract + 10 benchmarks), all green.