### PR TITLE
chore(pydantic): migrate V1 patterns to V2 across phionyx_core

### DIFF
--- a/phionyx_core/cep/cep_config.py
+++ b/phionyx_core/cep/cep_config.py
@@ -6,7 +6,7 @@ Configuration management for Conscious Echo Proof (CEP) engine.
 Supports profile-based configuration with YAML loading capability.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, List, Literal, Optional
 from pathlib import Path
 import logging
@@ -35,11 +35,7 @@ class CEPConfig(BaseModel):
         description="CEP thresholds for evaluation"
     )
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-
-
+    model_config = ConfigDict(use_enum_values=True)
 def _cep_config_search_paths(profile_name: str) -> List[Path]:
     """Return candidate paths for CEP profile YAML (first existing wins)."""
     base = Path(__file__).resolve().parent

--- a/phionyx_core/contracts/envelopes/agent_envelope.py
+++ b/phionyx_core/contracts/envelopes/agent_envelope.py
@@ -7,7 +7,7 @@ Enhanced with envelope hardening (Paket E): message_id, turn_id, timestamp, TTL,
 """
 
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from datetime import datetime, timezone
 import uuid
 
@@ -63,7 +63,8 @@ class AgentMessageEnvelope(BaseModel):
     )
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
-    @validator('message_id')
+    @field_validator('message_id')
+    @classmethod
     def validate_message_id(cls, v):
         """Validate message_id is a valid UUID."""
         try:
@@ -72,7 +73,8 @@ class AgentMessageEnvelope(BaseModel):
         except ValueError:
             raise ValueError(f"message_id must be a valid UUID, got: {v}")
 
-    @validator('timestamp_utc')
+    @field_validator('timestamp_utc')
+    @classmethod
     def validate_timestamp(cls, v):
         """Validate timestamp is ISO8601 format."""
         try:
@@ -81,7 +83,8 @@ class AgentMessageEnvelope(BaseModel):
         except (ValueError, AttributeError):
             raise ValueError(f"timestamp_utc must be ISO8601 format, got: {v}")
 
-    @validator('nonce')
+    @field_validator('nonce')
+    @classmethod
     def validate_nonce(cls, v):
         """Validate nonce is non-empty."""
         if not v or not v.strip():
@@ -234,7 +237,7 @@ class AgentMessageEnvelope(BaseModel):
             "intent": self.intent,
             "payload": self.payload,
             "capabilities": self.capabilities,
-            "cognitive_metrics": self.cognitive_metrics.dict() if self.cognitive_metrics else None,
+            "cognitive_metrics": self.cognitive_metrics.model_dump() if self.cognitive_metrics else None,
             "metadata": self.metadata
         }
 

--- a/phionyx_core/contracts/envelopes/turn_envelope.py
+++ b/phionyx_core/contracts/envelopes/turn_envelope.py
@@ -15,7 +15,7 @@ Schema version: 1.0
 """
 
 from typing import Optional
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 import hashlib
 
 
@@ -37,14 +37,16 @@ class TurnEnvelope(BaseModel):
     # Optional fields
     parent_turn_id: Optional[int] = Field(None, description="Parent turn ID (for conversation threading)")
 
-    @validator('turn_id')
+    @field_validator('turn_id')
+    @classmethod
     def validate_turn_id(cls, v):
         """Turn ID must be positive integer (starts at 1)."""
         if v < 1:
             raise ValueError(f"turn_id must be >= 1, got {v}")
         return v
 
-    @validator('user_text_sha256')
+    @field_validator('user_text_sha256')
+    @classmethod
     def validate_sha256_format(cls, v):
         """SHA256 hash must be 64 hex characters."""
         if len(v) != 64:
@@ -65,22 +67,7 @@ class TurnEnvelope(BaseModel):
         computed_hash = self.compute_sha256(self.user_text)
         return computed_hash.lower() == self.user_text_sha256.lower()
 
-    class Config:
-        """Pydantic config."""
-        json_schema_extra = {
-            "example": {
-                "conversation_id": "conv_abc123",
-                "turn_id": 1,
-                "message_id": "550e8400-e29b-41d4-a716-446655440000",
-                "user_text": "Hello, how are you?",
-                "user_text_sha256": "a1b2c3d4e5f6...",
-                "client_timestamp_ms": 1704067200000,
-                "schema_version": "1.0",
-                "parent_turn_id": None
-            }
-        }
-
-
+    model_config = ConfigDict(json_schema_extra={'example': {'conversation_id': 'conv_abc123', 'turn_id': 1, 'message_id': '550e8400-e29b-41d4-a716-446655440000', 'user_text': 'Hello, how are you?', 'user_text_sha256': 'a1b2c3d4e5f6...', 'client_timestamp_ms': 1704067200000, 'schema_version': '1.0', 'parent_turn_id': None}})
 class DeliveryAck(BaseModel):
     """
     Delivery acknowledgment - confirms message was received correctly.
@@ -97,17 +84,4 @@ class DeliveryAck(BaseModel):
     delivery_status: str = Field(default="delivered", description="Delivery status: delivered, mismatch, rejected")
     delivery_error: Optional[str] = Field(None, description="Error message if delivery failed")
 
-    class Config:
-        """Pydantic config."""
-        json_schema_extra = {
-            "example": {
-                "conversation_id": "conv_abc123",
-                "turn_id": 1,
-                "message_id": "550e8400-e29b-41d4-a716-446655440000",
-                "received_user_text_sha256": "a1b2c3d4e5f6...",
-                "prompt_context_sha256": "b2c3d4e5f6a1...",
-                "delivery_status": "delivered",
-                "delivery_error": None
-            }
-        }
-
+    model_config = ConfigDict(json_schema_extra={'example': {'conversation_id': 'conv_abc123', 'turn_id': 1, 'message_id': '550e8400-e29b-41d4-a716-446655440000', 'received_user_text_sha256': 'a1b2c3d4e5f6...', 'prompt_context_sha256': 'b2c3d4e5f6a1...', 'delivery_status': 'delivered', 'delivery_error': None}})

--- a/phionyx_core/contracts/participants.py
+++ b/phionyx_core/contracts/participants.py
@@ -8,7 +8,7 @@ This allows phionyx_core to work with participants without depending on bridge.
 
 from typing import Optional
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ParticipantType(str, Enum):
@@ -30,7 +30,4 @@ class ParticipantRef(BaseModel):
     name: Optional[str] = Field(None, description="Participant name")
     metadata: Optional[dict] = Field(None, description="Additional metadata")
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-
+    model_config = ConfigDict(use_enum_values=True)

--- a/phionyx_core/contracts/v4/action_intent.py
+++ b/phionyx_core/contracts/v4/action_intent.py
@@ -9,7 +9,7 @@ Includes sandbox/reversibility metadata for safe execution.
 
 from typing import Optional, Dict, Any
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -113,12 +113,4 @@ class ActionIntent(BaseModel):
     trace_id: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "action_type": "respond",
-                "reversibility": "fully_reversible",
-                "sandbox_required": False,
-                "confidence": 0.85,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'action_type': 'respond', 'reversibility': 'fully_reversible', 'sandbox_required': False, 'confidence': 0.85}})

--- a/phionyx_core/contracts/v4/audit_record.py
+++ b/phionyx_core/contracts/v4/audit_record.py
@@ -7,7 +7,7 @@ hash chain for immutability, and structured audit trail.
 """
 
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 import hashlib
@@ -152,12 +152,4 @@ class AuditRecord(BaseModel):
             return False
         return True
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "sequence_number": 42,
-                "turn_id": 5,
-                "event_type": "turn_complete",
-                "actor": "system",
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'sequence_number': 42, 'turn_id': 5, 'event_type': 'turn_complete', 'actor': 'system'}})

--- a/phionyx_core/contracts/v4/confidence_payload.py
+++ b/phionyx_core/contracts/v4/confidence_payload.py
@@ -8,7 +8,7 @@ ECE calibration, and OOD detection.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 
 
@@ -95,12 +95,4 @@ class ConfidencePayload(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "confidence_score": 0.82,
-                "epistemic_uncertainty": 0.12,
-                "aleatoric_uncertainty": 0.06,
-                "dominant_uncertainty": "epistemic",
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'confidence_score': 0.82, 'epistemic_uncertainty': 0.12, 'aleatoric_uncertainty': 0.06, 'dominant_uncertainty': 'epistemic'}})

--- a/phionyx_core/contracts/v4/discovery_candidate.py
+++ b/phionyx_core/contracts/v4/discovery_candidate.py
@@ -7,7 +7,7 @@ for open-ended discovery evaluation.
 """
 
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -103,12 +103,4 @@ class DiscoveryCandidate(BaseModel):
         )
         return self.composite_score
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "description": "Emotional resonance correlates with learning retention",
-                "novelty_score": 0.85,
-                "transfer_potential": 0.6,
-                "robustness_score": 0.7,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'description': 'Emotional resonance correlates with learning retention', 'novelty_score': 0.85, 'transfer_potential': 0.6, 'robustness_score': 0.7}})

--- a/phionyx_core/contracts/v4/error_payload.py
+++ b/phionyx_core/contracts/v4/error_payload.py
@@ -8,7 +8,7 @@ and structured error reporting.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -108,12 +108,4 @@ class ErrorPayload(BaseModel):
     correlation_id: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "severity": "error",
-                "error_code": "ETHICS_GATE_FAIL",
-                "message": "Ethics gate denied action",
-                "recovery_action": "fallback",
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'severity': 'error', 'error_code': 'ETHICS_GATE_FAIL', 'message': 'Ethics gate denied action', 'recovery_action': 'fallback'}})

--- a/phionyx_core/contracts/v4/ethics_decision.py
+++ b/phionyx_core/contracts/v4/ethics_decision.py
@@ -8,7 +8,7 @@ verdict enum, deliberation layer, and decision trace.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -100,12 +100,4 @@ class EthicsDecision(BaseModel):
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "verdict": "allow",
-                "deliberation_layer": "rule_based",
-                "enforced": False,
-                "max_risk_score": 0.2,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'verdict': 'allow', 'deliberation_layer': 'rule_based', 'enforced': False, 'max_risk_score': 0.2}})

--- a/phionyx_core/contracts/v4/goal_object.py
+++ b/phionyx_core/contracts/v4/goal_object.py
@@ -8,7 +8,7 @@ Represents system-level goals with legitimacy scoring and priority.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -121,13 +121,4 @@ class GoalObject(BaseModel):
             + w.get("gamma", 0.2) * self.user_score
         )
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "name": "maintain_safety_bounds",
-                "priority": "critical",
-                "safety_score": 1.0,
-                "system_score": 0.9,
-                "user_score": 0.5,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'name': 'maintain_safety_bounds', 'priority': 'critical', 'safety_score': 1.0, 'system_score': 0.9, 'user_score': 0.5}})

--- a/phionyx_core/contracts/v4/input_signal.py
+++ b/phionyx_core/contracts/v4/input_signal.py
@@ -8,7 +8,7 @@ AD-1: Composition — TurnEnvelope is composed, not replaced.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 
 from ..envelopes.turn_envelope import TurnEnvelope
@@ -68,12 +68,4 @@ class InputSignal(BaseModel):
         description="Extensible metadata"
     )
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "source_module": "user_interface",
-                "signal_type": "user_text",
-                "modalities": ["text"],
-                "priority": 0,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'source_module': 'user_interface', 'signal_type': 'user_text', 'modalities': ['text'], 'priority': 0}})

--- a/phionyx_core/contracts/v4/learning_update.py
+++ b/phionyx_core/contracts/v4/learning_update.py
@@ -8,7 +8,7 @@ Learning updates must pass through a gate before modifying parameters.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -118,13 +118,4 @@ class LearningUpdate(BaseModel):
     # Metadata
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "target_parameter": "physics.gamma",
-                "current_value": 0.15,
-                "proposed_value": 0.18,
-                "delta": 0.03,
-                "boundary_zone": "adaptive",
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'target_parameter': 'physics.gamma', 'current_value': 0.15, 'proposed_value': 0.18, 'delta': 0.03, 'boundary_zone': 'adaptive'}})

--- a/phionyx_core/contracts/v4/memory_entry.py
+++ b/phionyx_core/contracts/v4/memory_entry.py
@@ -8,7 +8,7 @@ with v4 boundary zone concept (immutable/gated/adaptive).
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -107,12 +107,4 @@ class MemoryEntry(BaseModel):
         """Check if modification requires learning gate approval."""
         return self.boundary_zone == BoundaryZone.GATED
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "content": "User prefers concise responses",
-                "memory_type": "semantic",
-                "boundary_zone": "adaptive",
-                "decay_rate": 0.1,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'content': 'User prefers concise responses', 'memory_type': 'semantic', 'boundary_zone': 'adaptive', 'decay_rate': 0.1}})

--- a/phionyx_core/contracts/v4/perceptual_frame.py
+++ b/phionyx_core/contracts/v4/perceptual_frame.py
@@ -8,7 +8,7 @@ AD-1: Composition — existing models are referenced, not replaced.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 
 
@@ -70,14 +70,4 @@ class PerceptualFrame(BaseModel):
         description="Raw feature vector for downstream processing"
     )
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "A_meas": 0.6,
-                "V_meas": 0.3,
-                "H_meas": 0.4,
-                "confidence": 0.85,
-                "modality": "text",
-                "salience": 0.7,
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'A_meas': 0.6, 'V_meas': 0.3, 'H_meas': 0.4, 'confidence': 0.85, 'modality': 'text', 'salience': 0.7}})

--- a/phionyx_core/contracts/v4/workspace_event.py
+++ b/phionyx_core/contracts/v4/workspace_event.py
@@ -8,7 +8,7 @@ Represents events broadcast to all modules via salience-based attention.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 import uuid
 
@@ -83,12 +83,4 @@ class WorkspaceEvent(BaseModel):
     trace_id: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "event_type": "ethics_trigger",
-                "salience": "high",
-                "salience_score": 0.9,
-                "source_module": "ethics_engine",
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'event_type': 'ethics_trigger', 'salience': 'high', 'salience_score': 0.9, 'source_module': 'ethics_engine'}})

--- a/phionyx_core/contracts/v4/world_state_snapshot.py
+++ b/phionyx_core/contracts/v4/world_state_snapshot.py
@@ -8,7 +8,7 @@ AD-1: Composition — EchoState2 is composed as echo_state field.
 
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 
 
@@ -74,11 +74,4 @@ class WorldStateSnapshot(BaseModel):
         description="Turn index at snapshot time"
     )
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "echo_state": {"A": 0.5, "V": 0.3, "H": 0.4},
-                "belief_vector": {"hypothesis_a": 0.7, "hypothesis_b": 0.3},
-                "arbitration_status": "stable",
-            }
-        }
+    model_config = ConfigDict(json_schema_extra={'example': {'echo_state': {'A': 0.5, 'V': 0.3, 'H': 0.4}, 'belief_vector': {'hypothesis_a': 0.7, 'hypothesis_b': 0.3}, 'arbitration_status': 'stable'}})

--- a/phionyx_core/physics/profiles.py
+++ b/phionyx_core/physics/profiles.py
@@ -8,7 +8,7 @@ Uses Pydantic for validation and YAML for preset storage.
 
 from enum import Enum
 from typing import Optional, Dict
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 import yaml
 from pathlib import Path
 
@@ -50,22 +50,11 @@ class PhysicsProfile(BaseModel):
         """Ensure values are in [0, 1] range."""
         return max(0.0, min(1.0, v))
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-        extra = "allow"  # ENTERPRISE UPGRADE: Allow extra fields like max_entropy from YAML
-        json_schema_extra = {
-            "example": {
-                "name": "SCHOOL_DEFAULT",
-                "base_mode": "SCHOOL",
-                "reactivity": 0.2,
-                "resilience": 0.9,
-                "safety": 0.8,
-                "description": "High resilience, low reactivity for educational settings"
-            }
-        }
-
-
+    model_config = ConfigDict(
+        use_enum_values=True,
+        extra='allow',
+        json_schema_extra={'example': {'name': 'SCHOOL_DEFAULT', 'base_mode': 'SCHOOL', 'reactivity': 0.2, 'resilience': 0.9, 'safety': 0.8, 'description': 'High resilience, low reactivity for educational settings'}},
+    )
 class ProfileLoader:
     """
     Loads and manages physics profiles from YAML files.

--- a/phionyx_core/profiles/schema.py
+++ b/phionyx_core/profiles/schema.py
@@ -7,7 +7,7 @@ Defines the nested structure for high-level personas and low-level technical par
 
 from enum import Enum
 from typing import Optional, Dict, List
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class BaseMode(str, Enum):
@@ -102,11 +102,7 @@ class GovernanceConfig(BaseModel):
     audit_level: AuditLevel = Field(AuditLevel.STANDARD, description="Audit logging level")
     custom_regex_patterns: Optional[List[str]] = Field(None, description="Custom PII regex patterns")
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-
-
+    model_config = ConfigDict(use_enum_values=True)
 class RoutingConfig(BaseModel):
     """
     LLM routing configuration.
@@ -118,11 +114,7 @@ class RoutingConfig(BaseModel):
     max_tokens_per_tier: Optional[Dict[str, int]] = Field(None, description="Max tokens per tier")
     enable_graph_rag: bool = Field(False, description="Enable GraphRAG for hidden context discovery (default: OFF, only for Academic/Enterprise/Deep-analysis modes)")
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-
-
+    model_config = ConfigDict(use_enum_values=True)
 class ExecutionGuardConfig(BaseModel):
     """
     Per-profile ExecutionGuard limits.
@@ -157,11 +149,7 @@ class ExecutionGuardConfig(BaseModel):
         description="Circular-sequence detection window. Guard default: 3.",
     )
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-
-
+    model_config = ConfigDict(use_enum_values=True)
 class Profile(BaseModel):
     """
     Root profile model containing all module configurations.
@@ -185,32 +173,7 @@ class Profile(BaseModel):
     version: Optional[str] = Field("1.0.0", description="Profile version")
     tags: Optional[List[str]] = Field(None, description="Tags for filtering/searching")
 
-    class Config:
-        """Pydantic config."""
-        use_enum_values = True
-        json_schema_extra = {
-            "example": {
-                "name": "SCHOOL_DEFAULT",
-                "description": "Default school profile: High resilience, low reactivity",
-                "physics": {
-                    "reactivity": 0.2,
-                    "resilience": 0.9,
-                    "safety_bias": 0.8,
-                    "base_mode": "SCHOOL"
-                },
-                "pedagogy": {
-                    "vygotsky_level": 0.7,
-                    "scaffolding_aggressiveness": 0.6,
-                    "intervention_threshold": 0.4
-                },
-                "governance": {
-                    "policy_id": "school_policy",
-                    "pii_mode": "FULL",
-                    "audit_level": "VERBOSE"
-                },
-                "routing": {
-                    "llm_tier_strategy": "QUALITY_OPTIMIZED"
-                }
-            }
-        }
-
+    model_config = ConfigDict(
+        use_enum_values=True,
+        json_schema_extra={'example': {'name': 'SCHOOL_DEFAULT', 'description': 'Default school profile: High resilience, low reactivity', 'physics': {'reactivity': 0.2, 'resilience': 0.9, 'safety_bias': 0.8, 'base_mode': 'SCHOOL'}, 'pedagogy': {'vygotsky_level': 0.7, 'scaffolding_aggressiveness': 0.6, 'intervention_threshold': 0.4}, 'governance': {'policy_id': 'school_policy', 'pii_mode': 'FULL', 'audit_level': 'VERBOSE'}, 'routing': {'llm_tier_strategy': 'QUALITY_OPTIMIZED'}}},
+    )

--- a/phionyx_core/schemas/npc_echo_profile.py
+++ b/phionyx_core/schemas/npc_echo_profile.py
@@ -9,7 +9,7 @@ Integrates Plutchik → Circumplex → Φ Physics pipeline.
 from __future__ import annotations
 
 from typing import Dict
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class NPCEchoProfile(BaseModel):
@@ -94,28 +94,4 @@ class NPCEchoProfile(BaseModel):
         description="High-level echo semantic label (e.g., 'harmony_growth', 'threat_vigilance')"
     )
 
-    class Config:
-        """Pydantic configuration."""
-        json_schema_extra = {
-            "example": {
-                "npc_id": "npc_guard_01",
-                "echo_type": "threat_vigilance",
-                "trace_half_life": 0.3,
-                "delay_tendency": 0.2,
-                "propagation_radius": 0.4,
-                "selectivity_threshold": 0.6,
-                "feedback_sensitivity": 0.5,
-                "domain_weights": {
-                    "physical": 0.4,
-                    "biological": 0.3,
-                    "psychological": 0.7,
-                    "social": 0.8,
-                    "technological": 0.5,
-                    "consciousness": 0.6,
-                    "metaphysical": 0.2,
-                },
-                "base_valence": -0.7,
-                "base_arousal": 0.8,
-            }
-        }
-
+    model_config = ConfigDict(json_schema_extra={'example': {'npc_id': 'npc_guard_01', 'echo_type': 'threat_vigilance', 'trace_half_life': 0.3, 'delay_tendency': 0.2, 'propagation_radius': 0.4, 'selectivity_threshold': 0.6, 'feedback_sensitivity': 0.5, 'domain_weights': {'physical': 0.4, 'biological': 0.3, 'psychological': 0.7, 'social': 0.8, 'technological': 0.5, 'consciousness': 0.6, 'metaphysical': 0.2}, 'base_valence': -0.7, 'base_arousal': 0.8}})

--- a/phionyx_core/state/aux_state.py
+++ b/phionyx_core/state/aux_state.py
@@ -12,7 +12,7 @@ Per Echoism Core v1.0:
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing import Dict, Any, Optional
 from datetime import datetime
 
@@ -184,7 +184,4 @@ class AuxState(BaseModel):
             metadata=data.get("metadata", {})
         )
 
-    class Config:
-        """Pydantic config."""
-        validate_assignment = True
-
+    model_config = ConfigDict(validate_assignment=True)

--- a/phionyx_core/state/echo_state_2.py
+++ b/phionyx_core/state/echo_state_2.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List, Dict, Any, Optional
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 import math
 import time as time_module  # For monotonic clock
 
@@ -585,12 +585,10 @@ class EchoState2(BaseModel):
             relationship_start=relationship_start
         )
 
-    class Config:
-        """Pydantic config."""
-        arbitrary_types_allowed = True
-        validate_assignment = True
-
-
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+    )
 class EchoState2Plus(EchoState2):
     """
     EchoState2Plus - Echoism Core v1.1 Extended State Model
@@ -1112,7 +1110,7 @@ class EchoState2Plus(EchoState2):
             D=data.get("D", None)
         )
 
-    class Config:
-        """Pydantic config."""
-        arbitrary_types_allowed = True
-        validate_assignment = True
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        validate_assignment=True,
+    )

--- a/phionyx_core/state/measurement_mapper.py
+++ b/phionyx_core/state/measurement_mapper.py
@@ -480,7 +480,7 @@ class MeasurementMapper:
                         "confidence": self.confidence,
                         "provider": self.provider,
                         "timestamp": self.timestamp.isoformat(),
-                        "evidence_spans": [span.dict() if hasattr(span, 'dict') else {"text": span.text, "start": span.start, "end": span.end, "tag": span.tag} for span in self.evidence_spans]
+                        "evidence_spans": [span.model_dump() if hasattr(span, 'dict') else {"text": span.text, "start": span.start, "end": span.end, "tag": span.tag} for span in self.evidence_spans]
                     }
 
         # Get base measurement

--- a/phionyx_core/state/measurement_mapper_v2.py
+++ b/phionyx_core/state/measurement_mapper_v2.py
@@ -52,7 +52,7 @@ class MeasurementPacket(BaseModel):
             "confidence": self.confidence,
             "provider": self.provider,
             "timestamp": self.timestamp.isoformat(),
-            "evidence_spans": [span.dict() for span in self.evidence_spans]
+            "evidence_spans": [span.model_dump() for span in self.evidence_spans]
         }
 
     @classmethod


### PR DESCRIPTION
Pydantic V2 has been the default for two minor releases and V1-style syntax raises `PydanticDeprecatedSince20` on every import. Pydantic V3 will remove the V1 shims entirely. Migrating now stops the warning flood, prevents a forced rewrite when V3 ships, and keeps PyPI metadata clean.

## Mechanical changes (22 files, 34 sites)

- **26 × `class Config:` → `model_config = ConfigDict(...)`** — body content (json_schema_extra, use_enum_values, arbitrary_types_allowed) preserved verbatim. V1-only attribute names mapped: allow_population_by_field_name → populate_by_name, orm_mode → from_attributes, schema_extra → json_schema_extra (rename only).
- **5 × `@validator('field')` → `@field_validator('field')` + `@classmethod`** — validator bodies unchanged; signature stays `(cls, v)`.
- **3 × `.dict()` → `.model_dump()`** on BaseModel instances — the remaining V1 shim that still triggered warnings post-migration.

Each touched file's `from pydantic import ...` line was extended to include `ConfigDict` and/or `field_validator`, with the obsolete `validator` import dropped.

## Verification

- Migration script handled the 22 files mechanically; 3 `.dict()` calls were patched manually after.
- `pytest tests/core tests/contract tests/benchmarks -q` → **1,130 passed, 7 skipped, 0 failed**
- `grep -c PydanticDeprecat` over the test output: **50+ → 0**
- Total pytest warnings: 59 → 27 (remaining: `datetime.utcnow` in tests + an unregistered pytest mark — follow-up PRs).

## Out of scope

- `pyproject.toml` already pins `pydantic>=2.0.0,<3.0.0`; no dependency change.
- No runtime API changes visible to users (the migrated symbols are all config metadata).
- `tests/core` had pre-existing tests pointing at the V2 surface; no test fixtures had to change.