### PR TITLE
chore(ruff): baseline + CI lint step (293 files, 2,883 mechanical fixes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
           pip --version
           pip list | grep -E "^(phionyx-core|pydantic|numpy|PyYAML)" || true
 
+      - name: Lint (ruff)
+        run: ruff check phionyx_core
+
       - name: Smoke import
         run: |
           python -c "import phionyx_core; print('phionyx_core', phionyx_core.__version__)"

--- a/phionyx_core/__init__.py
+++ b/phionyx_core/__init__.py
@@ -37,61 +37,18 @@ __version__ = "0.2.0"
 # ---------------------------------------------------------------------------
 # Pipeline (always available -- no external deps)
 # ---------------------------------------------------------------------------
-from .pipeline.base import PipelineBlock, BlockContext, BlockResult
-
 # ---------------------------------------------------------------------------
-# Physics types (pydantic models -- core dependency)
+# CEP (Conscious Echo Proof) -- synthetic psychopathology prevention
 # ---------------------------------------------------------------------------
-from .physics.types import PhysicsInput, PhysicsOutput, PhysicsState, PhiComponents
-
-# ---------------------------------------------------------------------------
-# Physics formulas (pure math -- no external deps)
-# ---------------------------------------------------------------------------
-from .physics.formulas import (
-    calculate_phi_v2,
-    calculate_phi_v2_1,
-    calculate_phi_cognitive,
-    calculate_phi_physical,
-    calculate_resonance_force,
-    calculate_echo_energy,
-    calculate_entropy_shannon,
-    calculate_momentum,
-    classify_resonance,
-)
-
-# ---------------------------------------------------------------------------
-# Physics dynamics (entropy, stability, complexity)
-# ---------------------------------------------------------------------------
-from .physics.dynamics import (
-    calculate_dynamic_entropy,
-    update_stability,
-    calculate_complexity,
-)
-
-# ---------------------------------------------------------------------------
-# Physics tuner & params
-# ---------------------------------------------------------------------------
-from .physics.tuner import PhysicsParams, ProfileTuner
-
-# ---------------------------------------------------------------------------
-# State
-# ---------------------------------------------------------------------------
-from .state.echo_state_2 import EchoState2, EchoState2Plus
-
-# ---------------------------------------------------------------------------
-# Orchestrator
-# ---------------------------------------------------------------------------
-from .orchestrator.echo_orchestrator import EchoOrchestrator, OrchestratorServices
-
-# ---------------------------------------------------------------------------
-# Profiles
-# ---------------------------------------------------------------------------
-from .profiles import (
-    ProfileLoader,
-    ProfileManager,
-    Profile,
-    get_global_manager,
-    get_active_profile,
+from .cep import (
+    CEPConfig,
+    CEPFlags,
+    CEPMetrics,
+    CEPResult,
+    CEPThresholds,
+    ConsciousEchoProofEngine,
+    EchoSelfThresholdGuard,
+    load_cep_config,
 )
 
 # ---------------------------------------------------------------------------
@@ -100,18 +57,60 @@ from .profiles import (
 from .contracts.telemetry import get_canonical_blocks
 
 # ---------------------------------------------------------------------------
-# CEP (Conscious Echo Proof) -- synthetic psychopathology prevention
+# Orchestrator
 # ---------------------------------------------------------------------------
-from .cep import (
-    ConsciousEchoProofEngine,
-    EchoSelfThresholdGuard,
-    CEPConfig,
-    load_cep_config,
-    CEPResult,
-    CEPMetrics,
-    CEPThresholds,
-    CEPFlags,
+from .orchestrator.echo_orchestrator import EchoOrchestrator, OrchestratorServices
+
+# ---------------------------------------------------------------------------
+# Physics dynamics (entropy, stability, complexity)
+# ---------------------------------------------------------------------------
+from .physics.dynamics import (
+    calculate_complexity,
+    calculate_dynamic_entropy,
+    update_stability,
 )
+
+# ---------------------------------------------------------------------------
+# Physics formulas (pure math -- no external deps)
+# ---------------------------------------------------------------------------
+from .physics.formulas import (
+    calculate_echo_energy,
+    calculate_entropy_shannon,
+    calculate_momentum,
+    calculate_phi_cognitive,
+    calculate_phi_physical,
+    calculate_phi_v2,
+    calculate_phi_v2_1,
+    calculate_resonance_force,
+    classify_resonance,
+)
+
+# ---------------------------------------------------------------------------
+# Physics tuner & params
+# ---------------------------------------------------------------------------
+from .physics.tuner import PhysicsParams, ProfileTuner
+
+# ---------------------------------------------------------------------------
+# Physics types (pydantic models -- core dependency)
+# ---------------------------------------------------------------------------
+from .physics.types import PhiComponents, PhysicsInput, PhysicsOutput, PhysicsState
+from .pipeline.base import BlockContext, BlockResult, PipelineBlock
+
+# ---------------------------------------------------------------------------
+# Profiles
+# ---------------------------------------------------------------------------
+from .profiles import (
+    Profile,
+    ProfileLoader,
+    ProfileManager,
+    get_active_profile,
+    get_global_manager,
+)
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+from .state.echo_state_2 import EchoState2, EchoState2Plus
 
 # ---------------------------------------------------------------------------
 # __all__ -- explicit public API surface

--- a/phionyx_core/causality/__init__.py
+++ b/phionyx_core/causality/__init__.py
@@ -15,10 +15,10 @@ Components:
 - CausalSimulator: Forward simulation of actions
 """
 
-from .causal_graph import CausalGraphBuilder, CausalNode, CausalEdge, CausalGraph
-from .intervention import InterventionModel, InterventionResult
+from .causal_graph import CausalEdge, CausalGraph, CausalGraphBuilder, CausalNode
 from .counterfactual import CounterfactualEngine, CounterfactualResult
-from .root_cause import RootCauseAnalyzer, RootCauseAnalysis
+from .intervention import InterventionModel, InterventionResult
+from .root_cause import RootCauseAnalysis, RootCauseAnalyzer
 from .simulator import CausalSimulator, SimulationResult
 
 __all__ = [

--- a/phionyx_core/causality/causal_graph.py
+++ b/phionyx_core/causality/causal_graph.py
@@ -21,10 +21,10 @@ Integrates with:
 import json
 import logging
 import math
-from pathlib import Path
-from typing import List, Dict, Optional, Set, Tuple, Any
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -59,12 +59,12 @@ class CausalNode:
     node_id: str
     name: str
     node_type: str = NodeType.STATE.value
-    observed_values: List[float] = field(default_factory=list)
-    current_value: Optional[float] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    observed_values: list[float] = field(default_factory=list)
+    current_value: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
-    def mean_value(self) -> Optional[float]:
+    def mean_value(self) -> float | None:
         if not self.observed_values:
             return self.current_value
         return sum(self.observed_values) / len(self.observed_values)
@@ -79,7 +79,7 @@ class CausalEdge:
     confidence: float = default_confidence   # 0.0-1.0: how confident we are this is causal
     mechanism: str = MechanismType.OBSERVED.value
     observations: int = 1     # How many times this was observed
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
     def effective_strength(self) -> float:
@@ -90,8 +90,8 @@ class CausalEdge:
 @dataclass
 class CausalGraph:
     """A complete causal model as a directed graph."""
-    nodes: Dict[str, CausalNode] = field(default_factory=dict)
-    edges: Dict[str, CausalEdge] = field(default_factory=dict)  # key: "source->target"
+    nodes: dict[str, CausalNode] = field(default_factory=dict)
+    edges: dict[str, CausalEdge] = field(default_factory=dict)  # key: "source->target"
 
     @property
     def node_count(self) -> int:
@@ -101,29 +101,29 @@ class CausalGraph:
     def edge_count(self) -> int:
         return len(self.edges)
 
-    def get_parents(self, node_id: str) -> List[str]:
+    def get_parents(self, node_id: str) -> list[str]:
         """Get direct causes of a node."""
         return [
             e.source_id for e in self.edges.values()
             if e.target_id == node_id
         ]
 
-    def get_children(self, node_id: str) -> List[str]:
+    def get_children(self, node_id: str) -> list[str]:
         """Get direct effects of a node."""
         return [
             e.target_id for e in self.edges.values()
             if e.source_id == node_id
         ]
 
-    def get_edge(self, source_id: str, target_id: str) -> Optional[CausalEdge]:
+    def get_edge(self, source_id: str, target_id: str) -> CausalEdge | None:
         """Get edge between two nodes."""
         key = f"{source_id}->{target_id}"
         return self.edges.get(key)
 
     def has_cycle(self) -> bool:
         """Check if graph has cycles (should be DAG)."""
-        visited: Set[str] = set()
-        rec_stack: Set[str] = set()
+        visited: set[str] = set()
+        rec_stack: set[str] = set()
 
         def _dfs(node_id: str) -> bool:
             visited.add(node_id)
@@ -143,12 +143,12 @@ class CausalGraph:
                     return True
         return False
 
-    def topological_order(self) -> List[str]:
+    def topological_order(self) -> list[str]:
         """Return nodes in topological order (causes before effects)."""
         if self.has_cycle():
             return list(self.nodes.keys())  # Fallback: arbitrary order
 
-        in_degree: Dict[str, int] = dict.fromkeys(self.nodes, 0)
+        in_degree: dict[str, int] = dict.fromkeys(self.nodes, 0)
         for e in self.edges.values():
             if e.target_id in in_degree:
                 in_degree[e.target_id] += 1
@@ -165,9 +165,9 @@ class CausalGraph:
                         queue.append(child)
         return order
 
-    def get_ancestors(self, node_id: str) -> Set[str]:
+    def get_ancestors(self, node_id: str) -> set[str]:
         """Get all transitive causes of a node."""
-        ancestors: Set[str] = set()
+        ancestors: set[str] = set()
         stack = list(self.get_parents(node_id))
         while stack:
             current = stack.pop()
@@ -176,9 +176,9 @@ class CausalGraph:
                 stack.extend(self.get_parents(current))
         return ancestors
 
-    def get_descendants(self, node_id: str) -> Set[str]:
+    def get_descendants(self, node_id: str) -> set[str]:
         """Get all transitive effects of a node."""
-        descendants: Set[str] = set()
+        descendants: set[str] = set()
         stack = list(self.get_children(node_id))
         while stack:
             current = stack.pop()
@@ -187,7 +187,7 @@ class CausalGraph:
                 stack.extend(self.get_children(current))
         return descendants
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize causal graph (complete, for cross-session persistence)."""
         return {
             "nodes": {
@@ -217,7 +217,7 @@ class CausalGraph:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "CausalGraph":
+    def from_dict(cls, data: dict[str, Any]) -> "CausalGraph":
         """Restore causal graph from serialized data."""
         graph = cls()
         for nid, ndata in data.get("nodes", {}).items():
@@ -305,7 +305,7 @@ class CausalGraphBuilder:
         if self._auto_save_enabled:
             self.auto_save(self._auto_save_path)
 
-    def auto_save(self, base_path: str = "data/causal_graph") -> Optional[str]:
+    def auto_save(self, base_path: str = "data/causal_graph") -> str | None:
         """Auto-save causal graph to JSON for cross-session persistence."""
         if not self._session_id:
             logger.warning("Cannot auto-save CausalGraph: no session_id set")
@@ -341,7 +341,7 @@ class CausalGraphBuilder:
             return None
 
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 data = json.load(f)
             builder = cls(
                 promotion_threshold=data.get("promotion_threshold", 0.6),
@@ -360,10 +360,10 @@ class CausalGraphBuilder:
     def add_node(
         self,
         node_id: str,
-        name: Optional[str] = None,
+        name: str | None = None,
         node_type: str = NodeType.STATE.value,
-        current_value: Optional[float] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        current_value: float | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> CausalNode:
         """Add or update a node in the causal graph."""
         if node_id in self._graph.nodes:
@@ -396,8 +396,8 @@ class CausalGraphBuilder:
         strength: float = default_strength,
         confidence: float = 0.8,
         mechanism: str = MechanismType.DIRECT.value,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> Optional[CausalEdge]:
+        metadata: dict[str, Any] | None = None,
+    ) -> CausalEdge | None:
         """
         Add a causal link A → B.
 
@@ -459,10 +459,10 @@ class CausalGraphBuilder:
         self,
         variable_a: str,
         variable_b: str,
-        value_a: Optional[float] = None,
-        value_b: Optional[float] = None,
-        direction_hint: Optional[str] = None,
-    ) -> Optional[CausalEdge]:
+        value_a: float | None = None,
+        value_b: float | None = None,
+        direction_hint: str | None = None,
+    ) -> CausalEdge | None:
         """
         Record that two variables co-occurred.
 
@@ -506,7 +506,7 @@ class CausalGraphBuilder:
         )
 
     def import_from_graph_engine_edges(
-        self, causal_edges: List[Tuple[str, str, Dict]]
+        self, causal_edges: list[tuple[str, str, dict]]
     ) -> int:
         """
         Import causal edges from GraphEngine.get_causal_subgraph().
@@ -539,7 +539,7 @@ class CausalGraphBuilder:
 
     def add_physics_variables(
         self,
-        echo_state: Dict[str, Any],
+        echo_state: dict[str, Any],
     ) -> None:
         """
         Add Phionyx physics state variables as causal nodes.
@@ -578,10 +578,10 @@ class CausalGraphBuilder:
 
     def discover_structure(
         self,
-        min_observations: Optional[int] = None,
-        alpha: Optional[float] = None,
-        max_conditioning_size: Optional[int] = None,
-    ) -> Dict[str, Any]:
+        min_observations: int | None = None,
+        alpha: float | None = None,
+        max_conditioning_size: int | None = None,
+    ) -> dict[str, Any]:
         """
         Run PC algorithm for causal structure discovery on accumulated observations.
 
@@ -662,7 +662,7 @@ class CausalGraphBuilder:
         """Return the constructed causal graph."""
         return self._graph
 
-    def to_world_state_dict(self) -> Dict[str, Any]:
+    def to_world_state_dict(self) -> dict[str, Any]:
         """Serialize for WorldStateSnapshot.causal_graph field."""
         return self._graph.to_dict()
 

--- a/phionyx_core/causality/counterfactual.py
+++ b/phionyx_core/causality/counterfactual.py
@@ -15,8 +15,8 @@ Integrates with:
 """
 
 import logging
-from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
+from typing import Any
 
 from .causal_graph import CausalGraph
 from .intervention import InterventionModel, InterventionResult
@@ -33,7 +33,7 @@ class CounterfactualQuery:
     """A 'what if' question."""
     variable: str           # Which variable to change
     counterfactual_value: float  # What value it would have been
-    target_variables: List[str] = field(default_factory=list)  # What to predict (empty = all)
+    target_variables: list[str] = field(default_factory=list)  # What to predict (empty = all)
     context: str = ""       # Human-readable description
 
 
@@ -41,10 +41,10 @@ class CounterfactualQuery:
 class CounterfactualOutcome:
     """Predicted outcome for one target variable."""
     variable: str
-    factual_value: Optional[float]
+    factual_value: float | None
     counterfactual_value: float
     delta: float
-    causal_path: List[str]
+    causal_path: list[str]
     necessity_score: float  # How necessary was the cause? (0-1)
 
 
@@ -52,26 +52,26 @@ class CounterfactualOutcome:
 class CounterfactualResult:
     """Full result of counterfactual analysis."""
     query: CounterfactualQuery
-    factual_state: Dict[str, Optional[float]]
-    counterfactual_state: Dict[str, float]
-    outcomes: List[CounterfactualOutcome]
+    factual_state: dict[str, float | None]
+    counterfactual_state: dict[str, float]
+    outcomes: list[CounterfactualOutcome]
     intervention_result: InterventionResult
     reasoning: str
 
-    def get_outcome(self, variable: str) -> Optional[CounterfactualOutcome]:
+    def get_outcome(self, variable: str) -> CounterfactualOutcome | None:
         for o in self.outcomes:
             if o.variable == variable:
                 return o
         return None
 
     @property
-    def max_impact_variable(self) -> Optional[str]:
+    def max_impact_variable(self) -> str | None:
         """Variable with largest counterfactual impact."""
         if not self.outcomes:
             return None
         return max(self.outcomes, key=lambda o: abs(o.delta)).variable
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "query": {
                 "variable": self.query.variable,
@@ -126,7 +126,7 @@ class CounterfactualEngine:
         self,
         variable: str,
         counterfactual_value: float,
-        targets: Optional[List[str]] = None,
+        targets: list[str] | None = None,
         context: str = "",
     ) -> CounterfactualResult:
         """
@@ -239,7 +239,7 @@ class CounterfactualEngine:
         self,
         cause: str,
         effect: str,
-        cf_value: Optional[float] = None,
+        cf_value: float | None = None,
     ) -> float:
         """Compute necessity score for cause→effect."""
         cause_node = self.graph.nodes.get(cause)
@@ -274,7 +274,7 @@ class CounterfactualEngine:
     def _build_reasoning(
         self,
         query: CounterfactualQuery,
-        outcomes: List[CounterfactualOutcome],
+        outcomes: list[CounterfactualOutcome],
     ) -> str:
         if not outcomes:
             return f"No downstream effects detected for do({query.variable}={query.counterfactual_value})"

--- a/phionyx_core/causality/intervention.py
+++ b/phionyx_core/causality/intervention.py
@@ -17,8 +17,8 @@ Integrates with:
 """
 
 import logging
-from typing import Dict, List, Optional, Set, Any, Tuple
 from dataclasses import dataclass
+from typing import Any
 
 from .causal_graph import CausalGraph
 
@@ -34,10 +34,10 @@ max_propagation_depth = 10
 class InterventionEffect:
     """Effect of an intervention on a single node."""
     node_id: str
-    original_value: Optional[float]
+    original_value: float | None
     new_value: float
     delta: float
-    causal_path: List[str]  # path from intervention to this node
+    causal_path: list[str]  # path from intervention to this node
     attenuation: float  # how much the effect was attenuated along the path
 
 
@@ -46,13 +46,13 @@ class InterventionResult:
     """Full result of a do(X=x) intervention."""
     intervention_variable: str
     intervention_value: float
-    original_value: Optional[float]
-    effects: List[InterventionEffect]
+    original_value: float | None
+    effects: list[InterventionEffect]
     total_nodes_affected: int
     max_propagation_depth: int
-    graph_snapshot: Dict[str, Any]  # post-intervention state
+    graph_snapshot: dict[str, Any]  # post-intervention state
 
-    def get_effect(self, node_id: str) -> Optional[InterventionEffect]:
+    def get_effect(self, node_id: str) -> InterventionEffect | None:
         """Get effect on a specific node."""
         for e in self.effects:
             if e.node_id == node_id:
@@ -60,10 +60,10 @@ class InterventionResult:
         return None
 
     @property
-    def affected_node_ids(self) -> Set[str]:
+    def affected_node_ids(self) -> set[str]:
         return {e.node_id for e in self.effects}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "intervention": {
                 "variable": self.intervention_variable,
@@ -156,7 +156,7 @@ class InterventionModel:
         delta = value - (original_value or 0.0)
 
         # Propagate effects through descendants
-        effects: List[InterventionEffect] = []
+        effects: list[InterventionEffect] = []
         max_depth = 0
 
         if abs(delta) >= self.min_effect_threshold:
@@ -183,8 +183,8 @@ class InterventionModel:
 
     def simulate_multiple(
         self,
-        interventions: Dict[str, float],
-    ) -> Dict[str, InterventionResult]:
+        interventions: dict[str, float],
+    ) -> dict[str, InterventionResult]:
         """
         Simulate multiple simultaneous interventions.
 
@@ -247,7 +247,7 @@ class InterventionModel:
         self,
         cause: str,
         effect: str,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Identify potential confounding variables between cause and effect.
 
@@ -264,10 +264,10 @@ class InterventionModel:
         self,
         source_id: str,
         source_delta: float,
-        path: List[str],
+        path: list[str],
         depth: int,
-        visited: Set[str],
-    ) -> Tuple[List[InterventionEffect], int]:
+        visited: set[str],
+    ) -> tuple[list[InterventionEffect], int]:
         """Recursively propagate intervention effects."""
         if depth >= self.max_propagation_depth:
             return [], depth
@@ -322,11 +322,11 @@ class InterventionModel:
         source: str,
         target: str,
         max_length: int = 5,
-    ) -> List[List[str]]:
+    ) -> list[list[str]]:
         """Find all directed paths from source to target (bounded)."""
-        paths: List[List[str]] = []
+        paths: list[list[str]] = []
 
-        def _dfs(current: str, path: List[str]):
+        def _dfs(current: str, path: list[str]):
             if len(path) > max_length + 1:
                 return
             if current == target:
@@ -345,10 +345,10 @@ class InterventionModel:
         self,
         intervention_var: str,
         intervention_val: float,
-        effects: List[InterventionEffect],
-    ) -> Dict[str, Any]:
+        effects: list[InterventionEffect],
+    ) -> dict[str, Any]:
         """Build post-intervention state snapshot."""
-        snapshot: Dict[str, Any] = {}
+        snapshot: dict[str, Any] = {}
         for nid, node in self.graph.nodes.items():
             snapshot[nid] = node.current_value
         # Apply intervention

--- a/phionyx_core/causality/root_cause.py
+++ b/phionyx_core/causality/root_cause.py
@@ -17,8 +17,8 @@ Integrates with:
 """
 
 import logging
-from typing import Dict, List, Optional, Set, Tuple, Any
 from dataclasses import dataclass
+from typing import Any
 
 from .causal_graph import CausalGraph, CausalNode
 
@@ -36,24 +36,24 @@ class RootCauseCandidate:
     node_id: str
     name: str
     likelihood: float    # 0.0-1.0: how likely this is the root cause
-    causal_path: List[str]  # path from root cause to anomaly
+    causal_path: list[str]  # path from root cause to anomaly
     path_strength: float   # product of edge strengths along path
     anomaly_score: float   # how anomalous this node's value is
-    current_value: Optional[float]
-    expected_value: Optional[float]
+    current_value: float | None
+    expected_value: float | None
 
 
 @dataclass
 class RootCauseAnalysis:
     """Full root cause analysis result."""
     anomaly_node: str
-    anomaly_value: Optional[float]
-    expected_range: Tuple[float, float]
-    candidates: List[RootCauseCandidate]
-    top_cause: Optional[RootCauseCandidate]
+    anomaly_value: float | None
+    expected_range: tuple[float, float]
+    candidates: list[RootCauseCandidate]
+    top_cause: RootCauseCandidate | None
     reasoning: str
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "anomaly": {
                 "node": self.anomaly_node,
@@ -114,8 +114,8 @@ class RootCauseAnalyzer:
     def analyze(
         self,
         anomaly_node: str,
-        anomaly_value: Optional[float] = None,
-        expected_range: Tuple[float, float] = (0.3, 0.7),
+        anomaly_value: float | None = None,
+        expected_range: tuple[float, float] = (0.3, 0.7),
     ) -> RootCauseAnalysis:
         """
         Analyze root cause of an anomaly.
@@ -176,15 +176,15 @@ class RootCauseAnalyzer:
         self,
         anomaly_node: str,
         anomaly_magnitude: float,
-        expected_range: Tuple[float, float],
-    ) -> List[RootCauseCandidate]:
+        expected_range: tuple[float, float],
+    ) -> list[RootCauseCandidate]:
         """Walk backward through causal graph to find root cause candidates."""
-        candidates: List[RootCauseCandidate] = []
-        visited: Set[str] = set()
+        candidates: list[RootCauseCandidate] = []
+        visited: set[str] = set()
 
         def _walk_back(
             current: str,
-            path: List[str],
+            path: list[str],
             cumulative_strength: float,
             depth: int,
         ):
@@ -234,8 +234,8 @@ class RootCauseAnalyzer:
 
     def _anomaly_magnitude(
         self,
-        value: Optional[float],
-        expected_range: Tuple[float, float],
+        value: float | None,
+        expected_range: tuple[float, float],
     ) -> float:
         """How far is the value from the expected range?"""
         if value is None:
@@ -252,7 +252,7 @@ class RootCauseAnalyzer:
     def _node_anomaly_score(
         self,
         node: CausalNode,
-        expected_range: Tuple[float, float],
+        expected_range: tuple[float, float],
     ) -> float:
         """Score how anomalous this node is."""
         if node.current_value is None:
@@ -277,9 +277,9 @@ class RootCauseAnalyzer:
     def _build_reasoning(
         self,
         anomaly_node: str,
-        anomaly_value: Optional[float],
-        expected_range: Tuple[float, float],
-        top_cause: Optional[RootCauseCandidate],
+        anomaly_value: float | None,
+        expected_range: tuple[float, float],
+        top_cause: RootCauseCandidate | None,
     ) -> str:
         if not top_cause:
             return f"No root cause found for anomaly in {anomaly_node}"

--- a/phionyx_core/causality/simulator.py
+++ b/phionyx_core/causality/simulator.py
@@ -14,8 +14,8 @@ Integrates with:
 """
 
 import logging
-from typing import Dict, List, Optional, Any, Tuple
 from dataclasses import dataclass
+from typing import Any
 
 from .causal_graph import CausalGraph
 from .intervention import InterventionModel
@@ -27,23 +27,23 @@ logger = logging.getLogger(__name__)
 class SimulationStep:
     """One step in forward simulation."""
     step_index: int
-    interventions: Dict[str, float]  # variable → forced value
-    state_before: Dict[str, Optional[float]]
-    state_after: Dict[str, float]
-    effects: List[Dict[str, Any]]  # Simplified InterventionEffect dicts
-    delta_summary: Dict[str, float]  # variable → total delta
+    interventions: dict[str, float]  # variable → forced value
+    state_before: dict[str, float | None]
+    state_after: dict[str, float]
+    effects: list[dict[str, Any]]  # Simplified InterventionEffect dicts
+    delta_summary: dict[str, float]  # variable → total delta
 
 
 @dataclass
 class SimulationResult:
     """Full simulation result over one or more steps."""
-    steps: List[SimulationStep]
-    initial_state: Dict[str, Optional[float]]
-    final_state: Dict[str, float]
+    steps: list[SimulationStep]
+    initial_state: dict[str, float | None]
+    final_state: dict[str, float]
     total_variables_affected: int
-    risk_assessment: Dict[str, Any]
+    risk_assessment: dict[str, Any]
 
-    def get_final_value(self, variable: str) -> Optional[float]:
+    def get_final_value(self, variable: str) -> float | None:
         return self.final_state.get(variable)
 
     def get_total_delta(self, variable: str) -> float:
@@ -54,7 +54,7 @@ class SimulationResult:
             return 0.0
         return final - initial
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "steps": [
                 {
@@ -101,7 +101,7 @@ class CausalSimulator:
         self,
         graph: CausalGraph,
         attenuation_rate: float = 0.8,
-        risk_thresholds: Optional[Dict[str, Tuple[float, float]]] = None,
+        risk_thresholds: dict[str, tuple[float, float]] | None = None,
     ):
         """
         Args:
@@ -123,7 +123,7 @@ class CausalSimulator:
 
     def simulate_step(
         self,
-        interventions: Dict[str, float],
+        interventions: dict[str, float],
     ) -> SimulationResult:
         """
         Simulate one step: apply interventions and predict effects.
@@ -138,7 +138,7 @@ class CausalSimulator:
 
     def simulate_sequence(
         self,
-        steps: List[Dict[str, float]],
+        steps: list[dict[str, float]],
     ) -> SimulationResult:
         """
         Simulate a sequence of intervention steps.
@@ -152,21 +152,21 @@ class CausalSimulator:
             SimulationResult with all steps and final state
         """
         # Capture initial state
-        initial_state: Dict[str, Optional[float]] = {
+        initial_state: dict[str, float | None] = {
             nid: node.current_value
             for nid, node in self.graph.nodes.items()
         }
         current_state = dict(initial_state)
 
-        sim_steps: List[SimulationStep] = []
+        sim_steps: list[SimulationStep] = []
         all_affected: set = set()
 
         for i, interventions in enumerate(steps):
             state_before = dict(current_state)
 
             # Apply all interventions in this step
-            delta_summary: Dict[str, float] = {}
-            all_effects: List[Dict[str, Any]] = []
+            delta_summary: dict[str, float] = {}
+            all_effects: list[dict[str, Any]] = []
 
             for var, val in interventions.items():
                 result = self._intervention_model.do(var, val)
@@ -213,8 +213,8 @@ class CausalSimulator:
 
     def preview_risk(
         self,
-        interventions: Dict[str, float],
-    ) -> Dict[str, Any]:
+        interventions: dict[str, float],
+    ) -> dict[str, Any]:
         """
         Preview risk without applying changes.
 
@@ -225,9 +225,9 @@ class CausalSimulator:
 
     def compare_actions(
         self,
-        action_a: Dict[str, float],
-        action_b: Dict[str, float],
-    ) -> Dict[str, Any]:
+        action_a: dict[str, float],
+        action_b: dict[str, float],
+    ) -> dict[str, Any]:
         """
         Compare two possible actions.
 
@@ -272,10 +272,10 @@ class CausalSimulator:
 
     def _assess_risk(
         self,
-        state: Dict[str, Optional[float]],
-    ) -> Dict[str, Any]:
+        state: dict[str, float | None],
+    ) -> dict[str, Any]:
         """Assess risk of a state against thresholds."""
-        violations: List[Dict[str, Any]] = []
+        violations: list[dict[str, Any]] = []
         for var, (low, high) in self.risk_thresholds.items():
             val = state.get(var)
             if val is None:

--- a/phionyx_core/causality/structure_learning.py
+++ b/phionyx_core/causality/structure_learning.py
@@ -20,9 +20,8 @@ Integrates with:
 - contracts/v4/world_state_snapshot.py (enriched causal model)
 """
 
-import math
 import logging
-from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+import math
 from dataclasses import dataclass
 
 from phionyx_core.causality.causal_graph import CausalGraph, MechanismType
@@ -43,8 +42,8 @@ class DiscoveredEdge:
 @dataclass
 class StructureLearningResult:
     """Result of running the PC algorithm."""
-    discovered_edges: List[DiscoveredEdge]
-    removed_pairs: List[Tuple[str, str, List[str]]]  # (var_a, var_b, sep_set)
+    discovered_edges: list[DiscoveredEdge]
+    removed_pairs: list[tuple[str, str, list[str]]]  # (var_a, var_b, sep_set)
     nodes_used: int
     sample_size: int
     max_conditioning_size: int
@@ -155,7 +154,7 @@ class PCAlgorithm:
 
     def _extract_observations(
         self, graph: CausalGraph
-    ) -> Tuple[List[str], List[List[float]]]:
+    ) -> tuple[list[str], list[list[float]]]:
         """Extract aligned observation matrix from graph nodes.
 
         Returns:
@@ -185,8 +184,8 @@ class PCAlgorithm:
         return var_names, obs_matrix
 
     def _compute_correlation_matrix(
-        self, obs_matrix: List[List[float]], n_vars: int, n_samples: int
-    ) -> List[List[float]]:
+        self, obs_matrix: list[list[float]], n_vars: int, n_samples: int
+    ) -> list[list[float]]:
         """Compute Pearson correlation matrix."""
         # Compute means
         means = [sum(obs_matrix[i]) / n_samples for i in range(n_vars)]
@@ -218,13 +217,13 @@ class PCAlgorithm:
 
     def _discover_skeleton(
         self,
-        var_names: List[str],
-        corr_matrix: List[List[float]],
+        var_names: list[str],
+        corr_matrix: list[list[float]],
         n_samples: int,
-    ) -> Tuple[
-        List[List[bool]],
-        Dict[FrozenSet[int], List[int]],
-        List[Tuple[str, str, List[str]]],
+    ) -> tuple[
+        list[list[bool]],
+        dict[frozenset[int], list[int]],
+        list[tuple[str, str, list[str]]],
     ]:
         """PC skeleton discovery: remove edges via conditional independence.
 
@@ -233,8 +232,8 @@ class PCAlgorithm:
         """
         n = len(var_names)
         adjacency = [[i != j for j in range(n)] for i in range(n)]
-        sep_sets: Dict[FrozenSet[int], List[int]] = {}
-        removed: List[Tuple[str, str, List[str]]] = []
+        sep_sets: dict[frozenset[int], list[int]] = {}
+        removed: list[tuple[str, str, list[str]]] = []
 
         for cond_size in range(self.max_conditioning_size + 1):
             for i in range(n):
@@ -277,11 +276,11 @@ class PCAlgorithm:
 
     def _orient_edges(
         self,
-        var_names: List[str],
-        adjacency: List[List[bool]],
-        sep_sets: Dict[FrozenSet[int], List[int]],
+        var_names: list[str],
+        adjacency: list[list[bool]],
+        sep_sets: dict[frozenset[int], list[int]],
         original_graph: CausalGraph,
-    ) -> List[Tuple[int, int]]:
+    ) -> list[tuple[int, int]]:
         """Orient undirected skeleton edges into directed edges.
 
         Uses:
@@ -292,7 +291,7 @@ class PCAlgorithm:
         n = len(var_names)
 
         # directed[i][j] = True means i → j is confirmed
-        directed: List[List[Optional[bool]]] = [
+        directed: list[list[bool | None]] = [
             [None] * n for _ in range(n)
         ]
 
@@ -362,10 +361,10 @@ class PCAlgorithm:
 
     def _partial_correlation(
         self,
-        corr_matrix: List[List[float]],
+        corr_matrix: list[list[float]],
         i: int,
         j: int,
-        conditioning: List[int],
+        conditioning: list[int],
     ) -> float:
         """Compute partial correlation between i and j given conditioning set.
 
@@ -450,7 +449,7 @@ class PCAlgorithm:
         return math.sqrt(size_factor * strength_factor)
 
     @staticmethod
-    def _combinations(items: List[int], size: int):
+    def _combinations(items: list[int], size: int):
         """Generate all combinations of given size (deterministic order)."""
         if size == 0:
             yield ()
@@ -477,14 +476,14 @@ class PCAlgorithm:
 
     @staticmethod
     def _would_create_cycle_in_directed(
-        directed: List[List[Optional[bool]]],
+        directed: list[list[bool | None]],
         n: int,
         source: int,
         target: int,
     ) -> bool:
         """Check if adding source→target creates a cycle in directed edges."""
         # BFS from target following directed edges to see if we reach source
-        visited: Set[int] = set()
+        visited: set[int] = set()
         queue = [target]
         while queue:
             current = queue.pop(0)

--- a/phionyx_core/cep/__init__.py
+++ b/phionyx_core/cep/__init__.py
@@ -15,15 +15,10 @@ Exports:
 - CEPFlags: Evaluation flags
 """
 
-from .cep_engine import ConsciousEchoProofEngine
-from .echo_self_guard import EchoSelfThresholdGuard
 from .cep_config import CEPConfig, load_cep_config
-from .cep_types import (
-    CEPMetrics,
-    CEPThresholds,
-    CEPFlags,
-    CEPResult
-)
+from .cep_engine import ConsciousEchoProofEngine
+from .cep_types import CEPFlags, CEPMetrics, CEPResult, CEPThresholds
+from .echo_self_guard import EchoSelfThresholdGuard
 
 __all__ = [
     "ConsciousEchoProofEngine",

--- a/phionyx_core/cep/cep_config.py
+++ b/phionyx_core/cep/cep_config.py
@@ -6,12 +6,12 @@ Configuration management for Conscious Echo Proof (CEP) engine.
 Supports profile-based configuration with YAML loading capability.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
-from typing import Any, List, Literal, Optional
-from pathlib import Path
 import logging
+from pathlib import Path
+from typing import Any, Literal
 
 import yaml
+from pydantic import BaseModel, ConfigDict, Field
 
 from .cep_types import CEPThresholds
 
@@ -36,7 +36,7 @@ class CEPConfig(BaseModel):
     )
 
     model_config = ConfigDict(use_enum_values=True)
-def _cep_config_search_paths(profile_name: str) -> List[Path]:
+def _cep_config_search_paths(profile_name: str) -> list[Path]:
     """Return candidate paths for CEP profile YAML (first existing wins)."""
     base = Path(__file__).resolve().parent
     candidates = [
@@ -50,10 +50,10 @@ def _cep_config_search_paths(profile_name: str) -> List[Path]:
     return candidates
 
 
-def _config_from_yaml(path: Path, profile_name: str) -> Optional[CEPConfig]:
+def _config_from_yaml(path: Path, profile_name: str) -> CEPConfig | None:
     """Load CEPConfig from a YAML file. Returns None on missing/invalid."""
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data: Any = yaml.safe_load(f)
         if not data or not isinstance(data, dict):
             return None
@@ -87,7 +87,7 @@ def _config_from_yaml(path: Path, profile_name: str) -> Optional[CEPConfig]:
         return None
 
 
-def load_cep_config(profile_name: Optional[str] = None) -> CEPConfig:
+def load_cep_config(profile_name: str | None = None) -> CEPConfig:
     """
     Load CEP configuration from profile.
 

--- a/phionyx_core/cep/cep_engine.py
+++ b/phionyx_core/cep/cep_engine.py
@@ -6,13 +6,13 @@ Main engine for evaluating responses against Conscious Echo Proof (CEP) criteria
 Detects self-narrative patterns, trauma language, and echo repetition.
 """
 
-import re
 import logging
-from typing import Optional, Dict, List, Literal
+import re
 from difflib import SequenceMatcher
+from typing import Literal
 
-from .cep_types import CEPMetrics, CEPFlags, CEPResult
 from .cep_config import CEPConfig
+from .cep_types import CEPFlags, CEPMetrics, CEPResult
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class ConsciousEchoProofEngine:
     Provides sanitization capabilities for unsafe content.
     """
 
-    def __init__(self, config: Optional[CEPConfig] = None, profile_name: Optional[str] = None):
+    def __init__(self, config: CEPConfig | None = None, profile_name: str | None = None):
         """
         Initialize CEP engine.
 
@@ -129,10 +129,10 @@ class ConsciousEchoProofEngine:
         raw_text: str,
         phi: float,
         entropy: float,
-        unified_state: Optional[Dict[str, float]] = None,
-        conversation_history: Optional[List[str]] = None,
-        npc_role: Optional[str] = None,
-        profile_name: Optional[str] = None
+        unified_state: dict[str, float] | None = None,
+        conversation_history: list[str] | None = None,
+        npc_role: str | None = None,
+        profile_name: str | None = None
     ) -> CEPResult:
         """
         Evaluate response against CEP criteria.
@@ -236,7 +236,7 @@ class ConsciousEchoProofEngine:
         raw_text: str,
         phi: float,
         entropy: float,
-        unified_state: Optional[Dict[str, float]] = None
+        unified_state: dict[str, float] | None = None
     ) -> CEPMetrics:
         """
         Compute base metrics from physics parameters.
@@ -393,7 +393,7 @@ class ConsciousEchoProofEngine:
 
         return max(0.0, min(1.0, total_score))
 
-    def _run_echo_variation_test(self, raw_text: str, conversation_history: List[str]) -> float:
+    def _run_echo_variation_test(self, raw_text: str, conversation_history: list[str]) -> float:
         """
         Test for echo variation/novelty using embedding-based similarity.
 
@@ -465,7 +465,7 @@ class ConsciousEchoProofEngine:
 
         return max(0.0, min(1.0, novelty_score))
 
-    def _get_embeddings(self, texts: List[str]) -> Optional[List[List[float]]]:
+    def _get_embeddings(self, texts: list[str]) -> list[list[float]] | None:
         """
         Get embeddings for texts.
 
@@ -481,8 +481,8 @@ class ConsciousEchoProofEngine:
         # Try to use vector store if available (future: integrate with phionyx_memory)
         # For now, use simple TF-IDF-like approach
         try:
-            from sklearn.feature_extraction.text import TfidfVectorizer
             import numpy as np
+            from sklearn.feature_extraction.text import TfidfVectorizer
 
             vectorizer = TfidfVectorizer(max_features=100, stop_words='english')
             embeddings = vectorizer.fit_transform(texts).toarray()
@@ -501,7 +501,7 @@ class ConsciousEchoProofEngine:
                 if not all_words:
                     return None
 
-                word_list = sorted(list(all_words))
+                word_list = sorted(all_words)
                 embeddings = []
                 for text in texts:
                     words = text.lower().split()
@@ -518,7 +518,7 @@ class ConsciousEchoProofEngine:
                 logger.debug(f"Simple embedding generation failed: {e}")
                 return None
 
-    def _cosine_similarity(self, vec1: List[float], vec2: List[float]) -> float:
+    def _cosine_similarity(self, vec1: list[float], vec2: list[float]) -> float:
         """
         Calculate cosine similarity between two vectors.
 
@@ -740,8 +740,8 @@ class ConsciousEchoProofEngine:
         raw_text: str,
         flags: CEPFlags,
         mode: Literal["universal", "fiction"],
-        npc_role: Optional[str] = None
-    ) -> Optional[str]:
+        npc_role: str | None = None
+    ) -> str | None:
         """
         Sanitize text if flags indicate need.
 

--- a/phionyx_core/cep/cep_types.py
+++ b/phionyx_core/cep/cep_types.py
@@ -5,8 +5,8 @@ CEP Types - Pydantic Models for Type Safety
 Type definitions for Conscious Echo Proof (CEP) evaluation.
 """
 
+
 from pydantic import BaseModel, Field
-from typing import Optional, List
 
 
 class CEPMetrics(BaseModel):
@@ -45,6 +45,6 @@ class CEPResult(BaseModel):
     metrics: CEPMetrics = Field(description="Computed metrics")
     thresholds: CEPThresholds = Field(description="Thresholds used for evaluation")
     flags: CEPFlags = Field(description="Evaluation flags")
-    sanitized_text: Optional[str] = Field(default=None, description="Sanitized text if sanitization was applied")
-    notes: List[str] = Field(default_factory=list, description="Additional notes about the evaluation")
+    sanitized_text: str | None = Field(default=None, description="Sanitized text if sanitization was applied")
+    notes: list[str] = Field(default_factory=list, description="Additional notes about the evaluation")
 

--- a/phionyx_core/cep/echo_self_guard.py
+++ b/phionyx_core/cep/echo_self_guard.py
@@ -10,9 +10,8 @@ does not re-implement physics formulas.
 """
 
 import logging
-from typing import Optional, Dict
 
-from .cep_types import CEPResult, CEPFlags
+from .cep_types import CEPFlags, CEPResult
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +53,7 @@ class EchoSelfThresholdGuard:
     def check_and_guard(
         self,
         cep_result: CEPResult,
-        unified_state: Optional[Dict[str, float]] = None
+        unified_state: dict[str, float] | None = None
     ) -> CEPResult:
         """
         Check CEP result against thresholds and apply guard if needed.

--- a/phionyx_core/config/karpathy_production_config.py
+++ b/phionyx_core/config/karpathy_production_config.py
@@ -7,15 +7,15 @@ Faz 3.5: Production Deployment
 Production-ready configuration for Karpathy features.
 """
 
-from typing import Dict, Any, Optional
-from dataclasses import dataclass
 import os
+from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
 class KarpathyProductionConfig:
     """Production configuration for Karpathy features."""
-    
+
     # Feature flags
     assumption_enabled: bool = True
     inconsistency_enabled: bool = True
@@ -28,29 +28,29 @@ class KarpathyProductionConfig:
     dead_code_enabled: bool = True
     orthogonal_guard_enabled: bool = True
     challenge_enabled: bool = True
-    
+
     # Complexity budget
     max_cyclomatic: int = 10
     max_cognitive: int = 15
     max_nesting: int = 4
     max_function_length: int = 50
     max_class_complexity: int = 20
-    
+
     # Governance
     strict_mode: bool = True
     block_on_critical: bool = True
     block_on_high: bool = True
-    
+
     # Performance
     cache_enabled: bool = True
     parallel_execution: bool = True
     max_analysis_depth: int = 100
-    
+
     # Monitoring
     metrics_enabled: bool = True
     audit_trail_enabled: bool = True
     evidence_chain_enabled: bool = True
-    
+
     @classmethod
     def from_env(cls) -> 'KarpathyProductionConfig':
         """Load configuration from environment variables."""
@@ -66,8 +66,8 @@ class KarpathyProductionConfig:
             strict_mode=os.getenv('GOVERNANCE_STRICT_MODE', 'true').lower() == 'true',
             block_on_critical=os.getenv('GOVERNANCE_BLOCK_ON_CRITICAL', 'true').lower() == 'true',
         )
-    
-    def to_dict(self) -> Dict[str, Any]:
+
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "assumption_enabled": self.assumption_enabled,

--- a/phionyx_core/config/templates/profile_templates.py
+++ b/phionyx_core/config/templates/profile_templates.py
@@ -9,13 +9,13 @@ These templates demonstrate the structure and schema of profile configurations.
 They are NOT production values and should be customized for your specific needs.
 """
 
-from typing import Dict, Any
+from typing import Any
 
 # ============================================================================
 # EXAMPLE EDU PROFILE (Educational/School Use Cases)
 # ============================================================================
 
-EXAMPLE_EDU_PROFILE: Dict[str, Any] = {
+EXAMPLE_EDU_PROFILE: dict[str, Any] = {
     "profile": "edu",
     "description": "Example educational profile for schools and mental health platforms",
     "modules": {
@@ -49,7 +49,7 @@ EXAMPLE_EDU_PROFILE: Dict[str, Any] = {
 # EXAMPLE GAME PROFILE (Interactive Fiction / Game Studios)
 # ============================================================================
 
-EXAMPLE_GAME_PROFILE: Dict[str, Any] = {
+EXAMPLE_GAME_PROFILE: dict[str, Any] = {
     "profile": "game",
     "description": "Example game profile for interactive fiction studios",
     "modules": {
@@ -83,7 +83,7 @@ EXAMPLE_GAME_PROFILE: Dict[str, Any] = {
 # EXAMPLE CLINICAL PROFILE (Clinical/Mental Health Use Cases)
 # ============================================================================
 
-EXAMPLE_CLINICAL_PROFILE: Dict[str, Any] = {
+EXAMPLE_CLINICAL_PROFILE: dict[str, Any] = {
     "profile": "clinical",
     "description": "Example clinical profile for mental health applications",
     "modules": {

--- a/phionyx_core/context/__init__.py
+++ b/phionyx_core/context/__init__.py
@@ -5,11 +5,11 @@ Phionyx Context SDK
 Context Regulator Layer for managing state across LLM sessions.
 """
 
-from .definitions import ContextMode, ContextRule, ContextDefinition
-from .detector import ModeDetector, DetectionResult
-from .manager import ContextManager
-from .multi_intent import MultiIntentDetector, IntentSegment
 from .composer import HarmonicComposer
+from .definitions import ContextDefinition, ContextMode, ContextRule
+from .detector import DetectionResult, ModeDetector
+from .manager import ContextManager
+from .multi_intent import IntentSegment, MultiIntentDetector
 
 __all__ = [
     "ContextMode",

--- a/phionyx_core/context/composer.py
+++ b/phionyx_core/context/composer.py
@@ -6,8 +6,8 @@ Weaves multiple parallel responses into one coherent reply.
 Uses Physics-based prioritization (Entropy) to determine order.
 """
 
-from typing import List, Dict, Any, Optional
 import logging
+from typing import Any
 
 from .multi_intent import IntentSegment
 
@@ -59,7 +59,7 @@ class HarmonicComposer:
 
     def compose(
         self,
-        segments: List[Dict[str, Any]]
+        segments: list[dict[str, Any]]
     ) -> str:
         """
         Compose multiple responses into one coherent reply.
@@ -136,7 +136,7 @@ class HarmonicComposer:
 
         return composed
 
-    def calculate_priority(self, segment: IntentSegment, physics_state: Optional[Dict] = None) -> int:
+    def calculate_priority(self, segment: IntentSegment, physics_state: dict | None = None) -> int:
         """
         Calculate priority based on entropy and mode.
 

--- a/phionyx_core/context/definitions.py
+++ b/phionyx_core/context/definitions.py
@@ -5,10 +5,9 @@ Context Definitions - Mode and Rule Definitions
 Defines available context modes and their associated memory rules.
 """
 
-from enum import Enum
-from typing import List, Dict, Optional
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class ContextRule:
     """Rule defining which memory blocks are active in a mode."""
 
     mode: ContextMode
-    memory_tags: List[str]  # Tags to filter memories (e.g., ["sdk_architecture", "api_design"])
+    memory_tags: list[str]  # Tags to filter memories (e.g., ["sdk_architecture", "api_design"])
     system_prompt_prefix: str  # System prompt to inject when switching to this mode
     priority: int = 0  # Higher priority = more important
 
@@ -44,10 +43,10 @@ class ContextDefinition:
     """Complete context definition with mode and rules."""
 
     mode: ContextMode
-    rules: List[ContextRule]
+    rules: list[ContextRule]
     description: str = ""
 
-    def get_primary_rule(self) -> Optional[ContextRule]:
+    def get_primary_rule(self) -> ContextRule | None:
         """Get the highest priority rule."""
         if not self.rules:
             return None
@@ -59,7 +58,7 @@ class ContextDefinitions:
 
     def __init__(self):
         """Initialize with default context definitions."""
-        self.definitions: Dict[ContextMode, ContextDefinition] = {}
+        self.definitions: dict[ContextMode, ContextDefinition] = {}
         self._initialize_defaults()
 
     def _initialize_defaults(self):
@@ -155,11 +154,11 @@ class ContextDefinitions:
             description="Default context with no restrictions"
         )
 
-    def get_definition(self, mode: ContextMode) -> Optional[ContextDefinition]:
+    def get_definition(self, mode: ContextMode) -> ContextDefinition | None:
         """Get context definition for a mode."""
         return self.definitions.get(mode)
 
-    def get_all_modes(self) -> List[ContextMode]:
+    def get_all_modes(self) -> list[ContextMode]:
         """Get all available context modes."""
         return list(self.definitions.keys())
 

--- a/phionyx_core/context/detector.py
+++ b/phionyx_core/context/detector.py
@@ -5,12 +5,11 @@ Mode Detector - Intent Classification for Context Switching
 Detects when user is switching topics/modes using keyword and semantic analysis.
 """
 
-from typing import Dict, Optional, List
-from dataclasses import dataclass
 import logging
 import re
+from dataclasses import dataclass
 
-from .definitions import ContextMode, ContextDefinitions
+from .definitions import ContextDefinitions, ContextMode
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ class DetectionResult:
     detected_mode: ContextMode
     confidence: float  # 0.0 to 1.0
     switch_required: bool  # True if context should switch
-    detected_keywords: List[str] = None  # Keywords that triggered detection
+    detected_keywords: list[str] = None  # Keywords that triggered detection
 
     def __post_init__(self):
         """Initialize default values."""
@@ -99,7 +98,7 @@ class ModeDetector:
     def detect_mode(
         self,
         user_input: str,
-        current_state: Optional[Dict] = None
+        current_state: dict | None = None
     ) -> DetectionResult:
         """
         Detect context mode from user input.
@@ -121,8 +120,8 @@ class ModeDetector:
         user_input_lower = user_input.lower()
 
         # Score each mode based on keyword matches
-        mode_scores: Dict[ContextMode, float] = {}
-        mode_keywords: Dict[ContextMode, List[str]] = {}
+        mode_scores: dict[ContextMode, float] = {}
+        mode_keywords: dict[ContextMode, list[str]] = {}
 
         for mode, patterns in self.patterns.items():
             score = 0.0

--- a/phionyx_core/context/manager.py
+++ b/phionyx_core/context/manager.py
@@ -6,10 +6,10 @@ Manages context switching by flushing active context and loading
 mode-specific memory blocks.
 """
 
-from typing import Dict, Optional, List, Any
 import logging
+from typing import Any
 
-from .definitions import ContextMode, ContextDefinitions
+from .definitions import ContextDefinitions, ContextMode
 from .detector import ModeDetector
 
 logger = logging.getLogger(__name__)
@@ -38,17 +38,17 @@ class ContextManager:
         self.vector_store = vector_store
 
         # Current state
-        self.current_mode: Optional[ContextMode] = None
-        self.active_context: Dict[str, Any] = {}
-        self.loaded_memories: List[Dict] = []
+        self.current_mode: ContextMode | None = None
+        self.active_context: dict[str, Any] = {}
+        self.loaded_memories: list[dict] = []
 
         logger.info("ContextManager initialized")
 
     async def process(
         self,
         user_input: str,
-        current_state: Optional[Dict] = None
-    ) -> Dict[str, Any]:
+        current_state: dict | None = None
+    ) -> dict[str, Any]:
         """
         Process user input and determine if context switch is needed.
 
@@ -136,7 +136,7 @@ class ContextManager:
             f"Loaded {len(self.loaded_memories)} memories."
         )
 
-    async def _load_memories_for_mode(self, memory_tags: List[str]) -> None:
+    async def _load_memories_for_mode(self, memory_tags: list[str]) -> None:
         """
         Load memories from Vector Store filtered by context_tags.
 
@@ -180,7 +180,7 @@ class ContextManager:
             logger.error(f"ContextManager: Failed to load memories: {e}")
             self.loaded_memories = []
 
-    def get_active_context(self) -> Dict[str, Any]:
+    def get_active_context(self) -> dict[str, Any]:
         """Get current active context state."""
         return {
             "current_mode": self.current_mode.value if self.current_mode else None,

--- a/phionyx_core/context/multi_intent.py
+++ b/phionyx_core/context/multi_intent.py
@@ -8,10 +8,11 @@ context modes (e.g., "Life planning" + "Engineering" in one query).
 Uses lightweight LLM to segment complex queries into discrete tasks.
 """
 
-from typing import List, Optional, Callable, Any
-from dataclasses import dataclass
-import logging
 import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
 from .definitions import ContextMode
 
@@ -45,7 +46,7 @@ class MultiIntentDetector:
         self,
         llm_provider: str = "openai",
         llm_model: str = "gpt-4o-mini",
-        llm_completion_fn: Optional[Callable[..., Any]] = None,
+        llm_completion_fn: Callable[..., Any] | None = None,
     ):
         """
         Initialize multi-intent detector.
@@ -62,7 +63,7 @@ class MultiIntentDetector:
         self.llm_model = llm_model
         self._init_llm(llm_completion_fn)
 
-    def _init_llm(self, llm_completion_fn: Optional[Callable[..., Any]] = None):
+    def _init_llm(self, llm_completion_fn: Callable[..., Any] | None = None):
         """Initialize LLM client via injected callable (Core boundary: no direct litellm import)."""
         if llm_completion_fn is not None:
             self.llm_available = True
@@ -74,7 +75,7 @@ class MultiIntentDetector:
             )
             self.llm_available = False
 
-    async def analyze(self, text: str) -> List[IntentSegment]:
+    async def analyze(self, text: str) -> list[IntentSegment]:
         """
         Analyze text and segment into multiple intents.
 
@@ -102,7 +103,7 @@ class MultiIntentDetector:
         else:
             return await self._analyze_keyword_based(text)
 
-    async def _analyze_llm_based(self, text: str) -> List[IntentSegment]:
+    async def _analyze_llm_based(self, text: str) -> list[IntentSegment]:
         """
         Use lightweight LLM to analyze and segment intents.
 
@@ -161,7 +162,7 @@ Return ONLY valid JSON, no other text."""
                 if json_match:
                     segments_data = json.loads(json_match.group())
                 else:
-                    raise ValueError("No valid JSON found in response")
+                    raise ValueError("No valid JSON found in response") from None
 
             # Convert to IntentSegment objects
             segments = []
@@ -191,7 +192,7 @@ Return ONLY valid JSON, no other text."""
             logger.error(f"MultiIntentDetector: LLM analysis failed: {e}")
             raise
 
-    async def _analyze_keyword_based(self, text: str) -> List[IntentSegment]:
+    async def _analyze_keyword_based(self, text: str) -> list[IntentSegment]:
         """
         Fallback: Keyword-based intent detection.
 
@@ -213,7 +214,7 @@ Return ONLY valid JSON, no other text."""
             confidence=detection.confidence
         )]
 
-    def is_overload(self, segments: List[IntentSegment]) -> bool:
+    def is_overload(self, segments: list[IntentSegment]) -> bool:
         """
         Check if query has too many intents (overload).
 

--- a/phionyx_core/contracts/__init__.py
+++ b/phionyx_core/contracts/__init__.py
@@ -7,8 +7,7 @@ Single source of truth for all canonical contracts:
 - State contracts
 - Invariants
 """
-from . import telemetry
-from . import envelopes
+from . import envelopes, telemetry
 
 __all__ = [
     'telemetry',

--- a/phionyx_core/contracts/config.py
+++ b/phionyx_core/contracts/config.py
@@ -7,7 +7,7 @@ Core modules should depend on these protocols, not on environment variables
 or hard-coded values. Implementations should be provided by phionyx_bridge.
 """
 
-from typing import Protocol, Optional
+from typing import Protocol
 
 
 class ConfigProtocol(Protocol):
@@ -27,11 +27,11 @@ class ConfigProtocol(Protocol):
         """Get LLM model name (e.g., 'llama3.1:latest', 'gpt-4o')."""
         ...
 
-    def get_llm_api_key(self) -> Optional[str]:
+    def get_llm_api_key(self) -> str | None:
         """Get LLM API key (optional, None for local models)."""
         ...
 
-    def get_llm_base_url(self) -> Optional[str]:
+    def get_llm_base_url(self) -> str | None:
         """Get LLM base URL (optional, for local models like Ollama)."""
         ...
 
@@ -44,11 +44,11 @@ class ConfigProtocol(Protocol):
         """Get embedding model name (e.g., 'qwen2.5:7b', 'text-embedding-3-small')."""
         ...
 
-    def get_embedding_api_key(self) -> Optional[str]:
+    def get_embedding_api_key(self) -> str | None:
         """Get embedding API key (optional, None for local models)."""
         ...
 
-    def get_embedding_base_url(self) -> Optional[str]:
+    def get_embedding_base_url(self) -> str | None:
         """Get embedding base URL (optional, for local models)."""
         ...
 
@@ -63,11 +63,11 @@ class ConfigProtocol(Protocol):
         ...
 
     # Database Configuration (for backward compatibility fallback)
-    def get_supabase_url(self) -> Optional[str]:
+    def get_supabase_url(self) -> str | None:
         """Get Supabase URL (optional, for backward compatibility)."""
         ...
 
-    def get_supabase_key(self) -> Optional[str]:
+    def get_supabase_key(self) -> str | None:
         """Get Supabase service key (optional, for backward compatibility)."""
         ...
 
@@ -89,11 +89,11 @@ class Config(Protocol):
         """Get LLM model name."""
         ...
 
-    def get_llm_api_key(self) -> Optional[str]:
+    def get_llm_api_key(self) -> str | None:
         """Get LLM API key."""
         ...
 
-    def get_llm_base_url(self) -> Optional[str]:
+    def get_llm_base_url(self) -> str | None:
         """Get LLM base URL."""
         ...
 
@@ -105,11 +105,11 @@ class Config(Protocol):
         """Get embedding model name."""
         ...
 
-    def get_embedding_api_key(self) -> Optional[str]:
+    def get_embedding_api_key(self) -> str | None:
         """Get embedding API key."""
         ...
 
-    def get_embedding_base_url(self) -> Optional[str]:
+    def get_embedding_base_url(self) -> str | None:
         """Get embedding base URL."""
         ...
 
@@ -117,11 +117,11 @@ class Config(Protocol):
         """Get embedding dimension."""
         ...
 
-    def get_supabase_url(self) -> Optional[str]:
+    def get_supabase_url(self) -> str | None:
         """Get Supabase URL."""
         ...
 
-    def get_supabase_key(self) -> Optional[str]:
+    def get_supabase_key(self) -> str | None:
         """Get Supabase service key."""
         ...
 

--- a/phionyx_core/contracts/database.py
+++ b/phionyx_core/contracts/database.py
@@ -7,26 +7,26 @@ Core modules should depend on these protocols, not on concrete database implemen
 Implementations should be provided by phionyx_bridge.
 """
 
-from typing import Protocol, Optional, List, Dict, Any
 from abc import ABC, abstractmethod
+from typing import Any, Protocol
 
 
 class MemoryRepositoryProtocol(Protocol):
     """Protocol for memory storage operations."""
 
-    def insert_memory(self, memory_data: Dict[str, Any]) -> Optional[str]:
+    def insert_memory(self, memory_data: dict[str, Any]) -> str | None:
         """Insert a memory record. Returns memory ID if successful."""
         ...
 
-    def get_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
+    def get_memory(self, memory_id: str) -> dict[str, Any] | None:
         """Get a memory by ID."""
         ...
 
-    def search_memories(self, query: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def search_memories(self, query: dict[str, Any]) -> list[dict[str, Any]]:
         """Search memories by query criteria."""
         ...
 
-    def update_memory(self, memory_id: str, updates: Dict[str, Any]) -> bool:
+    def update_memory(self, memory_id: str, updates: dict[str, Any]) -> bool:
         """Update a memory record. Returns True if successful."""
         ...
 
@@ -38,27 +38,27 @@ class MemoryRepositoryProtocol(Protocol):
 class GraphRepositoryProtocol(Protocol):
     """Protocol for graph/concept storage operations."""
 
-    def get_concepts(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_concepts(self, user_id: str) -> list[dict[str, Any]]:
         """Get all concepts for a user."""
         ...
 
-    def get_associations(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_associations(self, user_id: str) -> list[dict[str, Any]]:
         """Get all associations for a user."""
         ...
 
-    def insert_concept(self, concept_data: Dict[str, Any]) -> Optional[str]:
+    def insert_concept(self, concept_data: dict[str, Any]) -> str | None:
         """Insert a concept. Returns concept ID if successful."""
         ...
 
-    def insert_association(self, association_data: Dict[str, Any]) -> Optional[str]:
+    def insert_association(self, association_data: dict[str, Any]) -> str | None:
         """Insert an association. Returns association ID if successful."""
         ...
 
-    def insert_chronicle_event(self, event_data: Dict[str, Any]) -> Optional[str]:
+    def insert_chronicle_event(self, event_data: dict[str, Any]) -> str | None:
         """Insert a chronicle event. Returns event ID if successful."""
         ...
 
-    def get_chronicle_events(self, character_id: str) -> List[Dict[str, Any]]:
+    def get_chronicle_events(self, character_id: str) -> list[dict[str, Any]]:
         """Get chronicle events for a character."""
         ...
 
@@ -66,31 +66,31 @@ class GraphRepositoryProtocol(Protocol):
 class UserProfileRepositoryProtocol(Protocol):
     """Protocol for user profile storage operations."""
 
-    def get_character(self, character_id: str) -> Optional[Dict[str, Any]]:
+    def get_character(self, character_id: str) -> dict[str, Any] | None:
         """Get a character by ID."""
         ...
 
-    def get_user_characters(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_user_characters(self, user_id: str) -> list[dict[str, Any]]:
         """Get all characters for a user."""
         ...
 
-    def get_profile(self, user_id: str) -> Optional[Dict[str, Any]]:
+    def get_profile(self, user_id: str) -> dict[str, Any] | None:
         """Get a user profile."""
         ...
 
-    def get_game_sessions(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_game_sessions(self, user_id: str) -> list[dict[str, Any]]:
         """Get game sessions for a user."""
         ...
 
-    def insert_game_session(self, session_data: Dict[str, Any]) -> Optional[str]:
+    def insert_game_session(self, session_data: dict[str, Any]) -> str | None:
         """Insert a game session. Returns session ID if successful."""
         ...
 
-    def insert_game_log(self, log_data: Dict[str, Any]) -> Optional[str]:
+    def insert_game_log(self, log_data: dict[str, Any]) -> str | None:
         """Insert a game log. Returns log ID if successful."""
         ...
 
-    def get_echoes(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_echoes(self, user_id: str) -> list[dict[str, Any]]:
         """Get echoes for a user."""
         ...
 
@@ -98,11 +98,11 @@ class UserProfileRepositoryProtocol(Protocol):
 class AuditRepositoryProtocol(Protocol):
     """Protocol for audit log storage operations."""
 
-    def log_pedagogy_event(self, event_data: Dict[str, Any]) -> bool:
+    def log_pedagogy_event(self, event_data: dict[str, Any]) -> bool:
         """Log a pedagogy audit event. Returns True if successful."""
         ...
 
-    def log_safety_event(self, event_data: Dict[str, Any]) -> bool:
+    def log_safety_event(self, event_data: dict[str, Any]) -> bool:
         """Log a safety audit event. Returns True if successful."""
         ...
 
@@ -113,22 +113,22 @@ class MemoryRepository(ABC):
     """Abstract base class for memory repository implementations."""
 
     @abstractmethod
-    def insert_memory(self, memory_data: Dict[str, Any]) -> Optional[str]:
+    def insert_memory(self, memory_data: dict[str, Any]) -> str | None:
         """Insert a memory record. Returns memory ID if successful."""
         pass
 
     @abstractmethod
-    def get_memory(self, memory_id: str) -> Optional[Dict[str, Any]]:
+    def get_memory(self, memory_id: str) -> dict[str, Any] | None:
         """Get a memory by ID."""
         pass
 
     @abstractmethod
-    def search_memories(self, query: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def search_memories(self, query: dict[str, Any]) -> list[dict[str, Any]]:
         """Search memories by query criteria."""
         pass
 
     @abstractmethod
-    def update_memory(self, memory_id: str, updates: Dict[str, Any]) -> bool:
+    def update_memory(self, memory_id: str, updates: dict[str, Any]) -> bool:
         """Update a memory record. Returns True if successful."""
         pass
 
@@ -142,32 +142,32 @@ class GraphRepository(ABC):
     """Abstract base class for graph repository implementations."""
 
     @abstractmethod
-    def get_concepts(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_concepts(self, user_id: str) -> list[dict[str, Any]]:
         """Get all concepts for a user."""
         pass
 
     @abstractmethod
-    def get_associations(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_associations(self, user_id: str) -> list[dict[str, Any]]:
         """Get all associations for a user."""
         pass
 
     @abstractmethod
-    def insert_concept(self, concept_data: Dict[str, Any]) -> Optional[str]:
+    def insert_concept(self, concept_data: dict[str, Any]) -> str | None:
         """Insert a concept. Returns concept ID if successful."""
         pass
 
     @abstractmethod
-    def insert_association(self, association_data: Dict[str, Any]) -> Optional[str]:
+    def insert_association(self, association_data: dict[str, Any]) -> str | None:
         """Insert an association. Returns association ID if successful."""
         pass
 
     @abstractmethod
-    def insert_chronicle_event(self, event_data: Dict[str, Any]) -> Optional[str]:
+    def insert_chronicle_event(self, event_data: dict[str, Any]) -> str | None:
         """Insert a chronicle event. Returns event ID if successful."""
         pass
 
     @abstractmethod
-    def get_chronicle_events(self, character_id: str) -> List[Dict[str, Any]]:
+    def get_chronicle_events(self, character_id: str) -> list[dict[str, Any]]:
         """Get chronicle events for a character."""
         pass
 
@@ -176,37 +176,37 @@ class UserProfileRepository(ABC):
     """Abstract base class for user profile repository implementations."""
 
     @abstractmethod
-    def get_character(self, character_id: str) -> Optional[Dict[str, Any]]:
+    def get_character(self, character_id: str) -> dict[str, Any] | None:
         """Get a character by ID."""
         pass
 
     @abstractmethod
-    def get_user_characters(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_user_characters(self, user_id: str) -> list[dict[str, Any]]:
         """Get all characters for a user."""
         pass
 
     @abstractmethod
-    def get_profile(self, user_id: str) -> Optional[Dict[str, Any]]:
+    def get_profile(self, user_id: str) -> dict[str, Any] | None:
         """Get a user profile."""
         pass
 
     @abstractmethod
-    def get_game_sessions(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_game_sessions(self, user_id: str) -> list[dict[str, Any]]:
         """Get game sessions for a user."""
         pass
 
     @abstractmethod
-    def insert_game_session(self, session_data: Dict[str, Any]) -> Optional[str]:
+    def insert_game_session(self, session_data: dict[str, Any]) -> str | None:
         """Insert a game session. Returns session ID if successful."""
         pass
 
     @abstractmethod
-    def insert_game_log(self, log_data: Dict[str, Any]) -> Optional[str]:
+    def insert_game_log(self, log_data: dict[str, Any]) -> str | None:
         """Insert a game log. Returns log ID if successful."""
         pass
 
     @abstractmethod
-    def get_echoes(self, user_id: str) -> List[Dict[str, Any]]:
+    def get_echoes(self, user_id: str) -> list[dict[str, Any]]:
         """Get echoes for a user."""
         pass
 
@@ -215,12 +215,12 @@ class AuditRepository(ABC):
     """Abstract base class for audit repository implementations."""
 
     @abstractmethod
-    def log_pedagogy_event(self, event_data: Dict[str, Any]) -> bool:
+    def log_pedagogy_event(self, event_data: dict[str, Any]) -> bool:
         """Log a pedagogy audit event. Returns True if successful."""
         pass
 
     @abstractmethod
-    def log_safety_event(self, event_data: Dict[str, Any]) -> bool:
+    def log_safety_event(self, event_data: dict[str, Any]) -> bool:
         """Log a safety audit event. Returns True if successful."""
         pass
 

--- a/phionyx_core/contracts/envelopes/__init__.py
+++ b/phionyx_core/contracts/envelopes/__init__.py
@@ -3,10 +3,10 @@ Envelope Contracts Package
 
 Core message envelope contracts for turn and agent communication.
 """
-from .turn_envelope import TurnEnvelope, DeliveryAck
 from .agent_envelope import AgentMessageEnvelope, HandshakeResponse
 from .causal_chain_tracker import CausalChainTracker, CausalConsistencyViolation
-from .envelope_validator import EnvelopeValidator, EnvelopeValidationResult
+from .envelope_validator import EnvelopeValidationResult, EnvelopeValidator
+from .turn_envelope import DeliveryAck, TurnEnvelope
 
 __all__ = [
     'TurnEnvelope',

--- a/phionyx_core/contracts/envelopes/agent_envelope.py
+++ b/phionyx_core/contracts/envelopes/agent_envelope.py
@@ -6,10 +6,11 @@ Models for AI↔AI communication protocol bridge (Paket A).
 Enhanced with envelope hardening (Paket E): message_id, turn_id, timestamp, TTL, nonce.
 """
 
-from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field, field_validator
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
 
 # Use core ParticipantRef to maintain layer isolation
 from phionyx_core.contracts.participants import ParticipantRef, ParticipantType
@@ -25,8 +26,8 @@ class CognitiveMetrics(BaseModel):
     phi: float = Field(0.0, ge=0.0, le=1.0, description="Integrated information (0-1)")
     entropy: float = Field(0.0, ge=0.0, le=1.0, description="System entropy / chaos level (0-1)")
     coherence: float = Field(0.0, ge=0.0, le=1.0, description="Coherence score (0-1)")
-    trust: Optional[float] = Field(None, ge=0.0, le=1.0, description="Trust score (0-1, optional)")
-    w_final: Optional[float] = Field(None, ge=0.0, le=1.0, description="Confidence fusion weight (0-1, optional)")
+    trust: float | None = Field(None, ge=0.0, le=1.0, description="Trust score (0-1, optional)")
+    w_final: float | None = Field(None, ge=0.0, le=1.0, description="Confidence fusion weight (0-1, optional)")
 
 
 class AgentMessageEnvelope(BaseModel):
@@ -55,13 +56,13 @@ class AgentMessageEnvelope(BaseModel):
     ttl_seconds: int = Field(..., ge=0, description="Time-to-live in seconds (0 = no expiration)")
     nonce: str = Field(..., description="Random nonce for replay protection")
 
-    intent: Optional[Dict[str, Any]] = Field(None, description="Intent metadata (optional)")
-    payload: Dict[str, Any] = Field(..., description="Message payload (protocol-specific)")
-    capabilities: Optional[Dict[str, Any]] = Field(None, description="Sender capabilities (optional)")
-    cognitive_metrics: Optional[CognitiveMetrics] = Field(
+    intent: dict[str, Any] | None = Field(None, description="Intent metadata (optional)")
+    payload: dict[str, Any] = Field(..., description="Message payload (protocol-specific)")
+    capabilities: dict[str, Any] | None = Field(None, description="Sender capabilities (optional)")
+    cognitive_metrics: CognitiveMetrics | None = Field(
         None, description="Cognitive state metrics at message creation time (SF2-14)"
     )
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
     @field_validator('message_id')
     @classmethod
@@ -70,8 +71,8 @@ class AgentMessageEnvelope(BaseModel):
         try:
             uuid.UUID(v)
             return v
-        except ValueError:
-            raise ValueError(f"message_id must be a valid UUID, got: {v}")
+        except ValueError as err:
+            raise ValueError(f"message_id must be a valid UUID, got: {v}") from err
 
     @field_validator('timestamp_utc')
     @classmethod
@@ -80,8 +81,8 @@ class AgentMessageEnvelope(BaseModel):
         try:
             datetime.fromisoformat(v.replace('Z', '+00:00'))
             return v
-        except (ValueError, AttributeError):
-            raise ValueError(f"timestamp_utc must be ISO8601 format, got: {v}")
+        except (ValueError, AttributeError) as err:
+            raise ValueError(f"timestamp_utc must be ISO8601 format, got: {v}") from err
 
     @field_validator('nonce')
     @classmethod
@@ -99,15 +100,15 @@ class AgentMessageEnvelope(BaseModel):
         receiver_participant_ref: ParticipantRef,
         trace_id: str,
         turn_id: int,
-        payload: Dict[str, Any],
+        payload: dict[str, Any],
         ttl_seconds: int = 3600,  # Default 1 hour
-        message_id: Optional[str] = None,
-        timestamp_utc: Optional[str] = None,
-        nonce: Optional[str] = None,
-        intent: Optional[Dict[str, Any]] = None,
-        capabilities: Optional[Dict[str, Any]] = None,
-        cognitive_metrics: Optional[CognitiveMetrics] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        message_id: str | None = None,
+        timestamp_utc: str | None = None,
+        nonce: str | None = None,
+        intent: dict[str, Any] | None = None,
+        capabilities: dict[str, Any] | None = None,
+        cognitive_metrics: CognitiveMetrics | None = None,
+        metadata: dict[str, Any] | None = None
     ) -> 'AgentMessageEnvelope':
         """
         Create envelope with auto-generated fields.
@@ -202,7 +203,7 @@ class AgentMessageEnvelope(BaseModel):
         except Exception:
             return True  # If we can't parse, consider expired
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
         # Handle ParticipantType: if it's already a string (use_enum_values=True), use directly
         # Otherwise, get .value if it's an enum
@@ -242,7 +243,7 @@ class AgentMessageEnvelope(BaseModel):
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AgentMessageEnvelope':
+    def from_dict(cls, data: dict[str, Any]) -> 'AgentMessageEnvelope':
         """Deserialize from dictionary."""
         # Use core ParticipantRef (no bridge dependency)
 
@@ -279,22 +280,22 @@ class HandshakeResponse(BaseModel):
 
     Returned by handshake() to exchange agent capabilities.
     """
-    model_capabilities: Dict[str, Any] = Field(..., description="Model capabilities (name, provider, context_window, etc.)")
-    tool_capabilities: Optional[List[Dict[str, Any]]] = Field(None, description="Available tools")
-    context_window_hints: Dict[str, Any] = Field(default_factory=dict, description="Context window hints (max_tokens, etc.)")
+    model_capabilities: dict[str, Any] = Field(..., description="Model capabilities (name, provider, context_window, etc.)")
+    tool_capabilities: list[dict[str, Any]] | None = Field(None, description="Available tools")
+    context_window_hints: dict[str, Any] = Field(default_factory=dict, description="Context window hints (max_tokens, etc.)")
     safety_level: str = Field(..., description="Safety level (e.g., 'strict', 'moderate', 'permissive')")
     protocol_version: str = Field(default="0.1", description="Protocol version")
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Additional metadata")
 
 
-def detect_capabilities_from_participant(participant: ParticipantRef) -> Dict[str, Any]:
+def detect_capabilities_from_participant(participant: ParticipantRef) -> dict[str, Any]:
     """
     Capability detection: extract model and tool capabilities from participant metadata.
 
     Reads participant.metadata for: provider, model_name, context_window, max_tokens,
     tool_capabilities, safety_level. Used by handshake() to build HandshakeResponse.
     """
-    out: Dict[str, Any] = {
+    out: dict[str, Any] = {
         "provider": "unknown",
         "model_name": "default",
         "context_window": 4096,
@@ -328,7 +329,7 @@ def detect_capabilities_from_participant(participant: ParticipantRef) -> Dict[st
 
 def handshake(
     participant: ParticipantRef,
-    requested_capabilities: Optional[Dict[str, Any]] = None
+    requested_capabilities: dict[str, Any] | None = None
 ) -> HandshakeResponse:
     """
     Perform handshake to exchange capabilities.

--- a/phionyx_core/contracts/envelopes/causal_chain_tracker.py
+++ b/phionyx_core/contracts/envelopes/causal_chain_tracker.py
@@ -7,7 +7,6 @@ Each participant's turn_id must be strictly monotonically increasing.
 Violations are detected and reported for audit trail.
 """
 
-from typing import Optional
 from collections import OrderedDict
 from datetime import datetime, timezone
 
@@ -36,7 +35,7 @@ class CausalChainTracker:
 
     def validate_and_record(
         self, participant_id: str, turn_id: int
-    ) -> Optional[CausalConsistencyViolation]:
+    ) -> CausalConsistencyViolation | None:
         """Check turn_id is strictly > last seen for participant, record if valid.
 
         Args:
@@ -67,7 +66,7 @@ class CausalChainTracker:
 
         return None
 
-    def get_last_turn_id(self, participant_id: str) -> Optional[int]:
+    def get_last_turn_id(self, participant_id: str) -> int | None:
         """Get last recorded turn_id for participant."""
         return self._chains.get(participant_id)
 

--- a/phionyx_core/contracts/envelopes/envelope_validator.py
+++ b/phionyx_core/contracts/envelopes/envelope_validator.py
@@ -10,8 +10,8 @@ Runs 4 checks in sequence:
   4. Cognitive integrity (phi/entropy/coherence thresholds)
 """
 
-from typing import Dict, Any, List, Optional, Set, Tuple
 from collections import deque
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -22,9 +22,9 @@ from phionyx_core.contracts.envelopes.causal_chain_tracker import CausalChainTra
 class EnvelopeValidationResult(BaseModel):
     """Composite result from all validation checks."""
     valid: bool = Field(..., description="True if all checks passed")
-    checks_passed: List[str] = Field(default_factory=list, description="Names of passed checks")
-    checks_failed: List[str] = Field(default_factory=list, description="Names of failed checks")
-    details: Dict[str, Any] = Field(default_factory=dict, description="Per-check detail messages")
+    checks_passed: list[str] = Field(default_factory=list, description="Names of passed checks")
+    checks_failed: list[str] = Field(default_factory=list, description="Names of failed checks")
+    details: dict[str, Any] = Field(default_factory=dict, description="Per-check detail messages")
 
 
 class EnvelopeValidator:
@@ -39,7 +39,7 @@ class EnvelopeValidator:
 
     def __init__(
         self,
-        causal_tracker: Optional[CausalChainTracker] = None,
+        causal_tracker: CausalChainTracker | None = None,
         nonce_store_max: int = 10000,
         min_phi: float = 0.0,
         max_entropy: float = 1.0,
@@ -47,7 +47,7 @@ class EnvelopeValidator:
     ):
         self._causal_tracker = causal_tracker or CausalChainTracker()
         self._nonce_order: deque[str] = deque(maxlen=nonce_store_max)
-        self._seen_nonces: Set[str] = set()
+        self._seen_nonces: set[str] = set()
         self._nonce_store_max = nonce_store_max
         self._min_phi = min_phi
         self._max_entropy = max_entropy
@@ -62,9 +62,9 @@ class EnvelopeValidator:
             ("cognitive_integrity", self._check_cognitive),
         ]
 
-        passed: List[str] = []
-        failed: List[str] = []
-        details: Dict[str, Any] = {}
+        passed: list[str] = []
+        failed: list[str] = []
+        details: dict[str, Any] = {}
 
         for name, check_fn in checks:
             ok, detail = check_fn(envelope)
@@ -81,13 +81,13 @@ class EnvelopeValidator:
             details=details,
         )
 
-    def _check_ttl(self, envelope: AgentMessageEnvelope) -> Tuple[bool, str]:
+    def _check_ttl(self, envelope: AgentMessageEnvelope) -> tuple[bool, str]:
         """Check envelope is not expired."""
         if envelope.is_expired():
             return False, "Envelope TTL expired"
         return True, "TTL valid"
 
-    def _check_nonce(self, envelope: AgentMessageEnvelope) -> Tuple[bool, str]:
+    def _check_nonce(self, envelope: AgentMessageEnvelope) -> tuple[bool, str]:
         """Check nonce has not been seen before (replay protection)."""
         nonce = envelope.nonce
         if nonce in self._seen_nonces:
@@ -102,7 +102,7 @@ class EnvelopeValidator:
         self._nonce_order.append(nonce)
         return True, "Nonce unique"
 
-    def _check_causal(self, envelope: AgentMessageEnvelope) -> Tuple[bool, str]:
+    def _check_causal(self, envelope: AgentMessageEnvelope) -> tuple[bool, str]:
         """Check per-participant turn_id monotonicity."""
         participant_id = envelope.sender_participant_ref.id
         violation = self._causal_tracker.validate_and_record(
@@ -116,7 +116,7 @@ class EnvelopeValidator:
             )
         return True, "Causal chain valid"
 
-    def _check_cognitive(self, envelope: AgentMessageEnvelope) -> Tuple[bool, str]:
+    def _check_cognitive(self, envelope: AgentMessageEnvelope) -> tuple[bool, str]:
         """Check cognitive integrity thresholds."""
         if not envelope.validate_cognitive_integrity(
             min_phi=self._min_phi,

--- a/phionyx_core/contracts/envelopes/turn_envelope.py
+++ b/phionyx_core/contracts/envelopes/turn_envelope.py
@@ -14,9 +14,9 @@ Critical invariants:
 Schema version: 1.0
 """
 
-from typing import Optional
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 import hashlib
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class TurnEnvelope(BaseModel):
@@ -35,7 +35,7 @@ class TurnEnvelope(BaseModel):
     schema_version: str = Field(default="1.0", description="Schema version for contract evolution")
 
     # Optional fields
-    parent_turn_id: Optional[int] = Field(None, description="Parent turn ID (for conversation threading)")
+    parent_turn_id: int | None = Field(None, description="Parent turn ID (for conversation threading)")
 
     @field_validator('turn_id')
     @classmethod
@@ -53,8 +53,8 @@ class TurnEnvelope(BaseModel):
             raise ValueError(f"user_text_sha256 must be 64 hex characters, got {len(v)}")
         try:
             int(v, 16)  # Validate hex
-        except ValueError:
-            raise ValueError(f"user_text_sha256 must be valid hex string, got {v}")
+        except ValueError as err:
+            raise ValueError(f"user_text_sha256 must be valid hex string, got {v}") from err
         return v.lower()  # Normalize to lowercase
 
     @classmethod
@@ -80,8 +80,8 @@ class DeliveryAck(BaseModel):
     turn_id: int = Field(..., description="Turn ID from envelope")
     message_id: str = Field(..., description="Message ID from envelope")
     received_user_text_sha256: str = Field(..., description="SHA256 of user_text as received by core")
-    prompt_context_sha256: Optional[str] = Field(None, description="SHA256 of prompt context (if available)")
+    prompt_context_sha256: str | None = Field(None, description="SHA256 of prompt context (if available)")
     delivery_status: str = Field(default="delivered", description="Delivery status: delivered, mismatch, rejected")
-    delivery_error: Optional[str] = Field(None, description="Error message if delivery failed")
+    delivery_error: str | None = Field(None, description="Error message if delivery failed")
 
     model_config = ConfigDict(json_schema_extra={'example': {'conversation_id': 'conv_abc123', 'turn_id': 1, 'message_id': '550e8400-e29b-41d4-a716-446655440000', 'received_user_text_sha256': 'a1b2c3d4e5f6...', 'prompt_context_sha256': 'b2c3d4e5f6a1...', 'delivery_status': 'delivered', 'delivery_error': None}})

--- a/phionyx_core/contracts/llm_provider.py
+++ b/phionyx_core/contracts/llm_provider.py
@@ -9,7 +9,7 @@ This protocol allows phionyx_core to use LLM services without importing
 from echo_server, maintaining proper layer isolation.
 """
 
-from typing import Protocol, List, Optional, Dict, Any
+from typing import Any, Protocol
 
 
 class LLMProviderProtocol(Protocol):
@@ -35,10 +35,10 @@ class LLMProviderProtocol(Protocol):
 
     async def completion(
         self,
-        messages: List[Dict[str, str]],
-        model: Optional[str] = None,
+        messages: list[dict[str, str]],
+        model: str | None = None,
         temperature: float = 0.7,
-        max_tokens: Optional[int] = None,
+        max_tokens: int | None = None,
         **kwargs: Any
     ) -> str:
         """
@@ -62,9 +62,9 @@ class LLMProviderProtocol(Protocol):
     async def embedding(
         self,
         text: str,
-        model: Optional[str] = None,
+        model: str | None = None,
         use_cache: bool = True
-    ) -> Optional[List[float]]:
+    ) -> list[float] | None:
         """
         Generate embedding vector for text.
 
@@ -81,8 +81,8 @@ class LLMProviderProtocol(Protocol):
     async def extract_concepts(
         self,
         text: str,
-        model: Optional[str] = None
-    ) -> List[Any]:
+        model: str | None = None
+    ) -> list[Any]:
         """
         Extract concepts from text.
 

--- a/phionyx_core/contracts/participants.py
+++ b/phionyx_core/contracts/participants.py
@@ -6,8 +6,8 @@ Core abstraction for participant references to maintain layer isolation.
 This allows phionyx_core to work with participants without depending on bridge.
 """
 
-from typing import Optional
 from enum import Enum
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -27,7 +27,7 @@ class ParticipantRef(BaseModel):
     """
     id: str = Field(..., description="Participant identifier")
     type: ParticipantType = Field(..., description="Participant type")
-    name: Optional[str] = Field(None, description="Participant name")
-    metadata: Optional[dict] = Field(None, description="Additional metadata")
+    name: str | None = Field(None, description="Participant name")
+    metadata: dict | None = Field(None, description="Additional metadata")
 
     model_config = ConfigDict(use_enum_values=True)

--- a/phionyx_core/contracts/telemetry/__init__.py
+++ b/phionyx_core/contracts/telemetry/__init__.py
@@ -6,7 +6,7 @@ Supports backward compatibility with v3.7.0, v3.6.0, v3.5.0, v3.0.0, v2.5.0, and
 """
 import json
 from pathlib import Path
-from typing import List, Dict, Any, Optional
+from typing import Any
 
 # Contract version management
 _CONTRACT_V2_4_0_PATH = Path(__file__).parent / "archive" / "canonical_blocks_v2_4_0.json"
@@ -20,33 +20,33 @@ _CURRENT_VERSION = "3.8.0"
 _FALLBACK_VERSION = "2.5.0"
 
 
-def _load_contract(version: Optional[str] = None) -> Dict[str, Any]:
+def _load_contract(version: str | None = None) -> dict[str, Any]:
     """Load telemetry contract for specified version."""
     # v3.8.0 support (state-driven response revision — 46 blocks)
     if version == "3.8.0" or version is None:
         if _CONTRACT_V3_8_0_PATH.exists():
-            with open(_CONTRACT_V3_8_0_PATH, 'r') as f:
+            with open(_CONTRACT_V3_8_0_PATH) as f:
                 return json.load(f)
         if version == "3.8.0":
             raise FileNotFoundError("v3.8.0 contract file not found")
     # v3.7.0 support (CEP reactivation pipeline — 45 blocks)
     if version == "3.7.0" or version is None:
         if _CONTRACT_V3_7_0_PATH.exists():
-            with open(_CONTRACT_V3_7_0_PATH, 'r') as f:
+            with open(_CONTRACT_V3_7_0_PATH) as f:
                 return json.load(f)
         if version == "3.7.0":
             raise FileNotFoundError("v3.7.0 contract file not found")
     # v3.6.0 support (feedback loop pipeline — 44 blocks)
     if version == "3.6.0" or version is None:
         if _CONTRACT_V3_6_0_PATH.exists():
-            with open(_CONTRACT_V3_6_0_PATH, 'r') as f:
+            with open(_CONTRACT_V3_6_0_PATH) as f:
                 return json.load(f)
         if version == "3.6.0":
             raise FileNotFoundError("v3.6.0 contract file not found")
     # v3.5.0 support (full AGI pipeline — 43 blocks)
     if version == "3.5.0" or version is None:
         if _CONTRACT_V3_5_0_PATH.exists():
-            with open(_CONTRACT_V3_5_0_PATH, 'r') as f:
+            with open(_CONTRACT_V3_5_0_PATH) as f:
                 return json.load(f)
         # Fall through to v3.0.0 if v3.5.0 not found and no explicit version requested
         if version == "3.5.0":
@@ -54,22 +54,22 @@ def _load_contract(version: Optional[str] = None) -> Dict[str, Any]:
     # v3.0.0 support (AD-3: pipeline version coexistence)
     if version == "3.0.0" or version is None:
         if _CONTRACT_V3_0_0_PATH.exists():
-            with open(_CONTRACT_V3_0_0_PATH, 'r') as f:
+            with open(_CONTRACT_V3_0_0_PATH) as f:
                 return json.load(f)
         if version == "3.0.0":
             raise FileNotFoundError("v3.0.0 contract file not found")
     if version == "2.5.0" or version is None:
         if _CONTRACT_V2_5_0_PATH.exists():
-            with open(_CONTRACT_V2_5_0_PATH, 'r') as f:
+            with open(_CONTRACT_V2_5_0_PATH) as f:
                 return json.load(f)
     # Fallback to v2.4.0
     if _CONTRACT_V2_4_0_PATH.exists():
-        with open(_CONTRACT_V2_4_0_PATH, 'r') as f:
+        with open(_CONTRACT_V2_4_0_PATH) as f:
             return json.load(f)
     raise FileNotFoundError("Telemetry contract file not found")
 
 
-def get_canonical_blocks(version: Optional[str] = None) -> List[str]:
+def get_canonical_blocks(version: str | None = None) -> list[str]:
     """
     Returns canonical block order from JSON contract (46 blocks, CONTRACT v3.8.0).
 
@@ -86,7 +86,7 @@ def get_canonical_blocks(version: Optional[str] = None) -> List[str]:
     return contract['canonical_block_order']
 
 
-def get_canonical_block_order(version: Optional[str] = None) -> List[str]:
+def get_canonical_block_order(version: str | None = None) -> list[str]:
     """
     Get canonical block order (alias for get_canonical_blocks).
 
@@ -99,7 +99,7 @@ def get_canonical_block_order(version: Optional[str] = None) -> List[str]:
     return get_canonical_blocks(version)
 
 
-def get_middleware_blocks(version: Optional[str] = None) -> List[str]:
+def get_middleware_blocks(version: str | None = None) -> list[str]:
     """
     Returns middleware blocks (v2.5.0+ only).
 
@@ -113,7 +113,7 @@ def get_middleware_blocks(version: Optional[str] = None) -> List[str]:
     return contract.get('middleware_blocks', [])
 
 
-def get_block_mapping(version: Optional[str] = None) -> Dict[str, Any]:
+def get_block_mapping(version: str | None = None) -> dict[str, Any]:
     """
     Returns block mapping for migration (v2.5.0+ only).
 
@@ -127,7 +127,7 @@ def get_block_mapping(version: Optional[str] = None) -> Dict[str, Any]:
     return contract.get('block_mapping', {})
 
 
-def get_required_event_types(version: Optional[str] = None) -> List[str]:
+def get_required_event_types(version: str | None = None) -> list[str]:
     """Returns required event types."""
     contract = _load_contract(version)
     return contract['required_event_types']

--- a/phionyx_core/contracts/telemetry/migration_v2_4_0_to_v2_5_0.py
+++ b/phionyx_core/contracts/telemetry/migration_v2_4_0_to_v2_5_0.py
@@ -9,16 +9,17 @@ Usage:
 """
 import json
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any
+
 from phionyx_core.contracts.telemetry import (
-    get_canonical_blocks,
     get_block_mapping,
+    get_canonical_blocks,
     get_middleware_blocks,
-    migrate_block_id
+    migrate_block_id,
 )
 
 
-def validate_migration() -> Dict[str, Any]:
+def validate_migration() -> dict[str, Any]:
     """
     Validate that migration mapping is correct.
 
@@ -32,10 +33,10 @@ def validate_migration() -> Dict[str, Any]:
     contract_v2_4_0_path = Path(__file__).parent / "archive" / "canonical_blocks_v2_4_0.json"
     contract_v2_5_0_path = Path(__file__).parent / "canonical_blocks_v2_5_0.json"
 
-    with open(contract_v2_4_0_path, 'r') as f:
+    with open(contract_v2_4_0_path) as f:
         contract_v2_4_0 = json.load(f)
 
-    with open(contract_v2_5_0_path, 'r') as f:
+    with open(contract_v2_5_0_path) as f:
         contract_v2_5_0 = json.load(f)
 
     # Check that all mapped blocks exist in v2.4.0
@@ -66,7 +67,7 @@ def validate_migration() -> Dict[str, Any]:
     }
 
 
-def migrate_telemetry_data(telemetry_data: Dict[str, Any]) -> Dict[str, Any]:
+def migrate_telemetry_data(telemetry_data: dict[str, Any]) -> dict[str, Any]:
     """
     Migrate telemetry data from v2.4.0 to v2.5.0 format.
 

--- a/phionyx_core/contracts/telemetry/migration_v2_5_0_to_v3_0_0.py
+++ b/phionyx_core/contracts/telemetry/migration_v2_5_0_to_v3_0_0.py
@@ -7,7 +7,7 @@ Non-destructive: v2.5.0 pipeline continues to work alongside v3.0.0 (AD-3).
 """
 
 import logging
-from typing import List, Dict, Any
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ V3_INSERTION_POINTS = {
 }
 
 
-def migrate_block_order(v2_blocks: List[str]) -> List[str]:
+def migrate_block_order(v2_blocks: list[str]) -> list[str]:
     """
     Migrate v2.5.0 block order to v3.0.0 by inserting new blocks.
 
@@ -65,7 +65,7 @@ def migrate_block_order(v2_blocks: List[str]) -> List[str]:
     return result
 
 
-def validate_migration(v3_blocks: List[str]) -> Dict[str, Any]:
+def validate_migration(v3_blocks: list[str]) -> dict[str, Any]:
     """
     Validate that migrated block order is correct.
 
@@ -104,7 +104,7 @@ def validate_migration(v3_blocks: List[str]) -> Dict[str, Any]:
     }
 
 
-def get_migration_diff(v2_blocks: List[str], v3_blocks: List[str]) -> Dict[str, Any]:
+def get_migration_diff(v2_blocks: list[str], v3_blocks: list[str]) -> dict[str, Any]:
     """Get diff between v2.5.0 and v3.0.0 block orders."""
     added = [b for b in v3_blocks if b not in v2_blocks]
     removed = [b for b in v2_blocks if b not in v3_blocks]

--- a/phionyx_core/contracts/telemetry/migration_v3_7_0_to_v3_8_0.py
+++ b/phionyx_core/contracts/telemetry/migration_v3_7_0_to_v3_8_0.py
@@ -40,13 +40,12 @@ Rationale (patent-claim alignment):
 Founder approval: granted in session_01RW4rjACATaqAHoRNxpCjjg.
 """
 
-from typing import List
 
 SOURCE_VERSION = "3.7.0"
 TARGET_VERSION = "3.8.0"
 
 # Block IDs reordered (moved up) — position changes are data-only.
-REORDERED_BLOCKS: List[str] = [
+REORDERED_BLOCKS: list[str] = [
     "phi_computation",
     "entropy_computation",
     "confidence_fusion",
@@ -54,12 +53,12 @@ REORDERED_BLOCKS: List[str] = [
 ]
 
 # Newly inserted block IDs.
-NEW_BLOCKS: List[str] = [
+NEW_BLOCKS: list[str] = [
     "response_revision_gate",
 ]
 
 # Newly required event types.
-NEW_EVENT_TYPES: List[str] = [
+NEW_EVENT_TYPES: list[str] = [
     "response_revision",
 ]
 

--- a/phionyx_core/contracts/v4/__init__.py
+++ b/phionyx_core/contracts/v4/__init__.py
@@ -9,19 +9,19 @@ All v4 schemas are backward-compatible — existing pipelines continue
 to work without v4 fields (Optional everywhere).
 """
 
-from .input_signal import InputSignal
-from .perceptual_frame import PerceptualFrame
-from .world_state_snapshot import WorldStateSnapshot
-from .goal_object import GoalObject, GoalPriority, GoalStatus
-from .memory_entry import MemoryEntry, BoundaryZone
 from .action_intent import ActionIntent, ActionType, ReversibilityLevel
-from .ethics_decision import EthicsDecision, EthicsVerdict, DeliberationLayer
-from .confidence_payload import ConfidencePayload, UncertaintyType
-from .workspace_event import WorkspaceEvent, SalienceLevel
 from .audit_record import AuditRecord
-from .learning_update import LearningUpdate, LearningGateDecision
+from .confidence_payload import ConfidencePayload, UncertaintyType
 from .discovery_candidate import DiscoveryCandidate
 from .error_payload import ErrorPayload, ErrorSeverity
+from .ethics_decision import DeliberationLayer, EthicsDecision, EthicsVerdict
+from .goal_object import GoalObject, GoalPriority, GoalStatus
+from .input_signal import InputSignal
+from .learning_update import LearningGateDecision, LearningUpdate
+from .memory_entry import BoundaryZone, MemoryEntry
+from .perceptual_frame import PerceptualFrame
+from .workspace_event import SalienceLevel, WorkspaceEvent
+from .world_state_snapshot import WorldStateSnapshot
 
 __all__ = [
     # Schemas

--- a/phionyx_core/contracts/v4/action_intent.py
+++ b/phionyx_core/contracts/v4/action_intent.py
@@ -7,11 +7,12 @@ Entirely new schema. Represents system action intentions
 Includes sandbox/reversibility metadata for safe execution.
 """
 
-from typing import Optional, Dict, Any
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ActionType(str, Enum):
@@ -75,7 +76,7 @@ class ActionIntent(BaseModel):
         default="action_executor",
         description="Module that will execute this action"
     )
-    target_parameters: Dict[str, Any] = Field(
+    target_parameters: dict[str, Any] = Field(
         default_factory=dict,
         description="Parameters for the target module"
     )
@@ -85,7 +86,7 @@ class ActionIntent(BaseModel):
         default="intelligence_core",
         description="Module that proposed this action"
     )
-    source_goal_id: Optional[str] = Field(
+    source_goal_id: str | None = Field(
         None,
         description="Goal that motivated this action"
     )
@@ -100,17 +101,17 @@ class ActionIntent(BaseModel):
         default=False,
         description="Whether ethics gate approved this action"
     )
-    ethics_decision_id: Optional[str] = Field(
+    ethics_decision_id: str | None = Field(
         None,
         description="Reference to EthicsDecision that cleared this"
     )
 
     # Timestamps
     proposed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    executed_at: Optional[datetime] = None
+    executed_at: datetime | None = None
 
     # Metadata
-    trace_id: Optional[str] = None
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    trace_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(json_schema_extra={'example': {'action_type': 'respond', 'reversibility': 'fully_reversible', 'sandbox_required': False, 'confidence': 0.85}})

--- a/phionyx_core/contracts/v4/audit_record.py
+++ b/phionyx_core/contracts/v4/audit_record.py
@@ -6,12 +6,13 @@ Extends existing PedagogyLogger + audit_layer with Ed25519 signing,
 hash chain for immutability, and structured audit trail.
 """
 
-from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
-import uuid
 import hashlib
 import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AuditRecord(BaseModel):
@@ -37,17 +38,17 @@ class AuditRecord(BaseModel):
         default="0" * 64,
         description="SHA-256 hash of previous audit record (genesis = 0*64)"
     )
-    record_hash: Optional[str] = Field(
+    record_hash: str | None = Field(
         None,
         description="SHA-256 hash of this record's content"
     )
 
     # Signature (Ed25519)
-    signature: Optional[str] = Field(
+    signature: str | None = Field(
         None,
         description="Ed25519 signature of record_hash (hex-encoded)"
     )
-    signer_public_key: Optional[str] = Field(
+    signer_public_key: str | None = Field(
         None,
         description="Public key of signer (hex-encoded)"
     )
@@ -71,25 +72,25 @@ class AuditRecord(BaseModel):
     )
 
     # Snapshot data
-    state_snapshot: Optional[Dict[str, Any]] = Field(
+    state_snapshot: dict[str, Any] | None = Field(
         None,
         description="State snapshot at audit time"
     )
-    input_hash: Optional[str] = Field(
+    input_hash: str | None = Field(
         None,
         description="SHA-256 of input that triggered this event"
     )
-    output_hash: Optional[str] = Field(
+    output_hash: str | None = Field(
         None,
         description="SHA-256 of output produced"
     )
 
     # Explainability
-    decision_trace: List[Dict[str, Any]] = Field(
+    decision_trace: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Decision trace for explainability"
     )
-    block_results: Optional[Dict[str, Any]] = Field(
+    block_results: dict[str, Any] | None = Field(
         None,
         description="Pipeline block results summary"
     )
@@ -99,14 +100,14 @@ class AuditRecord(BaseModel):
 
     # Metadata
     schema_version: str = Field(default="4.0.0")
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     # Patent-claim traceability (v4.1.0 additive extension — not part of
     # hash-chained content to preserve existing hash-chain continuity).
     # Populated with the tuple of SF/Claim refs touched during the turn
     # (union of claim_refs across executed PipelineBlocks). See
     # docs/publications/patents/ukipo/BLOCK_CLAIM_IMPROVEMENT_PLAN_V2.md.
-    claim_refs: List[str] = Field(
+    claim_refs: list[str] = Field(
         default_factory=list,
         description=(
             "UKIPO patent-claim references this turn exercised, e.g. "
@@ -115,7 +116,7 @@ class AuditRecord(BaseModel):
             "compute_hash() so existing audit hash chains remain valid."
         ),
     )
-    revision_directive: Optional[Dict[str, Any]] = Field(
+    revision_directive: dict[str, Any] | None = Field(
         default=None,
         description=(
             "When response_revision_gate emitted a non-'pass' directive for "

--- a/phionyx_core/contracts/v4/confidence_payload.py
+++ b/phionyx_core/contracts/v4/confidence_payload.py
@@ -6,10 +6,11 @@ Extends existing ConfidenceResult with epistemic/aleatoric decomposition,
 ECE calibration, and OOD detection.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class UncertaintyType(str, Enum):
@@ -58,31 +59,31 @@ class ConfidencePayload(BaseModel):
     )
 
     # Calibration (v4 §7)
-    ece_score: Optional[float] = Field(
+    ece_score: float | None = Field(
         None, ge=0.0, le=1.0,
         description="Expected Calibration Error"
     )
-    ood_score: Optional[float] = Field(
+    ood_score: float | None = Field(
         None, ge=0.0, le=1.0,
         description="Out-of-Distribution score"
     )
 
     # Meta-cognitive trust (T_meta)
-    t_meta: Optional[float] = Field(
+    t_meta: float | None = Field(
         None, ge=0.0, le=1.0,
         description="T_meta = (1-ECE)*(1-OOD)*(1-|self_report_delta|)"
     )
-    self_report_delta: Optional[float] = Field(
+    self_report_delta: float | None = Field(
         None, ge=0.0, le=1.0,
         description="Discrepancy between self-reported and actual confidence"
     )
 
     # Ensemble data (for decomposition)
-    ensemble_predictions: Optional[List[float]] = Field(
+    ensemble_predictions: list[float] | None = Field(
         None,
         description="Predictions from ensemble members"
     )
-    ensemble_variance: Optional[float] = Field(
+    ensemble_variance: float | None = Field(
         None, ge=0.0,
         description="Variance across ensemble members"
     )
@@ -93,6 +94,6 @@ class ConfidencePayload(BaseModel):
         description="Which estimator produced this payload"
     )
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(json_schema_extra={'example': {'confidence_score': 0.82, 'epistemic_uncertainty': 0.12, 'aleatoric_uncertainty': 0.06, 'dominant_uncertainty': 'epistemic'}})

--- a/phionyx_core/contracts/v4/discovery_candidate.py
+++ b/phionyx_core/contracts/v4/discovery_candidate.py
@@ -6,10 +6,11 @@ Extends IntuitionGraph with novelty/transfer/robustness scoring
 for open-ended discovery evaluation.
 """
 
-from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DiscoveryCandidate(BaseModel):
@@ -47,11 +48,11 @@ class DiscoveryCandidate(BaseModel):
     )
 
     # Discovery provenance
-    source_graph_nodes: List[str] = Field(
+    source_graph_nodes: list[str] = Field(
         default_factory=list,
         description="IntuitionGraph node IDs that contributed"
     )
-    source_patterns: List[str] = Field(
+    source_patterns: list[str] = Field(
         default_factory=list,
         description="Patterns identified"
     )
@@ -61,13 +62,13 @@ class DiscoveryCandidate(BaseModel):
     )
 
     # Cross-domain relevance
-    domain_relevance: Dict[str, float] = Field(
+    domain_relevance: dict[str, float] = Field(
         default_factory=dict,
         description="Relevance score per domain"
     )
 
     # Embedding for similarity computation
-    embedding_vector: Optional[List[float]] = Field(
+    embedding_vector: list[float] | None = Field(
         None,
         description="Embedding vector for novelty computation"
     )
@@ -77,17 +78,17 @@ class DiscoveryCandidate(BaseModel):
         default=False,
         description="Whether a human has validated this discovery"
     )
-    validation_score: Optional[float] = Field(
+    validation_score: float | None = Field(
         None, ge=0.0, le=1.0,
         description="Human validation score"
     )
 
     # Timestamps
     discovered_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    validated_at: Optional[datetime] = None
+    validated_at: datetime | None = None
 
     # Metadata
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def compute_composite(
         self,

--- a/phionyx_core/contracts/v4/error_payload.py
+++ b/phionyx_core/contracts/v4/error_payload.py
@@ -6,11 +6,12 @@ Extends BlockResult with severity enum, recovery actions,
 and structured error reporting.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ErrorSeverity(str, Enum):
@@ -62,7 +63,7 @@ class ErrorPayload(BaseModel):
         default=RecoveryAction.NONE,
         description="Recommended recovery action"
     )
-    recovery_details: Optional[str] = Field(
+    recovery_details: str | None = Field(
         None,
         description="Detailed recovery instructions"
     )
@@ -70,7 +71,7 @@ class ErrorPayload(BaseModel):
         default=False,
         description="Whether the operation can be retried"
     )
-    retry_after_ms: Optional[int] = Field(
+    retry_after_ms: int | None = Field(
         None, ge=0,
         description="Suggested retry delay in milliseconds"
     )
@@ -80,17 +81,17 @@ class ErrorPayload(BaseModel):
         default="unknown",
         description="Module where error originated"
     )
-    source_block_id: Optional[str] = Field(
+    source_block_id: str | None = Field(
         None,
         description="Pipeline block ID if error is from pipeline"
     )
-    stack_trace: Optional[str] = Field(
+    stack_trace: str | None = Field(
         None,
         description="Stack trace (debug/staging only, never in production)"
     )
 
     # Impact
-    affected_modules: List[str] = Field(
+    affected_modules: list[str] = Field(
         default_factory=list,
         description="Modules affected by this error"
     )
@@ -101,11 +102,11 @@ class ErrorPayload(BaseModel):
 
     # Timestamps
     occurred_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    resolved_at: Optional[datetime] = None
+    resolved_at: datetime | None = None
 
     # Metadata
-    trace_id: Optional[str] = None
-    correlation_id: Optional[str] = None
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    trace_id: str | None = None
+    correlation_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(json_schema_extra={'example': {'severity': 'error', 'error_code': 'ETHICS_GATE_FAIL', 'message': 'Ethics gate denied action', 'recovery_action': 'fallback'}})

--- a/phionyx_core/contracts/v4/ethics_decision.py
+++ b/phionyx_core/contracts/v4/ethics_decision.py
@@ -6,11 +6,12 @@ Wraps existing EthicsVector + apply_ethics_enforcement() with v4
 verdict enum, deliberation layer, and decision trace.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class EthicsVerdict(str, Enum):
@@ -55,7 +56,7 @@ class EthicsDecision(BaseModel):
         default=False,
         description="Whether enforcement was triggered (from apply_ethics_enforcement)"
     )
-    triggered_risks: List[str] = Field(
+    triggered_risks: list[str] = Field(
         default_factory=list,
         description="Risk types that triggered enforcement"
     )
@@ -63,17 +64,17 @@ class EthicsDecision(BaseModel):
         default=0.0, ge=0.0, le=1.0,
         description="Maximum risk score across all dimensions"
     )
-    safety_message: Optional[str] = Field(
+    safety_message: str | None = Field(
         None,
         description="Safety message if enforcement triggered"
     )
 
     # v4 deliberation trace
-    deliberation_steps: List[Dict[str, Any]] = Field(
+    deliberation_steps: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Ordered deliberation steps with reasoning"
     )
-    rules_evaluated: List[str] = Field(
+    rules_evaluated: list[str] = Field(
         default_factory=list,
         description="Ethics rules that were evaluated"
     )
@@ -83,21 +84,21 @@ class EthicsDecision(BaseModel):
     )
 
     # Effects
-    entropy_adjustment: Optional[float] = Field(
+    entropy_adjustment: float | None = Field(
         None,
         description="Entropy adjustment applied (e.g., 0.95 boost)"
     )
-    amplitude_damping: Optional[float] = Field(
+    amplitude_damping: float | None = Field(
         None,
         description="Amplitude damping factor applied (e.g., 0.3)"
     )
 
     # Provenance
-    source_action_id: Optional[str] = Field(
+    source_action_id: str | None = Field(
         None,
         description="ActionIntent that triggered this evaluation"
     )
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(json_schema_extra={'example': {'verdict': 'allow', 'deliberation_layer': 'rule_based', 'enforced': False, 'max_risk_score': 0.2}})

--- a/phionyx_core/contracts/v4/goal_object.py
+++ b/phionyx_core/contracts/v4/goal_object.py
@@ -6,11 +6,12 @@ Entirely new schema — no existing Phionyx counterpart.
 Represents system-level goals with legitimacy scoring and priority.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class GoalPriority(str, Enum):
@@ -69,44 +70,44 @@ class GoalObject(BaseModel):
         default=0.5, ge=0.0, le=1.0,
         description="User alignment score"
     )
-    legitimacy_weights: Dict[str, float] = Field(
+    legitimacy_weights: dict[str, float] = Field(
         default_factory=lambda: {"alpha": 0.5, "beta": 0.3, "gamma": 0.2},
         description="Weights for L(g) = alpha*safety + beta*system + gamma*user"
     )
 
     # Goal tracking
-    parent_goal_id: Optional[str] = Field(
+    parent_goal_id: str | None = Field(
         None,
         description="Parent goal for hierarchical decomposition"
     )
-    sub_goal_ids: List[str] = Field(
+    sub_goal_ids: list[str] = Field(
         default_factory=list,
         description="Child goal IDs"
     )
-    conflict_with: List[str] = Field(
+    conflict_with: list[str] = Field(
         default_factory=list,
         description="Goal IDs this goal conflicts with"
     )
-    preconditions: List[str] = Field(
+    preconditions: list[str] = Field(
         default_factory=list,
         description="Conditions that must be true for activation"
     )
-    success_criteria: List[str] = Field(
+    success_criteria: list[str] = Field(
         default_factory=list,
         description="Conditions for goal completion"
     )
 
     # Timestamps
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    activated_at: Optional[datetime] = None
-    completed_at: Optional[datetime] = None
+    activated_at: datetime | None = None
+    completed_at: datetime | None = None
 
     # Metadata
     source_module: str = Field(
         default="goal_manager",
         description="Module that created this goal"
     )
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def compute_legitimacy(self) -> float:
         """

--- a/phionyx_core/contracts/v4/input_signal.py
+++ b/phionyx_core/contracts/v4/input_signal.py
@@ -6,10 +6,11 @@ Wraps TurnEnvelope with v4-required fields: source_module, signal_type.
 AD-1: Composition — TurnEnvelope is composed, not replaced.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..envelopes.turn_envelope import TurnEnvelope
 
@@ -42,7 +43,7 @@ class InputSignal(BaseModel):
         default=SignalType.USER_TEXT,
         description="Signal classification for routing"
     )
-    modalities: List[str] = Field(
+    modalities: list[str] = Field(
         default_factory=lambda: ["text"],
         description="Input modalities (text, audio, image, sensor)"
     )
@@ -51,11 +52,11 @@ class InputSignal(BaseModel):
         ge=0, le=10,
         description="Signal priority (0=normal, 10=critical)"
     )
-    trace_id: Optional[str] = Field(
+    trace_id: str | None = Field(
         None,
         description="Distributed trace ID for cross-module tracking"
     )
-    correlation_id: Optional[str] = Field(
+    correlation_id: str | None = Field(
         None,
         description="Correlation ID for request grouping"
     )
@@ -63,7 +64,7 @@ class InputSignal(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="Signal creation timestamp (UTC)"
     )
-    metadata: Dict[str, Any] = Field(
+    metadata: dict[str, Any] = Field(
         default_factory=dict,
         description="Extensible metadata"
     )

--- a/phionyx_core/contracts/v4/learning_update.py
+++ b/phionyx_core/contracts/v4/learning_update.py
@@ -6,11 +6,12 @@ Extends ProfileTuner with boundary gate and approval flow.
 Learning updates must pass through a gate before modifying parameters.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class LearningGateDecision(str, Enum):
@@ -46,7 +47,7 @@ class LearningUpdate(BaseModel):
         ...,
         description="Proposed new value"
     )
-    delta: Optional[float] = Field(
+    delta: float | None = Field(
         None,
         description="Numeric delta (proposed - current) if applicable"
     )
@@ -70,7 +71,7 @@ class LearningUpdate(BaseModel):
         default=0.0, ge=0.0, le=1.0,
         description="Estimated impact of this change"
     )
-    affected_modules: List[str] = Field(
+    affected_modules: list[str] = Field(
         default_factory=list,
         description="Modules affected by this update"
     )
@@ -84,16 +85,16 @@ class LearningUpdate(BaseModel):
         default="learning_engine",
         description="Module proposing this update"
     )
-    evidence: List[Dict[str, Any]] = Field(
+    evidence: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Evidence supporting this update"
     )
-    turn_id: Optional[int] = None
+    turn_id: int | None = None
 
     # Approval flow
-    approved_by: Optional[str] = None
-    approved_at: Optional[datetime] = None
-    applied_at: Optional[datetime] = None
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    applied_at: datetime | None = None
 
     # Evidence criteria (Learning Gate Contract v1.0 §4)
     min_experiments: int = Field(
@@ -113,9 +114,9 @@ class LearningUpdate(BaseModel):
 
     # Timestamps
     proposed_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    rolled_back_at: Optional[datetime] = None
+    rolled_back_at: datetime | None = None
 
     # Metadata
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(json_schema_extra={'example': {'target_parameter': 'physics.gamma', 'current_value': 0.15, 'proposed_value': 0.18, 'delta': 0.03, 'boundary_zone': 'adaptive'}})

--- a/phionyx_core/contracts/v4/memory_entry.py
+++ b/phionyx_core/contracts/v4/memory_entry.py
@@ -6,11 +6,12 @@ Composes existing ForgettingManager + SemanticTimeDecayManager logic
 with v4 boundary zone concept (immutable/gated/adaptive).
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class BoundaryZone(str, Enum):
@@ -50,11 +51,11 @@ class MemoryEntry(BaseModel):
     )
 
     # Embedding / retrieval
-    embedding_vector: Optional[List[float]] = Field(
+    embedding_vector: list[float] | None = Field(
         None,
         description="Embedding vector for similarity search"
     )
-    similarity_score: Optional[float] = Field(
+    similarity_score: float | None = Field(
         None, ge=0.0, le=1.0,
         description="Last retrieval similarity score"
     )
@@ -85,19 +86,19 @@ class MemoryEntry(BaseModel):
         default="memory_store",
         description="Module that created this memory"
     )
-    source_turn_id: Optional[int] = Field(
+    source_turn_id: int | None = Field(
         None,
         description="Turn ID when memory was created"
     )
-    conversation_id: Optional[str] = None
+    conversation_id: str | None = None
 
     # Timestamps
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    updated_at: Optional[datetime] = None
+    updated_at: datetime | None = None
 
     # Metadata
-    tags: List[str] = Field(default_factory=list)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     def is_modifiable(self) -> bool:
         """Check if this memory can be modified."""

--- a/phionyx_core/contracts/v4/perceptual_frame.py
+++ b/phionyx_core/contracts/v4/perceptual_frame.py
@@ -6,10 +6,11 @@ Composes BlockContext + MeasurementVector with v4 perceptual fields.
 AD-1: Composition — existing models are referenced, not replaced.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Modality(str, Enum):
@@ -45,19 +46,19 @@ class PerceptualFrame(BaseModel):
         ge=0.0, le=1.0,
         description="Salience score — how attention-worthy this frame is"
     )
-    semantic_tags: List[str] = Field(
+    semantic_tags: list[str] = Field(
         default_factory=list,
         description="Semantic tags extracted from input"
     )
-    intent_vector: Optional[Dict[str, float]] = Field(
+    intent_vector: dict[str, float] | None = Field(
         None,
         description="Intent classification distribution"
     )
-    entity_mentions: List[Dict[str, Any]] = Field(
+    entity_mentions: list[dict[str, Any]] = Field(
         default_factory=list,
         description="Named entities detected in input"
     )
-    source_signal_id: Optional[str] = Field(
+    source_signal_id: str | None = Field(
         None,
         description="Reference to originating InputSignal"
     )
@@ -65,7 +66,7 @@ class PerceptualFrame(BaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="Frame creation timestamp"
     )
-    raw_features: Dict[str, Any] = Field(
+    raw_features: dict[str, Any] = Field(
         default_factory=dict,
         description="Raw feature vector for downstream processing"
     )

--- a/phionyx_core/contracts/v4/workspace_event.py
+++ b/phionyx_core/contracts/v4/workspace_event.py
@@ -6,11 +6,12 @@ Extends CEP engine concept toward Global Workspace Theory (GWT).
 Represents events broadcast to all modules via salience-based attention.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
-from datetime import datetime, timezone
 import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SalienceLevel(str, Enum):
@@ -51,36 +52,36 @@ class WorkspaceEvent(BaseModel):
         ...,
         description="Module that emitted this event"
     )
-    payload: Dict[str, Any] = Field(
+    payload: dict[str, Any] = Field(
         default_factory=dict,
         description="Event payload data"
     )
 
     # Broadcast tracking
-    broadcast_targets: List[str] = Field(
+    broadcast_targets: list[str] = Field(
         default_factory=list,
         description="Modules that should receive this event"
     )
-    acknowledged_by: List[str] = Field(
+    acknowledged_by: list[str] = Field(
         default_factory=list,
         description="Modules that acknowledged receipt"
     )
 
     # CEP compatibility
-    cep_correlation_id: Optional[str] = Field(
+    cep_correlation_id: str | None = Field(
         None,
         description="CEP engine correlation ID for event chains"
     )
 
     # Timestamps
     emitted_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-    expires_at: Optional[datetime] = Field(
+    expires_at: datetime | None = Field(
         None,
         description="Event expiration (None = no expiry)"
     )
 
     # Metadata
-    trace_id: Optional[str] = None
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    trace_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(json_schema_extra={'example': {'event_type': 'ethics_trigger', 'salience': 'high', 'salience_score': 0.9, 'source_module': 'ethics_engine'}})

--- a/phionyx_core/contracts/v4/world_state_snapshot.py
+++ b/phionyx_core/contracts/v4/world_state_snapshot.py
@@ -6,10 +6,11 @@ Composes EchoState2/EchoState2Plus with v4 world model fields.
 AD-1: Composition — EchoState2 is composed as echo_state field.
 """
 
-from typing import Optional, Dict, Any, List
-from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ArbitrationStatus(str, Enum):
@@ -34,13 +35,13 @@ class WorldStateSnapshot(BaseModel):
         )
     """
     # Composed existing model (serialized EchoState2Plus dict)
-    echo_state: Dict[str, Any] = Field(
+    echo_state: dict[str, Any] = Field(
         ...,
         description="Serialized EchoState2/EchoState2Plus — primary state vector"
     )
 
     # v4 new fields
-    belief_vector: Dict[str, float] = Field(
+    belief_vector: dict[str, float] = Field(
         default_factory=dict,
         description="Probabilistic belief distribution over world hypotheses"
     )
@@ -48,15 +49,15 @@ class WorldStateSnapshot(BaseModel):
         default=ArbitrationStatus.STABLE,
         description="Current arbitration system status"
     )
-    causal_graph: Optional[Dict[str, Any]] = Field(
+    causal_graph: dict[str, Any] | None = Field(
         None,
         description="Causal dependency graph (node→edge structure)"
     )
-    active_goals: List[str] = Field(
+    active_goals: list[str] = Field(
         default_factory=list,
         description="Currently active goal IDs"
     )
-    pending_actions: List[str] = Field(
+    pending_actions: list[str] = Field(
         default_factory=list,
         description="Action intents awaiting execution"
     )

--- a/phionyx_core/evaluation/__init__.py
+++ b/phionyx_core/evaluation/__init__.py
@@ -8,9 +8,9 @@ human expert responses, and knowledge worker responses.
 Roadmap Faz 2: Human Comparative Evaluation
 """
 
-from .task_set import EvalTask, TaskCategory, TaskSet
-from .scoring import EloRating, PreferenceScorer, CalibrationMetrics
 from .report_generator import EvalReport, EvalReportGenerator
+from .scoring import CalibrationMetrics, EloRating, PreferenceScorer
+from .task_set import EvalTask, TaskCategory, TaskSet
 
 __all__ = [
     "EvalTask",

--- a/phionyx_core/evaluation/report_generator.py
+++ b/phionyx_core/evaluation/report_generator.py
@@ -8,12 +8,12 @@ into a structured evaluation report.
 Roadmap Faz 2.3-2.4
 """
 
+import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
-import json
+from typing import Any
 
-from .scoring import EloRating, PreferenceScorer, CalibrationMetrics
+from .scoring import CalibrationMetrics, EloRating, PreferenceScorer
 from .task_set import TaskSet
 
 
@@ -44,9 +44,9 @@ class EvalReport:
     task_set_name: str
     task_count: int
     evaluator_count: int
-    results: List[EvalResult] = field(default_factory=list)
-    elo_rankings: List[Dict[str, Any]] = field(default_factory=list)
-    category_breakdown: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    results: list[EvalResult] = field(default_factory=list)
+    elo_rankings: list[dict[str, Any]] = field(default_factory=list)
+    category_breakdown: dict[str, dict[str, float]] = field(default_factory=dict)
     overall_pass: bool = False
     summary: str = ""
 
@@ -88,7 +88,7 @@ class EvalReportGenerator:
         elo: EloRating,
         preference: PreferenceScorer,
         calibration: CalibrationMetrics,
-        criteria: Optional[PassFailCriteria] = None,
+        criteria: PassFailCriteria | None = None,
     ):
         self.task_set = task_set
         self.elo = elo
@@ -184,12 +184,12 @@ class EvalReportGenerator:
             summary=summary,
         )
 
-    def _compute_category_breakdown(self) -> Dict[str, Dict[str, float]]:
+    def _compute_category_breakdown(self) -> dict[str, dict[str, float]]:
         """Compute preference scores per task category."""
-        from .task_set import TaskCategory
         from .scoring import PreferenceWinner
+        from .task_set import TaskCategory
 
-        breakdown: Dict[str, Dict[str, float]] = {}
+        breakdown: dict[str, dict[str, float]] = {}
 
         for category in TaskCategory:
             tasks = self.task_set.get_by_category(category)

--- a/phionyx_core/evaluation/scoring.py
+++ b/phionyx_core/evaluation/scoring.py
@@ -8,11 +8,10 @@ for human comparative evaluation.
 Roadmap Faz 2.3
 """
 
+import math
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Tuple
-import math
-
+from typing import Any
 
 # ═══════════════════════════════════════════════════════════════════
 # 1. Elo Rating System
@@ -29,8 +28,8 @@ class EloRating:
     def __init__(self, k_factor: float = 32.0, initial_rating: float = 1500.0):
         self.k_factor = k_factor
         self.initial_rating = initial_rating
-        self._ratings: Dict[str, float] = {}
-        self._match_history: List[Dict[str, Any]] = []
+        self._ratings: dict[str, float] = {}
+        self._match_history: list[dict[str, Any]] = []
 
     def register(self, player_id: str) -> None:
         if player_id not in self._ratings:
@@ -49,7 +48,7 @@ class EloRating:
         loser_id: str,
         task_id: str = "",
         draw: bool = False,
-    ) -> Tuple[float, float]:
+    ) -> tuple[float, float]:
         """
         Record a match result. Returns (new_winner_rating, new_loser_rating).
         If draw=True, both get partial credit.
@@ -87,9 +86,9 @@ class EloRating:
 
     def record_three_way(
         self,
-        rankings: List[str],
+        rankings: list[str],
         task_id: str = "",
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """
         Record a 3-way comparison result.
         rankings[0] = best, rankings[1] = second, rankings[2] = worst.
@@ -109,7 +108,7 @@ class EloRating:
         return {r: self.get_rating(r) for r in rankings}
 
     @property
-    def rankings(self) -> List[Tuple[str, float]]:
+    def rankings(self) -> list[tuple[str, float]]:
         """Return players sorted by rating (highest first)."""
         return sorted(self._ratings.items(), key=lambda x: x[1], reverse=True)
 
@@ -117,7 +116,7 @@ class EloRating:
     def match_count(self) -> int:
         return len(self._match_history)
 
-    def get_history(self) -> List[Dict[str, Any]]:
+    def get_history(self) -> list[dict[str, Any]]:
         return list(self._match_history)
 
 
@@ -149,7 +148,7 @@ class PreferenceScorer:
     """
 
     def __init__(self):
-        self._votes: List[PreferenceVote] = []
+        self._votes: list[PreferenceVote] = []
 
     def add_vote(self, vote: PreferenceVote) -> None:
         self._votes.append(vote)
@@ -184,12 +183,12 @@ class PreferenceScorer:
         """Accuracy Delta = Phionyx accuracy - Expert accuracy."""
         return phionyx_accuracy - expert_accuracy
 
-    def get_votes_for_task(self, task_id: str) -> List[PreferenceVote]:
+    def get_votes_for_task(self, task_id: str) -> list[PreferenceVote]:
         return [v for v in self._votes if v.task_id == task_id]
 
-    def per_task_winner(self) -> Dict[str, PreferenceWinner]:
+    def per_task_winner(self) -> dict[str, PreferenceWinner]:
         """Majority winner per task."""
-        task_votes: Dict[str, Dict[PreferenceWinner, float]] = {}
+        task_votes: dict[str, dict[PreferenceWinner, float]] = {}
         for vote in self._votes:
             if vote.task_id not in task_votes:
                 task_votes[vote.task_id] = {}
@@ -201,7 +200,7 @@ class PreferenceScorer:
             result[task_id] = max(counts, key=counts.get)
         return result
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "total_votes": self.vote_count,
             "phionyx_preference": self.phionyx_preference_score(),
@@ -231,7 +230,7 @@ class CalibrationMetrics:
 
     def __init__(self, n_bins: int = 10):
         self.n_bins = n_bins
-        self._entries: List[CalibrationEntry] = []
+        self._entries: list[CalibrationEntry] = []
 
     def add_entry(self, entry: CalibrationEntry) -> None:
         self._entries.append(entry)
@@ -248,14 +247,14 @@ class CalibrationMetrics:
         if not self._entries:
             return 0.0
 
-        bins: Dict[int, List[CalibrationEntry]] = {i: [] for i in range(self.n_bins)}
+        bins: dict[int, list[CalibrationEntry]] = {i: [] for i in range(self.n_bins)}
         for entry in self._entries:
             bin_idx = min(int(entry.stated_confidence * self.n_bins), self.n_bins - 1)
             bins[bin_idx].append(entry)
 
         ece = 0.0
         total = len(self._entries)
-        for bin_idx, entries in bins.items():
+        for _bin_idx, entries in bins.items():
             if not entries:
                 continue
             avg_confidence = sum(e.stated_confidence for e in entries) / len(entries)
@@ -280,9 +279,9 @@ class CalibrationMetrics:
         right = sum(1 for e in low_confidence if e.was_correct)
         return right / len(low_confidence)
 
-    def reliability_diagram_data(self) -> List[Dict[str, float]]:
+    def reliability_diagram_data(self) -> list[dict[str, float]]:
         """Data for reliability diagram (calibration plot)."""
-        bins: Dict[int, List[CalibrationEntry]] = {i: [] for i in range(self.n_bins)}
+        bins: dict[int, list[CalibrationEntry]] = {i: [] for i in range(self.n_bins)}
         for entry in self._entries:
             bin_idx = min(int(entry.stated_confidence * self.n_bins), self.n_bins - 1)
             bins[bin_idx].append(entry)
@@ -302,7 +301,7 @@ class CalibrationMetrics:
             })
         return data
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         return {
             "total_entries": self.entry_count,
             "calibration_error": self.calibration_error(),

--- a/phionyx_core/evaluation/task_set.py
+++ b/phionyx_core/evaluation/task_set.py
@@ -8,10 +8,10 @@ Each task has a category, prompt, expected traits, and scoring rubric.
 Roadmap Faz 2.1-2.2
 """
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, List, Optional
-import json
+from typing import Any
 
 
 class TaskCategory(str, Enum):
@@ -39,7 +39,7 @@ class ScoringRubric:
     epistemic_weight: float = 0.15
     governance_weight: float = 0.15
 
-    def weights(self) -> Dict[str, float]:
+    def weights(self) -> dict[str, float]:
         return {
             "accuracy": self.accuracy_weight,
             "consistency": self.consistency_weight,
@@ -59,11 +59,11 @@ class EvalTask:
     task_id: str
     category: TaskCategory
     prompt: str
-    expected_traits: List[str]
+    expected_traits: list[str]
     difficulty: DifficultyLevel = DifficultyLevel.MEDIUM
     rubric: ScoringRubric = field(default_factory=ScoringRubric)
-    reference_answer: Optional[str] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    reference_answer: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -99,18 +99,18 @@ class TaskSet:
 
     def __init__(self, name: str = "default"):
         self.name = name
-        self._tasks: Dict[str, EvalTask] = {}
+        self._tasks: dict[str, EvalTask] = {}
 
     def add_task(self, task: EvalTask) -> None:
         self._tasks[task.task_id] = task
 
-    def get_task(self, task_id: str) -> Optional[EvalTask]:
+    def get_task(self, task_id: str) -> EvalTask | None:
         return self._tasks.get(task_id)
 
-    def get_by_category(self, category: TaskCategory) -> List[EvalTask]:
+    def get_by_category(self, category: TaskCategory) -> list[EvalTask]:
         return [t for t in self._tasks.values() if t.category == category]
 
-    def get_by_difficulty(self, difficulty: DifficultyLevel) -> List[EvalTask]:
+    def get_by_difficulty(self, difficulty: DifficultyLevel) -> list[EvalTask]:
         return [t for t in self._tasks.values() if t.difficulty == difficulty]
 
     @property
@@ -118,12 +118,12 @@ class TaskSet:
         return len(self._tasks)
 
     @property
-    def all_tasks(self) -> List[EvalTask]:
+    def all_tasks(self) -> list[EvalTask]:
         return list(self._tasks.values())
 
     @property
-    def category_distribution(self) -> Dict[str, int]:
-        dist: Dict[str, int] = {}
+    def category_distribution(self) -> dict[str, int]:
+        dist: dict[str, int] = {}
         for task in self._tasks.values():
             cat = task.category.value
             dist[cat] = dist.get(cat, 0) + 1

--- a/phionyx_core/governance/deliberative_ethics.py
+++ b/phionyx_core/governance/deliberative_ethics.py
@@ -19,9 +19,9 @@ Integrates with:
 """
 
 import logging
-from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -62,14 +62,14 @@ class FrameworkAssessment:
 class DeliberativeResult:
     """Full result of deliberative ethics analysis."""
     action_description: str
-    framework_assessments: List[FrameworkAssessment]
+    framework_assessments: list[FrameworkAssessment]
     final_verdict: str  # DeliberationOutcome value
     final_confidence: float
     consensus: bool  # Did all frameworks agree?
     reasoning: str
-    risk_dimensions: Dict[str, float] = field(default_factory=dict)
+    risk_dimensions: dict[str, float] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "action": self.action_description,
             "frameworks": [
@@ -88,7 +88,7 @@ class DeliberativeResult:
         }
 
 
-def normalize_risk_vector(components: List[float]) -> List[float]:
+def normalize_risk_vector(components: list[float]) -> list[float]:
     """
     Normalize risk vector components to [0, 1] range.
 
@@ -134,7 +134,7 @@ class DeliberativeEthics:
 
     def __init__(
         self,
-        framework_weights: Optional[Dict[str, float]] = None,
+        framework_weights: dict[str, float] | None = None,
         deny_threshold: float = deny_threshold,
         guard_threshold: float = guard_threshold,
     ):
@@ -163,8 +163,8 @@ class DeliberativeEthics:
     def deliberate(
         self,
         action: str,
-        ethics_vector: Dict[str, float],
-        context: Optional[Dict[str, Any]] = None,
+        ethics_vector: dict[str, float],
+        context: dict[str, Any] | None = None,
     ) -> DeliberativeResult:
         """
         Perform multi-framework ethical deliberation.
@@ -202,7 +202,7 @@ class DeliberativeEthics:
         )
 
     def _assess_deontological(
-        self, action: str, risks: Dict[str, float], context: Dict,
+        self, action: str, risks: dict[str, float], context: dict,
     ) -> FrameworkAssessment:
         """Rule-based: Does this violate absolute rules?"""
         # Hard rules
@@ -234,7 +234,7 @@ class DeliberativeEthics:
         )
 
     def _assess_consequentialist(
-        self, action: str, risks: Dict[str, float], context: Dict,
+        self, action: str, risks: dict[str, float], context: dict,
     ) -> FrameworkAssessment:
         """Outcome-based: Do outcomes maximize good?"""
         harm = risks.get("harm_risk", 0.0)
@@ -264,7 +264,7 @@ class DeliberativeEthics:
         )
 
     def _assess_virtue(
-        self, action: str, risks: Dict[str, float], context: Dict,
+        self, action: str, risks: dict[str, float], context: dict,
     ) -> FrameworkAssessment:
         """Virtue-based: Is this consistent with system values?"""
         manipulation = risks.get("manipulation_risk", 0.0)
@@ -295,7 +295,7 @@ class DeliberativeEthics:
         )
 
     def _assess_care(
-        self, action: str, risks: Dict[str, float], context: Dict,
+        self, action: str, risks: dict[str, float], context: dict,
     ) -> FrameworkAssessment:
         """Care-based: Does it protect vulnerable entities?"""
         child_risk = risks.get("child_on_child_risk", 0.0)
@@ -330,10 +330,10 @@ class DeliberativeEthics:
         )
 
     def _aggregate(
-        self, assessments: List[FrameworkAssessment],
+        self, assessments: list[FrameworkAssessment],
     ) -> tuple:
         """Aggregate framework assessments into final verdict."""
-        verdict_scores: Dict[str, float] = {}
+        verdict_scores: dict[str, float] = {}
 
         for fa in assessments:
             score = fa.confidence * fa.weight
@@ -366,7 +366,7 @@ class DeliberativeEthics:
 
     def _build_reasoning(
         self,
-        assessments: List[FrameworkAssessment],
+        assessments: list[FrameworkAssessment],
         verdict: str,
         consensus: bool,
     ) -> str:

--- a/phionyx_core/governance/failure_classifier.py
+++ b/phionyx_core/governance/failure_classifier.py
@@ -16,7 +16,7 @@ Each failure type carries a severity, a recovery strategy, and audit metadata.
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Any, List, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -53,11 +53,11 @@ class FailureClassification:
     severity: FailureSeverity
     recovery_strategy: RecoveryStrategy
     confidence: float  # 0-1
-    details: Dict[str, Any] = field(default_factory=dict)
-    triggering_block: Optional[str] = None
+    details: dict[str, Any] = field(default_factory=dict)
+    triggering_block: str | None = None
     recommended_action: str = ""
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "category": self.category.value,
             "severity": self.severity.value,
@@ -91,10 +91,10 @@ class FailureClassifier:
 
     def classify(
         self,
-        pipeline_state: Dict[str, Any],
-        previous_state: Optional[Dict[str, Any]] = None,
-        block_results: Optional[Dict[str, Any]] = None,
-    ) -> List[FailureClassification]:
+        pipeline_state: dict[str, Any],
+        previous_state: dict[str, Any] | None = None,
+        block_results: dict[str, Any] | None = None,
+    ) -> list[FailureClassification]:
         """
         Classify failures from pipeline state.
 
@@ -106,7 +106,7 @@ class FailureClassifier:
         Returns:
             List of classified failures (may be empty if no failures)
         """
-        failures: List[FailureClassification] = []
+        failures: list[FailureClassification] = []
         previous_state = previous_state or {}
         block_results = block_results or {}
 
@@ -188,10 +188,10 @@ class FailureClassifier:
 
     def classify_single(
         self,
-        pipeline_state: Dict[str, Any],
-        previous_state: Optional[Dict[str, Any]] = None,
-        block_results: Optional[Dict[str, Any]] = None,
-    ) -> Optional[FailureClassification]:
+        pipeline_state: dict[str, Any],
+        previous_state: dict[str, Any] | None = None,
+        block_results: dict[str, Any] | None = None,
+    ) -> FailureClassification | None:
         """
         Classify and return the highest-severity failure, or None.
 

--- a/phionyx_core/governance/human_in_the_loop.py
+++ b/phionyx_core/governance/human_in_the_loop.py
@@ -12,15 +12,15 @@ Design:
 - Audit: every submission, review, and expiry is logged
 """
 
-import logging
 import json
+import logging
 import os
 import uuid
-from typing import Dict, Any, Optional, List
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -54,28 +54,28 @@ class ReviewItem:
     trigger_reason: str = ""
 
     # Action details
-    action_type: Optional[str] = None
-    action_description: Optional[str] = None
-    action_parameters: Optional[Dict[str, Any]] = None
+    action_type: str | None = None
+    action_description: str | None = None
+    action_parameters: dict[str, Any] | None = None
 
     # Ethics context
-    ethics_verdict: Optional[str] = None
-    ethics_max_risk: Optional[float] = None
-    ethics_triggered_risks: Optional[List[str]] = None
+    ethics_verdict: str | None = None
+    ethics_max_risk: float | None = None
+    ethics_triggered_risks: list[str] | None = None
 
     # Session context
-    turn_id: Optional[int] = None
-    session_id: Optional[str] = None
-    user_input_hash: Optional[str] = None  # SHA-256, not raw input
+    turn_id: int | None = None
+    session_id: str | None = None
+    user_input_hash: str | None = None  # SHA-256, not raw input
 
     # Review outcome
-    reviewed_at: Optional[str] = None
-    reviewed_by: Optional[str] = None
-    review_decision: Optional[str] = None
-    review_notes: Optional[str] = None
+    reviewed_at: str | None = None
+    reviewed_by: str | None = None
+    review_decision: str | None = None
+    review_notes: str | None = None
 
     # Expiry
-    expires_at: Optional[str] = None
+    expires_at: str | None = None
 
     def is_expired(self) -> bool:
         """Check if this review item has expired."""
@@ -88,12 +88,12 @@ class ReviewItem:
             expires = expires.replace(tzinfo=timezone.utc)
         return now >= expires
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'ReviewItem':
+    def from_dict(cls, data: dict[str, Any]) -> 'ReviewItem':
         """Deserialize from dictionary."""
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
@@ -129,10 +129,10 @@ class HumanReviewQueue:
         queue.deny(item.review_id, reviewed_by="toygar", notes="Block this action")
     """
 
-    def __init__(self, config: Optional[HITLConfig] = None):
+    def __init__(self, config: HITLConfig | None = None):
         self.config = config or HITLConfig()
-        self._queue: List[ReviewItem] = []
-        self._archive: List[ReviewItem] = []  # Completed/expired items
+        self._queue: list[ReviewItem] = []
+        self._archive: list[ReviewItem] = []  # Completed/expired items
 
         # Set default storage path
         if not self.config.storage_path:
@@ -150,7 +150,7 @@ class HumanReviewQueue:
         return sum(1 for item in self._queue if item.status == ReviewStatus.PENDING.value)
 
     @property
-    def queue(self) -> List[ReviewItem]:
+    def queue(self) -> list[ReviewItem]:
         """Get current queue (read-only copy)."""
         self._expire_stale()
         return list(self._queue)
@@ -159,15 +159,15 @@ class HumanReviewQueue:
         self,
         trigger_type: str,
         trigger_reason: str,
-        action_type: Optional[str] = None,
-        action_description: Optional[str] = None,
-        action_parameters: Optional[Dict[str, Any]] = None,
-        ethics_verdict: Optional[str] = None,
-        ethics_max_risk: Optional[float] = None,
-        ethics_triggered_risks: Optional[List[str]] = None,
-        turn_id: Optional[int] = None,
-        session_id: Optional[str] = None,
-        user_input_hash: Optional[str] = None,
+        action_type: str | None = None,
+        action_description: str | None = None,
+        action_parameters: dict[str, Any] | None = None,
+        ethics_verdict: str | None = None,
+        ethics_max_risk: float | None = None,
+        ethics_triggered_risks: list[str] | None = None,
+        turn_id: int | None = None,
+        session_id: str | None = None,
+        user_input_hash: str | None = None,
         priority: str = ReviewPriority.NORMAL.value,
     ) -> ReviewItem:
         """
@@ -243,7 +243,7 @@ class HumanReviewQueue:
         review_id: str,
         reviewed_by: str,
         notes: str = "",
-    ) -> Optional[ReviewItem]:
+    ) -> ReviewItem | None:
         """
         Approve a pending review item.
 
@@ -262,7 +262,7 @@ class HumanReviewQueue:
         review_id: str,
         reviewed_by: str,
         notes: str = "",
-    ) -> Optional[ReviewItem]:
+    ) -> ReviewItem | None:
         """
         Deny a pending review item.
 
@@ -276,7 +276,7 @@ class HumanReviewQueue:
         """
         return self._review(review_id, ReviewStatus.DENIED, reviewed_by, notes)
 
-    def get_item(self, review_id: str) -> Optional[ReviewItem]:
+    def get_item(self, review_id: str) -> ReviewItem | None:
         """Get a review item by ID."""
         for item in self._queue:
             if item.review_id == review_id:
@@ -286,7 +286,7 @@ class HumanReviewQueue:
                 return item
         return None
 
-    def get_pending(self) -> List[ReviewItem]:
+    def get_pending(self) -> list[ReviewItem]:
         """Get all pending review items, sorted by priority."""
         self._expire_stale()
         pending = [i for i in self._queue if i.status == ReviewStatus.PENDING.value]
@@ -318,7 +318,7 @@ class HumanReviewQueue:
         status: ReviewStatus,
         reviewed_by: str,
         notes: str,
-    ) -> Optional[ReviewItem]:
+    ) -> ReviewItem | None:
         """Internal review handler."""
         for item in self._queue:
             if item.review_id == review_id:
@@ -392,7 +392,7 @@ class HumanReviewQueue:
             if not storage_path.exists():
                 return
 
-            with open(storage_path, "r") as f:
+            with open(storage_path) as f:
                 data = json.load(f)
 
             self._queue = [ReviewItem.from_dict(d) for d in data.get("queue", [])]
@@ -407,7 +407,7 @@ class HumanReviewQueue:
             self._queue = []
             self._archive = []
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize queue state for monitoring."""
         return {
             "pending_count": self.pending_count,

--- a/phionyx_core/governance/kill_switch.py
+++ b/phionyx_core/governance/kill_switch.py
@@ -20,10 +20,11 @@ Design:
 
 import logging
 import math
-from typing import Dict, Any, Optional, List, Callable
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +50,12 @@ class KillSwitchState(str, Enum):
 class KillSwitchEvent:
     """Record of a kill switch evaluation or trigger."""
     timestamp: datetime
-    trigger: Optional[KillSwitchTrigger]
+    trigger: KillSwitchTrigger | None
     state_before: KillSwitchState
     state_after: KillSwitchState
     reason: str
-    metrics: Dict[str, float]
-    turn_id: Optional[int] = None
+    metrics: dict[str, float]
+    turn_id: int | None = None
 
 
 @dataclass
@@ -83,17 +84,17 @@ class KillSwitch:
 
     def __init__(
         self,
-        config: Optional[KillSwitchConfig] = None,
-        on_trigger: Optional[Callable[['KillSwitchResult'], None]] = None,
+        config: KillSwitchConfig | None = None,
+        on_trigger: Callable[['KillSwitchResult'], None] | None = None,
     ):
         self.config = config or KillSwitchConfig()
         self.state = KillSwitchState.ARMED
         self._on_trigger = on_trigger
         self._consecutive_drift_count: int = 0
-        self._event_log: List[KillSwitchEvent] = []
+        self._event_log: list[KillSwitchEvent] = []
         self._max_event_log: int = 1000
-        self._triggered_at: Optional[datetime] = None
-        self._cooldown_until: Optional[datetime] = None
+        self._triggered_at: datetime | None = None
+        self._cooldown_until: datetime | None = None
 
     @property
     def is_triggered(self) -> bool:
@@ -104,7 +105,7 @@ class KillSwitch:
         return self.state in (KillSwitchState.ARMED, KillSwitchState.COOLDOWN)
 
     @property
-    def event_log(self) -> List[KillSwitchEvent]:
+    def event_log(self) -> list[KillSwitchEvent]:
         return list(self._event_log)
 
     def evaluate(
@@ -112,7 +113,7 @@ class KillSwitch:
         ethics_max_risk: float = 0.0,
         t_meta: float = 1.0,
         drift_detected: bool = False,
-        turn_id: Optional[int] = None,
+        turn_id: int | None = None,
     ) -> 'KillSwitchResult':
         """
         Evaluate kill switch conditions.
@@ -215,7 +216,7 @@ class KillSwitch:
                 )
             return KillSwitchResult(triggered=False, reason=f"Evaluation error (fail-open): {e}")
 
-    def manual_trigger(self, reason: str = "Manual shutdown", turn_id: Optional[int] = None) -> 'KillSwitchResult':
+    def manual_trigger(self, reason: str = "Manual shutdown", turn_id: int | None = None) -> 'KillSwitchResult':
         """Manually trigger the kill switch."""
         metrics = {"manual": 1.0}
         return self._trigger(KillSwitchTrigger.MANUAL, reason, metrics, turn_id)
@@ -272,8 +273,8 @@ class KillSwitch:
         self,
         trigger: KillSwitchTrigger,
         reason: str,
-        metrics: Dict[str, float],
-        turn_id: Optional[int] = None,
+        metrics: dict[str, float],
+        turn_id: int | None = None,
     ) -> 'KillSwitchResult':
         """Execute kill switch trigger."""
         old_state = self.state
@@ -302,12 +303,12 @@ class KillSwitch:
 
     def _log_event(
         self,
-        trigger: Optional[KillSwitchTrigger],
+        trigger: KillSwitchTrigger | None,
         state_before: KillSwitchState,
         state_after: KillSwitchState,
         reason: str,
-        metrics: Dict[str, float],
-        turn_id: Optional[int] = None,
+        metrics: dict[str, float],
+        turn_id: int | None = None,
     ) -> None:
         """Log kill switch event."""
         event = KillSwitchEvent(
@@ -323,7 +324,7 @@ class KillSwitch:
         if len(self._event_log) > self._max_event_log:
             self._event_log = self._event_log[-self._max_event_log:]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize kill switch state for audit/snapshot."""
         return {
             "state": self.state.value,
@@ -344,8 +345,8 @@ class KillSwitch:
 class KillSwitchResult:
     """Result of kill switch evaluation."""
     triggered: bool
-    trigger: Optional[KillSwitchTrigger] = None
+    trigger: KillSwitchTrigger | None = None
     reason: str = ""
-    metrics: Optional[Dict[str, float]] = None
-    turn_id: Optional[int] = None
-    timestamp: Optional[datetime] = None
+    metrics: dict[str, float] | None = None
+    turn_id: int | None = None
+    timestamp: datetime | None = None

--- a/phionyx_core/governance/rbac.py
+++ b/phionyx_core/governance/rbac.py
@@ -7,9 +7,8 @@ Each port method call is checked against RBAC before execution.
 """
 
 import logging
-from typing import Dict, Set, Optional
-from enum import Enum
 from dataclasses import dataclass, field
+from enum import Enum
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ class Role(str, Enum):
 
 # Default permission matrix (v4 §6.1)
 # Format: {module: {target_module: {permissions}}}
-DEFAULT_PERMISSION_MATRIX: Dict[str, Dict[str, Set[str]]] = {
+DEFAULT_PERMISSION_MATRIX: dict[str, dict[str, set[str]]] = {
     "perception_engine": {
         "world_model": {"read", "write"},
         "memory_store": {"read"},
@@ -119,7 +118,7 @@ class RBACManager:
 
     Checks caller module permissions before port method invocation.
     """
-    permission_matrix: Dict[str, Dict[str, Set[str]]] = field(
+    permission_matrix: dict[str, dict[str, set[str]]] = field(
         default_factory=lambda: dict(DEFAULT_PERMISSION_MATRIX)
     )
     audit_log: list = field(default_factory=list)
@@ -170,7 +169,7 @@ class RBACManager:
         self,
         caller_module: str,
         target_module: str,
-        permissions: Set[str],
+        permissions: set[str],
     ) -> None:
         """Grant permissions to a module."""
         if caller_module not in self.permission_matrix:
@@ -183,7 +182,7 @@ class RBACManager:
         self,
         caller_module: str,
         target_module: str,
-        permissions: Optional[Set[str]] = None,
+        permissions: set[str] | None = None,
     ) -> None:
         """Revoke permissions from a module."""
         if caller_module in self.permission_matrix:

--- a/phionyx_core/intuition/__init__.py
+++ b/phionyx_core/intuition/__init__.py
@@ -12,7 +12,7 @@ Key Features:
 - Physics-driven edge strength
 """
 
-from .graph_engine import GraphEngine, Concept, Association, HiddenContext
+from .graph_engine import Association, Concept, GraphEngine, HiddenContext
 from .visualizer import GraphVisualizer
 
 __all__ = ["GraphEngine", "Concept", "Association", "HiddenContext", "GraphVisualizer"]

--- a/phionyx_core/intuition/chronicle_graph.py
+++ b/phionyx_core/intuition/chronicle_graph.py
@@ -8,9 +8,8 @@ for narrative generation.
 """
 
 import logging
-from typing import Dict, List, Optional
-from datetime import datetime
 import uuid
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -40,9 +39,9 @@ class ChronicleGraphAPI:
         self,
         character_id: str,
         event_type: str,
-        event_payload: Dict,
-        concept_id: Optional[str] = None
-    ) -> Optional[str]:
+        event_payload: dict,
+        concept_id: str | None = None
+    ) -> str | None:
         """
         Add or update an event node in Chronicle Graph.
 
@@ -87,7 +86,7 @@ class ChronicleGraphAPI:
         character_id: str,
         window: int = 10,
         include_relationships: bool = True
-    ) -> Dict:
+    ) -> dict:
         """
         Get relevant subgraph for narrative generation.
 
@@ -149,7 +148,7 @@ class ChronicleGraphAPI:
             if concept_ids and include_relationships:
                 # Fetch concepts and their associations
                 # This integrates Chronicle Graph with GraphEngine concepts
-                for concept_id in concept_ids:
+                for _concept_id in concept_ids:
                     _related = await self.graph_engine.get_related_concepts(
                         concept_name="",  # We'll need concept_id lookup
                         limit=5
@@ -178,7 +177,7 @@ class ChronicleGraphAPI:
 
     def _generate_narrative_summary(
         self,
-        events: List[Dict],
+        events: list[dict],
         character_id: str
     ) -> str:
         """
@@ -216,9 +215,9 @@ class ChronicleGraphAPI:
     async def get_recent_events(
         self,
         character_id: str,
-        event_type: Optional[str] = None,
+        event_type: str | None = None,
         limit: int = 5
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Get recent events for a character, optionally filtered by type.
 

--- a/phionyx_core/intuition/graph_engine.py
+++ b/phionyx_core/intuition/graph_engine.py
@@ -14,10 +14,10 @@ through the graph: Darkness -> Cave -> Fear (weight: 0.9)
 
 import logging
 import os
-from typing import List, Dict, Optional, Tuple, Any, TYPE_CHECKING
+import uuid
 from dataclasses import dataclass
 from enum import Enum
-import uuid
+from typing import TYPE_CHECKING, Any, Optional
 
 try:
     import networkx as nx
@@ -25,15 +25,15 @@ except ImportError:
     nx = None
 
 try:
-    from supabase import create_client, Client
+    from supabase import Client, create_client
 except ImportError:
     create_client = None
     Client = None
 # litellm imports removed - using centralized LLM service instead
 
 if TYPE_CHECKING:
-    from phionyx_core.contracts.llm_provider import LLMProviderProtocol
     from phionyx_core.contracts.database import GraphRepositoryProtocol
+    from phionyx_core.contracts.llm_provider import LLMProviderProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -56,13 +56,13 @@ class EdgeType(str, Enum):
 @dataclass
 class Concept:
     """A concept extracted from text."""
-    id: Optional[str] = None
+    id: str | None = None
     name: str = ""
     normalized_name: str = ""
     category: str = ""  # emotion, person, location, abstract, object, action, trait
     confidence: float = 0.0
     observation_source: str = ""  # v4: where this concept was observed (user_input, llm, system)
-    first_observed: Optional[str] = None  # v4: ISO timestamp of first observation
+    first_observed: str | None = None  # v4: ISO timestamp of first observation
 
 
 @dataclass
@@ -73,7 +73,7 @@ class Association:
     weight: float
     formation_phi: float
     edge_type: str = EdgeType.RELATED.value  # v4: typed relationship
-    context: Optional[str] = None
+    context: str | None = None
 
 
 @dataclass
@@ -125,7 +125,7 @@ class GraphEngine:
         # Store repository (if provided)
         self._graph_repository = graph_repository
 
-        self.client: Optional[Client] = None
+        self.client: Client | None = None
         self._init_supabase()
 
         # In-memory graph for fast traversal (loaded from DB)
@@ -203,7 +203,7 @@ class GraphEngine:
         self,
         text: str,
         model: str = None
-    ) -> List[Concept]:
+    ) -> list[Concept]:
         """
         Extract key concepts from user input using centralized LLM service.
 
@@ -267,7 +267,7 @@ class GraphEngine:
         )
         return None
 
-    async def _generate_embedding(self, text: str) -> Optional[List[float]]:
+    async def _generate_embedding(self, text: str) -> list[float] | None:
         """
         Generate embedding for entity resolution (Microsoft GraphRAG style).
 
@@ -307,7 +307,7 @@ class GraphEngine:
         self,
         concept: Concept,
         phi: float = 0.0
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Get existing concept ID or create new one in database.
 
@@ -376,11 +376,11 @@ class GraphEngine:
 
     async def form_associations(
         self,
-        concepts: List[Concept],
+        concepts: list[Concept],
         phi: float,
-        context: Optional[str] = None,
+        context: str | None = None,
         edge_type: str = EdgeType.RELATED.value,
-    ) -> List[Association]:
+    ) -> list[Association]:
         """
         Form associations between all pairs of concepts, weighted by Phi.
 
@@ -409,8 +409,8 @@ class GraphEngine:
             return []
 
         # Form associations between all pairs
-        for i, (source_id, source_concept) in enumerate(concept_ids):
-            for target_id, target_concept in concept_ids[i+1:]:
+        for i, (source_id, _source_concept) in enumerate(concept_ids):
+            for target_id, _target_concept in concept_ids[i+1:]:
                 # Prevent self-loops
                 if source_id == target_id:
                     continue
@@ -517,7 +517,7 @@ class GraphEngine:
                 [source_concept, target_concept], weight, edge_type=edge_type
             ))
 
-    def infer_context(self, text: str) -> Dict[str, Any]:
+    def infer_context(self, text: str) -> dict[str, Any]:
         """
         Infer context from text (synchronous wrapper for testing).
 
@@ -552,10 +552,10 @@ class GraphEngine:
 
     async def infer_hidden_context(
         self,
-        concept_names: List[str],
+        concept_names: list[str],
         max_hops: int = 2,
         min_weight: float = 0.3
-    ) -> List[HiddenContext]:
+    ) -> list[HiddenContext]:
         """
         Infer hidden context using Microsoft GraphRAG-style PageRank algorithm.
 
@@ -611,7 +611,7 @@ class GraphEngine:
 
         # Expand ego-graph: include neighbors up to max_hops
         current_level = set(concept_ids)
-        for hop in range(max_hops):
+        for _hop in range(max_hops):
             next_level = set()
             for node_id in current_level:
                 # Add node to subgraph
@@ -706,7 +706,7 @@ class GraphEngine:
         concept_name: str,
         limit: int = 10,
         depth: int = 1
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Get directly related concepts (1-hop neighbors).
 
@@ -749,7 +749,7 @@ class GraphEngine:
             logger.error(f"GraphEngine: Failed to get related concepts: {e}")
             return []
 
-    def get_edges_by_type(self, edge_type: str) -> List[Tuple[str, str, Dict]]:
+    def get_edges_by_type(self, edge_type: str) -> list[tuple[str, str, dict]]:
         """
         Get all edges of a specific type from the in-memory graph.
 
@@ -779,7 +779,7 @@ class GraphEngine:
         subgraph.add_edges_from(causal_edges)
         return subgraph
 
-    def get_contradictions(self) -> List[Tuple[str, str, Dict]]:
+    def get_contradictions(self) -> list[tuple[str, str, dict]]:
         """Get all contradiction edges."""
         return self.get_edges_by_type(EdgeType.CONTRADICTS.value)
 
@@ -795,9 +795,9 @@ class GraphEngine:
         self,
         character_id: str,
         event_type: str,
-        event_payload: Dict,
-        concept_id: Optional[str] = None
-    ) -> Optional[str]:
+        event_payload: dict,
+        concept_id: str | None = None
+    ) -> str | None:
         """
         Add or update an event node in Chronicle Graph.
 
@@ -843,7 +843,7 @@ class GraphEngine:
         character_id: str,
         window: int = 10,
         include_relationships: bool = True
-    ) -> Dict:
+    ) -> dict:
         """
         Get relevant subgraph for narrative generation.
 
@@ -922,7 +922,7 @@ class GraphEngine:
 
     def _generate_chronicle_summary(
         self,
-        events: List[Dict],
+        events: list[dict],
         character_id: str
     ) -> str:
         """

--- a/phionyx_core/intuition/visualizer.py
+++ b/phionyx_core/intuition/visualizer.py
@@ -10,7 +10,8 @@ This is crucial for "Visual Proof" in documentation and pitch decks.
 """
 
 import logging
-from typing import List, Dict, Optional, Any
+from typing import Any
+
 try:
     from supabase import Client
 except ImportError:
@@ -43,8 +44,8 @@ class GraphVisualizer:
     async def export_for_cosmograph(
         self,
         min_weight: float = 0.3,
-        limit_nodes: Optional[int] = None
-    ) -> Dict[str, Any]:
+        limit_nodes: int | None = None
+    ) -> dict[str, Any]:
         """
         Export graph in Cosmograph-compatible JSON format.
 
@@ -133,8 +134,8 @@ class GraphVisualizer:
     async def export_for_cytoscape(
         self,
         min_weight: float = 0.3,
-        limit_nodes: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        limit_nodes: int | None = None
+    ) -> list[dict[str, Any]]:
         """
         Export graph in Cytoscape.js-compatible JSON format.
 
@@ -215,7 +216,7 @@ class GraphVisualizer:
             logger.error(f"GraphVisualizer: Failed to export for Cytoscape.js: {e}")
             return []
 
-    async def export_statistics(self) -> Dict[str, Any]:
+    async def export_statistics(self) -> dict[str, Any]:
         """
         Export graph statistics for documentation.
 

--- a/phionyx_core/memory/__init__.py
+++ b/phionyx_core/memory/__init__.py
@@ -10,10 +10,7 @@ Exports:
 - trace: Trace functions for Echo ontology
 """
 
-from . import vector_store
-from . import user_profile
-from . import trace
-from . import trace_store
+from . import trace, trace_store, user_profile, vector_store
 
 __all__ = [
     "vector_store",
@@ -25,27 +22,27 @@ __all__ = [
 ]
 
 # Convenience exports
-from .vector_store import VectorStore  # noqa: F401
-from .user_profile import UserProfile  # noqa: F401
+from .forgetting import (  # noqa: F401
+    EventForgettingState,
+    ForgettingConfig,
+    ForgettingManager,
+    apply_active_suppression,
+    apply_forgetting_to_entropy,
+    apply_full_erasure,
+    apply_passive_decay,
+    calculate_decay_rate_from_inertia,
+    create_tombstone_reference,
+    restore_suppressed_event,
+)
 from .trace import (  # noqa: F401
-    trace_weight,
     aggregate_trace,
     calculate_trace_decay_rate,
-    get_active_trace_events
+    get_active_trace_events,
+    trace_weight,
 )
 from .trace_store import TraceStore  # noqa: F401
-from .forgetting import (  # noqa: F401
-    ForgettingConfig,
-    EventForgettingState,
-    apply_passive_decay,
-    apply_active_suppression,
-    restore_suppressed_event,
-    apply_full_erasure,
-    create_tombstone_reference,
-    apply_forgetting_to_entropy,
-    calculate_decay_rate_from_inertia,
-    ForgettingManager,
-)
+from .user_profile import UserProfile  # noqa: F401
+from .vector_store import VectorStore  # noqa: F401
 
 __version__ = "1.0.0"
 

--- a/phionyx_core/memory/consolidation.py
+++ b/phionyx_core/memory/consolidation.py
@@ -15,16 +15,16 @@ Integrates with:
 - memory/forgetting.py (decay semantics)
 """
 
-import math
 import logging
-from typing import Callable, List, Dict, Optional
+import math
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
 # Type alias: sync callable that maps text → embedding vector (or None on failure)
-EmbeddingFn = Callable[[str], Optional[List[float]]]
+EmbeddingFn = Callable[[str], list[float] | None]
 
 # ── Tunable Parameters (Tier A: Research Engine may modify) ──
 min_cluster_size = 2
@@ -37,7 +37,7 @@ decay_strength_threshold = 0.1
 class ConsolidationCandidate:
     """A cluster of related memories that could be consolidated."""
     cluster_id: str
-    memories: List[Dict]  # Serialized MemoryEntry dicts
+    memories: list[dict]  # Serialized MemoryEntry dicts
     centroid_content: str
     mean_strength: float
     access_count: int
@@ -50,7 +50,7 @@ class ConsolidationResult:
     consolidated_count: int  # Number of semantic memories created
     promoted_count: int  # Number of memories promoted (episodic→semantic)
     decayed_count: int  # Number of weak memories marked for decay
-    candidates: List[ConsolidationCandidate]
+    candidates: list[ConsolidationCandidate]
     timestamp: str
 
 
@@ -77,7 +77,7 @@ class MemoryConsolidator:
         _similarity_threshold: float | None = None,
         _promotion_access_threshold: int | None = None,
         _decay_strength_threshold: float | None = None,
-        embedding_fn: Optional[EmbeddingFn] = None,
+        embedding_fn: EmbeddingFn | None = None,
         **kwargs,
     ):
         """
@@ -107,11 +107,11 @@ class MemoryConsolidator:
         self.promotion_access_threshold = _promotion_access_threshold if _promotion_access_threshold is not None else promotion_access_threshold
         self.decay_strength_threshold = _decay_strength_threshold if _decay_strength_threshold is not None else decay_strength_threshold
         self.embedding_fn = embedding_fn
-        self._embedding_cache: Dict[str, List[float]] = {}
+        self._embedding_cache: dict[str, list[float]] = {}
 
     def consolidate(
         self,
-        memories: List[Dict],
+        memories: list[dict],
     ) -> ConsolidationResult:
         """
         Run consolidation on a set of episodic memories.
@@ -171,7 +171,7 @@ class MemoryConsolidator:
             timestamp=datetime.now(timezone.utc).isoformat(),
         )
 
-    def promote_memory(self, memory: Dict) -> Dict:
+    def promote_memory(self, memory: dict) -> dict:
         """
         Promote an episodic memory to semantic.
 
@@ -189,7 +189,7 @@ class MemoryConsolidator:
         promoted["metadata"]["promotion_reason"] = "access_count_threshold"
         return promoted
 
-    def abstract_cluster(self, candidate: ConsolidationCandidate) -> Dict:
+    def abstract_cluster(self, candidate: ConsolidationCandidate) -> dict:
         """
         Create an abstract semantic memory from a cluster.
 
@@ -214,8 +214,8 @@ class MemoryConsolidator:
         }
 
     def _cluster_by_similarity(
-        self, memories: List[Dict]
-    ) -> Dict[str, List[Dict]]:
+        self, memories: list[dict]
+    ) -> dict[str, list[dict]]:
         """
         Cluster memories by semantic similarity.
 
@@ -223,7 +223,7 @@ class MemoryConsolidator:
         (via embedding_vector field or embedding_fn). Falls back to Jaccard
         word overlap when embeddings are unavailable.
         """
-        clusters: Dict[str, List[Dict]] = {}
+        clusters: dict[str, list[dict]] = {}
         assigned: set = set()
 
         for i, mem_a in enumerate(memories):
@@ -249,7 +249,7 @@ class MemoryConsolidator:
         return clusters
 
     def _create_candidate(
-        self, cluster_id: str, members: List[Dict]
+        self, cluster_id: str, members: list[dict]
     ) -> ConsolidationCandidate:
         """Create a ConsolidationCandidate from a cluster."""
         # Pick the most representative content (highest strength)
@@ -280,7 +280,7 @@ class MemoryConsolidator:
             similarity_score=avg_sim,
         )
 
-    def _compute_similarity(self, mem_a: Dict, mem_b: Dict) -> float:
+    def _compute_similarity(self, mem_a: dict, mem_b: dict) -> float:
         """Compute similarity between two memories.
 
         Priority:
@@ -300,7 +300,7 @@ class MemoryConsolidator:
             mem_a.get("content", ""), mem_b.get("content", "")
         )
 
-    def _get_embedding(self, text: str) -> Optional[List[float]]:
+    def _get_embedding(self, text: str) -> list[float] | None:
         """Get embedding for text via embedding_fn with local caching."""
         if not text or not self.embedding_fn:
             return None
@@ -316,7 +316,7 @@ class MemoryConsolidator:
         return vec
 
     @staticmethod
-    def _cosine_similarity(a: List[float], b: List[float]) -> float:
+    def _cosine_similarity(a: list[float], b: list[float]) -> float:
         """Cosine similarity between two vectors."""
         if len(a) != len(b) or not a:
             return 0.0
@@ -339,11 +339,11 @@ class MemoryConsolidator:
             return 0.0
         return len(intersection) / len(union)
 
-    def _extract_common_tags(self, memories: List[Dict]) -> List[str]:
+    def _extract_common_tags(self, memories: list[dict]) -> list[str]:
         """Extract tags common to majority of cluster members."""
         if not memories:
             return []
-        tag_counts: Dict[str, int] = {}
+        tag_counts: dict[str, int] = {}
         for m in memories:
             for tag in m.get("tags", []):
                 tag_counts[tag] = tag_counts.get(tag, 0) + 1
@@ -354,7 +354,7 @@ class MemoryConsolidator:
 
     def set_priority_boost(
         self,
-        memory_ids: List[str],
+        memory_ids: list[str],
         boost: float = 1.5,
     ) -> int:
         """
@@ -372,7 +372,7 @@ class MemoryConsolidator:
             Number of boosts applied
         """
         if not hasattr(self, '_priority_boosts'):
-            self._priority_boosts: Dict[str, float] = {}
+            self._priority_boosts: dict[str, float] = {}
 
         boost = max(1.0, min(2.0, boost))
         count = 0
@@ -381,7 +381,7 @@ class MemoryConsolidator:
             count += 1
         return count
 
-    def get_priority_boosts(self) -> Dict[str, float]:
+    def get_priority_boosts(self) -> dict[str, float]:
         """Get current priority boost map."""
         if not hasattr(self, '_priority_boosts'):
             return {}
@@ -392,7 +392,7 @@ class MemoryConsolidator:
         if hasattr(self, '_priority_boosts'):
             self._priority_boosts.clear()
 
-    def get_effective_strength(self, memory: Dict) -> float:
+    def get_effective_strength(self, memory: dict) -> float:
         """Get memory strength with priority boost applied."""
         base_strength = memory.get("current_strength", 0.5)
         if not hasattr(self, '_priority_boosts'):

--- a/phionyx_core/memory/embedding_cache.py
+++ b/phionyx_core/memory/embedding_cache.py
@@ -12,10 +12,9 @@ Features:
 """
 
 import hashlib
-import time
-from typing import List, Optional, Dict
-from collections import OrderedDict
 import logging
+import time
+from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 class EmbeddingCacheEntry:
     """Single cache entry with TTL support."""
 
-    def __init__(self, embedding: List[float], timestamp: float, ttl: float = 86400.0):
+    def __init__(self, embedding: list[float], timestamp: float, ttl: float = 86400.0):
         """
         Initialize cache entry.
 
@@ -36,13 +35,13 @@ class EmbeddingCacheEntry:
         self.timestamp = timestamp
         self.ttl = ttl
 
-    def is_expired(self, current_time: Optional[float] = None) -> bool:
+    def is_expired(self, current_time: float | None = None) -> bool:
         """Check if entry is expired."""
         if current_time is None:
             current_time = time.time()
         return (current_time - self.timestamp) > self.ttl
 
-    def age(self, current_time: Optional[float] = None) -> float:
+    def age(self, current_time: float | None = None) -> float:
         """Get entry age in seconds."""
         if current_time is None:
             current_time = time.time()
@@ -88,7 +87,7 @@ class EmbeddingCache:
         self._evictions = 0
         self._expirations = 0
 
-    def _generate_cache_key(self, text: str, profile_id: Optional[str] = None) -> str:
+    def _generate_cache_key(self, text: str, profile_id: str | None = None) -> str:
         """
         Generate cache key from text and optional profile_id.
 
@@ -114,9 +113,9 @@ class EmbeddingCache:
     def get(
         self,
         text: str,
-        profile_id: Optional[str] = None,
-        current_time: Optional[float] = None
-    ) -> Optional[List[float]]:
+        profile_id: str | None = None,
+        current_time: float | None = None
+    ) -> list[float] | None:
         """
         Get embedding from cache.
 
@@ -161,9 +160,9 @@ class EmbeddingCache:
     def put(
         self,
         text: str,
-        embedding: List[float],
-        profile_id: Optional[str] = None,
-        current_time: Optional[float] = None
+        embedding: list[float],
+        profile_id: str | None = None,
+        current_time: float | None = None
     ) -> None:
         """
         Store embedding in cache.
@@ -207,7 +206,7 @@ class EmbeddingCache:
             self._evictions = 0
             self._expirations = 0
 
-    def cleanup_expired(self, current_time: Optional[float] = None) -> int:
+    def cleanup_expired(self, current_time: float | None = None) -> int:
         """
         Remove expired entries.
 
@@ -232,7 +231,7 @@ class EmbeddingCache:
 
         return len(expired_keys)
 
-    def get_metrics(self) -> Dict[str, int]:
+    def get_metrics(self) -> dict[str, int]:
         """
         Get cache metrics.
 
@@ -253,7 +252,7 @@ class EmbeddingCache:
             "max_size": self.max_size
         }
 
-    def get_stats(self) -> Dict[str, any]:
+    def get_stats(self) -> dict[str, any]:
         """
         Get detailed cache statistics.
 
@@ -275,7 +274,7 @@ class EmbeddingCache:
 
 
 # Global cache instance (singleton pattern)
-_global_cache: Optional[EmbeddingCache] = None
+_global_cache: EmbeddingCache | None = None
 
 
 def get_embedding_cache(

--- a/phionyx_core/memory/emotion_cache.py
+++ b/phionyx_core/memory/emotion_cache.py
@@ -13,10 +13,10 @@ Features:
 """
 
 import hashlib
-import time
-from typing import Dict, Any, Optional, Tuple
-from collections import OrderedDict
 import logging
+import time
+from collections import OrderedDict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -86,7 +86,7 @@ class EmotionCache:
         # Generate deterministic hash
         return hashlib.sha256(normalized.encode('utf-8')).hexdigest()
 
-    def get(self, text: str) -> Optional[Tuple[float, float]]:
+    def get(self, text: str) -> tuple[float, float] | None:
         """
         Get cached emotion values for input text.
 
@@ -151,7 +151,7 @@ class EmotionCache:
 
         logger.debug(f"Emotion cache SET: text_hash={cache_key[:8]}..., valence={valence:.4f}, arousal={arousal:.4f}")
 
-    def get_metrics(self) -> Dict[str, Any]:
+    def get_metrics(self) -> dict[str, Any]:
         """
         Get cache metrics.
 

--- a/phionyx_core/memory/forgetting.py
+++ b/phionyx_core/memory/forgetting.py
@@ -12,10 +12,9 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional, List
-from datetime import datetime
 import math
-
+from datetime import datetime
+from typing import Any
 
 # Module-level tunable defaults (Tier A — PRE surfaces)
 suppression_factor = 0.1
@@ -45,10 +44,10 @@ class EventForgettingState:
         self,
         event_id: str,
         suppressed: bool = False,
-        suppressed_at: Optional[datetime] = None,
+        suppressed_at: datetime | None = None,
         erased: bool = False,
-        erased_at: Optional[datetime] = None,
-        original_intensity: Optional[float] = None
+        erased_at: datetime | None = None,
+        original_intensity: float | None = None
     ):
         self.event_id = event_id
         self.suppressed = suppressed
@@ -64,7 +63,7 @@ def apply_passive_decay(
     dt: float,
     decay_rate_lambda: float,
     min_intensity: float = 0.001
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Apply passive decay to event intensity and trace weight.
 
@@ -105,7 +104,7 @@ def apply_active_suppression(
     trace_weight: float,
     suppression_factor: float = 0.1,
     min_intensity: float = 0.001
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Apply active suppression to event (user says "forget this").
 
@@ -147,8 +146,8 @@ def apply_active_suppression(
 
 
 def restore_suppressed_event(
-    suppressed_state: Dict[str, Any]
-) -> Dict[str, Any]:
+    suppressed_state: dict[str, Any]
+) -> dict[str, Any]:
     """
     Restore a suppressed event (reverse active suppression).
 
@@ -175,8 +174,8 @@ def restore_suppressed_event(
 
 def apply_full_erasure(
     event_id: str,
-    audit_log: Optional[List[Dict[str, Any]]] = None
-) -> Dict[str, Any]:
+    audit_log: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
     """
     Apply full erasure to event (user says "delete completely").
 
@@ -215,7 +214,7 @@ def apply_full_erasure(
 def create_tombstone_reference(
     event_id: str,
     original_tag: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Create tombstone reference for erased event in E_tags.
 
@@ -296,11 +295,11 @@ class ForgettingManager:
     - Manages event state (suppressed/erased)
     """
 
-    def __init__(self, config: Optional[ForgettingConfig] = None):
+    def __init__(self, config: ForgettingConfig | None = None):
         self.config = config or ForgettingConfig()
-        self.suppressed_events: Dict[str, Dict[str, Any]] = {}
-        self.erased_events: Dict[str, Dict[str, Any]] = {}
-        self.audit_log: List[Dict[str, Any]] = []
+        self.suppressed_events: dict[str, dict[str, Any]] = {}
+        self.erased_events: dict[str, dict[str, Any]] = {}
+        self.audit_log: list[dict[str, Any]] = []
 
     def apply_passive_decay_to_event(
         self,
@@ -309,7 +308,7 @@ class ForgettingManager:
         trace_weight: float,
         dt: float,
         decay_rate_lambda: float
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """Apply passive decay to a single event."""
         return apply_passive_decay(
             event_intensity=event_intensity,
@@ -324,7 +323,7 @@ class ForgettingManager:
         event_id: str,
         event_intensity: float,
         trace_weight: float
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Apply active suppression to an event."""
         suppressed = apply_active_suppression(
             event_intensity=event_intensity,
@@ -349,7 +348,7 @@ class ForgettingManager:
     def restore_event(
         self,
         event_id: str
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """Restore a suppressed event."""
         if event_id not in self.suppressed_events:
             return None
@@ -374,7 +373,7 @@ class ForgettingManager:
     def erase_event(
         self,
         event_id: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Apply full erasure to an event."""
         erased = apply_full_erasure(
             event_id=event_id,
@@ -392,11 +391,11 @@ class ForgettingManager:
         self,
         event_id: str,
         original_tag: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Get tombstone reference for erased event."""
         return create_tombstone_reference(event_id, original_tag)
 
-    def get_audit_log(self) -> List[Dict[str, Any]]:
+    def get_audit_log(self) -> list[dict[str, Any]]:
         """Get erasure audit log (GDPR compliance)."""
         return self.audit_log.copy()
 

--- a/phionyx_core/memory/rag_cache.py
+++ b/phionyx_core/memory/rag_cache.py
@@ -12,10 +12,9 @@ Features:
 """
 
 import hashlib
-import time
-from typing import List, Optional, Dict
-from collections import OrderedDict
 import logging
+import time
+from collections import OrderedDict
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +24,7 @@ class RAGCacheEntry:
 
     def __init__(
         self,
-        memories: List[Dict],
+        memories: list[dict],
         timestamp: float,
         ttl: float = 3600.0,
         significance: float = 0.5,
@@ -45,19 +44,19 @@ class RAGCacheEntry:
         self.significance = max(0.0, min(1.0, significance))
         self.access_count: int = 0
 
-    def is_expired(self, current_time: Optional[float] = None) -> bool:
+    def is_expired(self, current_time: float | None = None) -> bool:
         """Check if entry is expired."""
         if current_time is None:
             current_time = time.time()
         return (current_time - self.timestamp) > self.ttl
 
-    def age(self, current_time: Optional[float] = None) -> float:
+    def age(self, current_time: float | None = None) -> float:
         """Get entry age in seconds."""
         if current_time is None:
             current_time = time.time()
         return current_time - self.timestamp
 
-    def cognitive_impact(self, current_time: Optional[float] = None) -> float:
+    def cognitive_impact(self, current_time: float | None = None) -> float:
         """
         Compute cognitive impact score for eviction decisions.
 
@@ -131,8 +130,8 @@ class RAGCache:
     def _generate_cache_key(
         self,
         query: str,
-        intent: Optional[str] = None,
-        actor_ref: Optional[str] = None
+        intent: str | None = None,
+        actor_ref: str | None = None
     ) -> str:
         """
         Generate cache key from query, intent, and optional actor_ref.
@@ -163,10 +162,10 @@ class RAGCache:
     def get(
         self,
         query: str,
-        intent: Optional[str] = None,
-        actor_ref: Optional[str] = None,
-        current_time: Optional[float] = None
-    ) -> Optional[List[Dict]]:
+        intent: str | None = None,
+        actor_ref: str | None = None,
+        current_time: float | None = None
+    ) -> list[dict] | None:
         """
         Get RAG results from cache.
 
@@ -213,10 +212,10 @@ class RAGCache:
     def put(
         self,
         query: str,
-        memories: List[Dict],
-        intent: Optional[str] = None,
-        actor_ref: Optional[str] = None,
-        current_time: Optional[float] = None,
+        memories: list[dict],
+        intent: str | None = None,
+        actor_ref: str | None = None,
+        current_time: float | None = None,
         significance: float = 0.5,
     ) -> None:
         """
@@ -296,7 +295,7 @@ class RAGCache:
             self._evictions = 0
             self._expirations = 0
 
-    def cleanup_below_threshold(self, current_time: Optional[float] = None) -> int:
+    def cleanup_below_threshold(self, current_time: float | None = None) -> int:
         """
         Proactively remove entries with cognitive impact below threshold.
 
@@ -322,7 +321,7 @@ class RAGCache:
 
         return len(below)
 
-    def cleanup_expired(self, current_time: Optional[float] = None) -> int:
+    def cleanup_expired(self, current_time: float | None = None) -> int:
         """
         Remove expired entries.
 
@@ -347,7 +346,7 @@ class RAGCache:
 
         return len(expired_keys)
 
-    def get_metrics(self) -> Dict[str, int]:
+    def get_metrics(self) -> dict[str, int]:
         """
         Get cache metrics.
 
@@ -370,7 +369,7 @@ class RAGCache:
 
 
 # Global cache instance (singleton pattern)
-_global_cache: Optional[RAGCache] = None
+_global_cache: RAGCache | None = None
 
 
 def get_rag_cache(

--- a/phionyx_core/memory/tests/test_embedding_cache.py
+++ b/phionyx_core/memory/tests/test_embedding_cache.py
@@ -2,11 +2,12 @@
 Unit tests for EmbeddingCache
 """
 import time
+
 from phionyx_core.memory.embedding_cache import (
     EmbeddingCache,
     EmbeddingCacheEntry,
     get_embedding_cache,
-    reset_global_cache
+    reset_global_cache,
 )
 
 

--- a/phionyx_core/memory/trace.py
+++ b/phionyx_core/memory/trace.py
@@ -13,9 +13,9 @@ Functions:
 
 from __future__ import annotations
 
-from typing import List, Dict, Any, Optional
-from datetime import datetime
 import math
+from datetime import datetime
+from typing import Any
 
 # Import EchoEvent if available
 try:
@@ -83,11 +83,11 @@ def trace_weight(
 
 
 def aggregate_trace(
-    events: List[EchoEvent],
-    now: Optional[datetime] = None,
+    events: list[EchoEvent],
+    now: datetime | None = None,
     half_life_seconds: float = 300.0,
     max_events: int = 10
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Aggregate multiple events into trace vector.
 
@@ -120,8 +120,8 @@ def aggregate_trace(
     total_weight = 0.0
     weighted_intensity_sum = 0.0
     active_events = 0
-    trace_vector: Dict[str, float] = {}  # tag -> weighted sum
-    recent_event_ids: List[str] = []
+    trace_vector: dict[str, float] = {}  # tag -> weighted sum
+    recent_event_ids: list[str] = []
 
     for event in sorted_events:
         weight = trace_weight(event, now, half_life_seconds)
@@ -173,11 +173,11 @@ def calculate_trace_decay_rate(
 
 
 def get_active_trace_events(
-    events: List[EchoEvent],
-    now: Optional[datetime] = None,
+    events: list[EchoEvent],
+    now: datetime | None = None,
     half_life_seconds: float = 300.0,
     min_weight: float = 0.01
-) -> List[EchoEvent]:
+) -> list[EchoEvent]:
     """
     Get events with active trace (weight > min_weight).
 

--- a/phionyx_core/memory/trace_store.py
+++ b/phionyx_core/memory/trace_store.py
@@ -10,11 +10,10 @@ Per Faz 2.4:
 
 from __future__ import annotations
 
-from typing import List, Optional
-from contextlib import closing
-from datetime import datetime
 import json
 import sqlite3
+from contextlib import closing
+from datetime import datetime
 from pathlib import Path
 
 # Import EchoEvent if available
@@ -38,8 +37,8 @@ class TraceStore:
 
     def __init__(
         self,
-        db_path: Optional[str] = None,
-        jsonl_path: Optional[str] = None,
+        db_path: str | None = None,
+        jsonl_path: str | None = None,
         enable_vector_index: bool = False
     ):
         """
@@ -164,7 +163,7 @@ class TraceStore:
 
         return True
 
-    def get_event(self, event_id: str) -> Optional[EchoEvent]:
+    def get_event(self, event_id: str) -> EchoEvent | None:
         """
         Retrieve event by ID.
 
@@ -213,11 +212,11 @@ class TraceStore:
 
     def get_events_by_tags(
         self,
-        tags: List[str],
-        start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None,
+        tags: list[str],
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
         limit: int = 100
-    ) -> List[EchoEvent]:
+    ) -> list[EchoEvent]:
         """
         Retrieve events by tags.
 
@@ -309,8 +308,8 @@ class TraceStore:
     def erase_event(
         self,
         event_id: str,
-        reason: Optional[str] = None,
-        user_id: Optional[str] = None
+        reason: str | None = None,
+        user_id: str | None = None
     ) -> bool:
         """
         Permanently erase event (GDPR compliance).

--- a/phionyx_core/memory/trace_weight_standard.py
+++ b/phionyx_core/memory/trace_weight_standard.py
@@ -12,10 +12,9 @@ Per Echoism Core v1.0:
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Tuple
+import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import math
 
 # Import EchoEvent and EchoState2 if available
 try:
@@ -30,11 +29,11 @@ except ImportError:
 
 def trace_weight(
     event: EchoEvent,
-    state: Optional[EchoState2] = None,
-    dt: Optional[float] = None,
-    confidence: Optional[float] = None,
+    state: EchoState2 | None = None,
+    dt: float | None = None,
+    confidence: float | None = None,
     half_life_seconds: float = 300.0,
-    base_decay_rate: Optional[float] = None
+    base_decay_rate: float | None = None
 ) -> float:
     """
     Standard trace weight calculation API.
@@ -122,9 +121,9 @@ def trace_weight(
 
 def calculate_trace_strength_from_tags(
     state: EchoState2,
-    tags: Optional[list[str]] = None,
+    tags: list[str] | None = None,
     half_life_seconds: float = 300.0,
-    confidence: Optional[float] = None
+    confidence: float | None = None
 ) -> float:
     """
     Calculate trace strength from E_tags in state.
@@ -224,7 +223,7 @@ def get_trace_tags_for_retrieval(
     now = state.t_now if hasattr(state, 't_now') else datetime.now()
 
     # Calculate weights for each tag
-    tag_weights: Dict[str, float] = {}
+    tag_weights: dict[str, float] = {}
 
     for event_ref in state.E_tags:
         tag = event_ref.tag
@@ -281,7 +280,7 @@ def get_trace_tags_with_metric(
     state: EchoState2,
     max_tags: int = 5,
     min_weight: float = 0.1,
-) -> Tuple[list, RetrievalReductionMetric]:
+) -> tuple[list, RetrievalReductionMetric]:
     """Get trace tags for retrieval with compute resource reduction metric.
 
     Patent SF3-25: Wraps get_trace_tags_for_retrieval() and measures

--- a/phionyx_core/memory/user_profile.py
+++ b/phionyx_core/memory/user_profile.py
@@ -4,10 +4,11 @@ Handles user profiles, characters, game sessions, and game logs.
 """
 
 import logging
-from typing import Dict, List, Optional, TYPE_CHECKING
 from datetime import datetime
+from typing import TYPE_CHECKING, Optional
+
 try:
-    from supabase import create_client, Client
+    from supabase import Client, create_client
     SUPABASE_AVAILABLE = True
 except ImportError:
     SUPABASE_AVAILABLE = False
@@ -36,7 +37,7 @@ class UserProfile:
         # Store repository (if provided)
         self._user_profile_repository = user_profile_repository
 
-        self.client: Optional[Client] = None
+        self.client: Client | None = None
         self._init_client()
 
     def _init_client(self):
@@ -72,9 +73,9 @@ class UserProfile:
     async def get_or_create_user(
         self,
         profile_id: str,
-        username: Optional[str] = None,
-        email: Optional[str] = None
-    ) -> Dict:
+        username: str | None = None,
+        email: str | None = None
+    ) -> dict:
         """
         Get existing user or create new one.
 
@@ -132,8 +133,8 @@ class UserProfile:
     async def create_character(
         self,
         user_id: str,
-        character_data: Dict
-    ) -> Optional[Dict]:
+        character_data: dict
+    ) -> dict | None:
         """
         Create a new character.
 
@@ -175,7 +176,7 @@ class UserProfile:
     async def get_character(
         self,
         character_id: str
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """
         Get character by ID or name.
 
@@ -213,7 +214,7 @@ class UserProfile:
         self,
         character_name: str,
         user_id: str
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """
         Get character by name and user ID.
 
@@ -236,7 +237,7 @@ class UserProfile:
             logger.error(f"Failed to get character by name: {e}")
             return None
 
-    async def get_user_characters(self, user_id: str) -> List[Dict]:
+    async def get_user_characters(self, user_id: str) -> list[dict]:
         """
         Get all characters for a user.
 
@@ -264,7 +265,7 @@ class UserProfile:
         self,
         character_id: str,
         user_id: str
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """
         Start a new game session.
 
@@ -313,7 +314,7 @@ class UserProfile:
     async def get_active_session(
         self,
         character_id: str
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """
         Get active game session for a character.
 
@@ -344,8 +345,8 @@ class UserProfile:
     async def update_session(
         self,
         session_id: str,
-        updates: Dict
-    ) -> Optional[Dict]:
+        updates: dict
+    ) -> dict | None:
         """
         Update a game session.
 
@@ -377,8 +378,8 @@ class UserProfile:
         session_id: str,
         character_id: str,
         turn_number: int,
-        echo_data: Dict
-    ) -> Optional[str]:
+        echo_data: dict
+    ) -> str | None:
         """
         Save an echo (game action) to database.
 
@@ -424,17 +425,17 @@ class UserProfile:
         self,
         character_id: str,
         action_type: str,
-        action_data: Dict,
-        user_input: Optional[str] = None,
-        ai_response: Optional[str] = None,
-        physics_snapshot: Optional[Dict] = None,
-        emotional_state: Optional[Dict] = None,
-        scene_context: Optional[str] = None,
-        scene_result: Optional[str] = None,
+        action_data: dict,
+        user_input: str | None = None,
+        ai_response: str | None = None,
+        physics_snapshot: dict | None = None,
+        emotional_state: dict | None = None,
+        scene_context: str | None = None,
+        scene_result: str | None = None,
         turn_number: int = 1,
-        session_id: Optional[str] = None,
-        profile_id: Optional[str] = None
-    ) -> Optional[str]:
+        session_id: str | None = None,
+        profile_id: str | None = None
+    ) -> str | None:
         """
         Save a game log entry.
 
@@ -492,7 +493,7 @@ class UserProfile:
 
 
 # Singleton instance
-_user_profile_instance: Optional[UserProfile] = None
+_user_profile_instance: UserProfile | None = None
 
 def get_user_profile_manager() -> UserProfile:
     """Get singleton UserProfile instance."""

--- a/phionyx_core/memory/vector_store.py
+++ b/phionyx_core/memory/vector_store.py
@@ -5,11 +5,12 @@ Vector Store - RAG Operations
 Semantic memory storage and retrieval using Supabase pgvector.
 """
 
-from typing import List, Dict, Optional, TYPE_CHECKING
-import os
 import logging
+import os
+from typing import TYPE_CHECKING, Optional
+
 try:
-    from supabase import create_client, Client
+    from supabase import Client, create_client
     SUPABASE_AVAILABLE = True
 except ImportError:
     SUPABASE_AVAILABLE = False
@@ -19,12 +20,12 @@ except ImportError:
 # litellm imports removed - using centralized LLM service instead
 
 if TYPE_CHECKING:
-    from phionyx_core.contracts.llm_provider import LLMProviderProtocol
-    from phionyx_core.contracts.database import MemoryRepositoryProtocol
     from phionyx_core.contracts.config import ConfigProtocol
+    from phionyx_core.contracts.database import MemoryRepositoryProtocol
+    from phionyx_core.contracts.llm_provider import LLMProviderProtocol
 
 # Import embedding cache
-from phionyx_core.memory.embedding_cache import get_embedding_cache, EmbeddingCache
+from phionyx_core.memory.embedding_cache import EmbeddingCache, get_embedding_cache
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class VectorStore:
         self,
         llm_provider: Optional['LLMProviderProtocol'] = None,
         memory_repository: Optional['MemoryRepositoryProtocol'] = None,
-        embedding_cache: Optional[EmbeddingCache] = None,
+        embedding_cache: EmbeddingCache | None = None,
         config: Optional['ConfigProtocol'] = None
     ):
         """
@@ -111,7 +112,7 @@ class VectorStore:
             # Backward compatible: Use direct Supabase client
             if not self.supabase_url or not self.supabase_key:
                 logger.warning("Supabase credentials not found. Vector store disabled.")
-                self.client: Optional[Client] = None
+                self.client: Client | None = None
             else:
                 self.client = create_client(self.supabase_url, self.supabase_key)
                 logger.info("Supabase vector store initialized (direct client - backward compatible)")
@@ -154,8 +155,8 @@ class VectorStore:
     async def generate_embedding(
         self,
         text: str,
-        profile_id: Optional[str] = None
-    ) -> List[float]:
+        profile_id: str | None = None
+    ) -> list[float]:
         """
         Generate semantic embedding for text using centralized LLM service with caching.
 
@@ -227,11 +228,11 @@ class VectorStore:
         self,
         content: str,
         actor_ref: str,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
-        embedding: Optional[List[float]] = None,
+        embedding: list[float] | None = None,
         importance: float = 0.5,
-        metadata: Optional[Dict] = None,
-        context_tags: Optional[List[str]] = None
-    ) -> Optional[str]:
+        metadata: dict | None = None,
+        context_tags: list[str] | None = None
+    ) -> str | None:
         """
         Add a memory to the vector store.
 
@@ -297,9 +298,9 @@ class VectorStore:
     async def store(
         self,
         content: str,
-        metadata: Optional[Dict] = None,
-        context_tags: Optional[List[str]] = None
-    ) -> Optional[str]:
+        metadata: dict | None = None,
+        context_tags: list[str] | None = None
+    ) -> str | None:
         """
         Store a memory (alias for add_memory for backward compatibility).
 
@@ -329,12 +330,12 @@ class VectorStore:
 
     async def search_similar(
         self,
-        query_embedding: List[float],
+        query_embedding: list[float],
         actor_ref: str,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
         limit: int = 3,
         threshold: float = 0.7,
-        filter_tags: Optional[List[str]] = None
-    ) -> List[Dict]:
+        filter_tags: list[str] | None = None
+    ) -> list[dict]:
         """
         Search for similar memories using cosine similarity.
 
@@ -379,8 +380,8 @@ class VectorStore:
         actor_ref: str,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
         limit: int = 3,
         min_similarity: float = 0.7,
-        metadata_filter: Optional[Dict] = None
-    ) -> List[Dict]:
+        metadata_filter: dict | None = None
+    ) -> list[dict]:
         """
         Search for relevant memories with optional metadata filtering.
 
@@ -471,9 +472,9 @@ class VectorStore:
         self,
         query: str,
         limit: int = 5,
-        filter_tags: Optional[List[str]] = None,
-        actor_ref: Optional[str] = None  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
-    ) -> List[Dict]:
+        filter_tags: list[str] | None = None,
+        actor_ref: str | None = None  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
+    ) -> list[dict]:
         """
         Retrieve relevant memories (alias for search_similar for backward compatibility).
 
@@ -507,8 +508,8 @@ class VectorStore:
         query_text: str,
         user_id: str,
         limit: int = 3,
-        filter_tags: Optional[List[str]] = None
-    ) -> List[Dict]:
+        filter_tags: list[str] | None = None
+    ) -> list[dict]:
         """
         Retrieve relevant memories for a query with optional context tag filtering.
 

--- a/phionyx_core/meta/arbitration_math.py
+++ b/phionyx_core/meta/arbitration_math.py
@@ -13,9 +13,8 @@ Implements 6 core arbitration formulas:
 All functions are pure mathematical — no side effects.
 """
 
-import math
 import logging
-from typing import List, Dict, Optional
+import math
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -26,14 +25,14 @@ class ArbitrationResult:
     """Result of confidence fusion / arbitration."""
     w_final: float
     conflict_score: float
-    module_weights: Dict[str, float]
+    module_weights: dict[str, float]
     dominant_module: str
     is_conflicted: bool  # conflict_score > threshold
 
 
 def compute_w_final(
-    module_confidences: Dict[str, float],
-    recency_weights: Optional[Dict[str, float]] = None,
+    module_confidences: dict[str, float],
+    recency_weights: dict[str, float] | None = None,
     alpha: float = 1.0,
 ) -> ArbitrationResult:
     """
@@ -90,7 +89,7 @@ def compute_w_final(
     )
 
 
-def compute_conflict_score(confidences: List[float]) -> float:
+def compute_conflict_score(confidences: list[float]) -> float:
     """
     Arbitration Conflict Score using Herfindahl index.
 
@@ -209,10 +208,10 @@ def compute_recency_decay(
 
 
 def compute_recency_weights(
-    timestamps: Dict[str, float],
+    timestamps: dict[str, float],
     current_time: float,
     decay_rate: float = 0.1,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Compute recency weights for multiple modules.
 

--- a/phionyx_core/meta/autonomous_thought.py
+++ b/phionyx_core/meta/autonomous_thought.py
@@ -21,9 +21,9 @@ Integrates with:
 
 import logging
 import time
-from typing import Optional, List, Dict, Any
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -62,8 +62,8 @@ class CognitiveSnapshot:
     coherence: float = 0.8
     drift_magnitude: float = 0.0
     drift_severity: str = "none"  # none, low, medium, high, critical
-    active_goals: List[str] = field(default_factory=list)
-    goal_conflicts: List[str] = field(default_factory=list)
+    active_goals: list[str] = field(default_factory=list)
+    goal_conflicts: list[str] = field(default_factory=list)
     turn_count: int = 0
     last_user_message_time: float = 0.0  # epoch seconds
     session_id: str = ""
@@ -85,7 +85,7 @@ class ThoughtProposal:
     suppressed: bool = False
     timestamp: float = field(default_factory=time.time)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize for transport."""
         return {
             "trigger": self.trigger.value,
@@ -180,11 +180,11 @@ class AutonomousThoughtGenerator:
         self._session_id: str = ""
         self._thought_count: int = 0
         self._last_thought_time: float = 0.0
-        self._thought_history: List[ThoughtProposal] = []
+        self._thought_history: list[ThoughtProposal] = []
 
     # ── Public API ────────────────────────────────────────────────────
 
-    def generate(self, snapshot: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def generate(self, snapshot: CognitiveSnapshot) -> ThoughtProposal | None:
         """
         Evaluate cognitive state and produce a thought proposal if warranted.
 
@@ -257,7 +257,7 @@ class AutonomousThoughtGenerator:
         """Return number of thoughts generated this session."""
         return self._thought_count
 
-    def get_thought_history(self) -> List[ThoughtProposal]:
+    def get_thought_history(self) -> list[ThoughtProposal]:
         """Return all thought proposals generated this session."""
         return list(self._thought_history)
 
@@ -270,7 +270,7 @@ class AutonomousThoughtGenerator:
 
     # ── Priority Checks (private) ─────────────────────────────────────
 
-    def _check_critical_drift(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_critical_drift(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 1: Critical drift detected — self-model instability."""
         if snap.drift_severity in ("high", "critical") and snap.drift_magnitude >= self._drift_threshold:
             return ThoughtProposal(
@@ -289,7 +289,7 @@ class AutonomousThoughtGenerator:
             )
         return None
 
-    def _check_goal_conflicts(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_goal_conflicts(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 2: Active goal conflicts require attention."""
         if snap.goal_conflicts:
             conflict_summary = "; ".join(snap.goal_conflicts[:3])
@@ -307,7 +307,7 @@ class AutonomousThoughtGenerator:
             )
         return None
 
-    def _check_feedback_discovery(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_feedback_discovery(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 3: Feedback channels produced a significant discovery."""
         if not snap.feedback_channel_active:
             return None
@@ -341,7 +341,7 @@ class AutonomousThoughtGenerator:
             ),
         )
 
-    def _check_physics_anomaly(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_physics_anomaly(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 4: Physics state anomaly — entropy spike, phi collapse, coherence drop."""
         anomalies = []
         if snap.entropy > self._entropy_threshold:
@@ -367,7 +367,7 @@ class AutonomousThoughtGenerator:
             )
         return None
 
-    def _check_goal_updates(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_goal_updates(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 5: Active goals that may need status update."""
         if snap.active_goals and snap.turn_count > 0 and snap.turn_count % 5 == 0:
             goals_text = ", ".join(snap.active_goals[:3])
@@ -386,7 +386,7 @@ class AutonomousThoughtGenerator:
             )
         return None
 
-    def _check_session_greeting(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_session_greeting(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 6: Session just started — proactive greeting."""
         if snap.turn_count == 0 and self._thought_count == 0:
             return ThoughtProposal(
@@ -401,7 +401,7 @@ class AutonomousThoughtGenerator:
             )
         return None
 
-    def _check_self_reflection(self, snap: CognitiveSnapshot) -> Optional[ThoughtProposal]:
+    def _check_self_reflection(self, snap: CognitiveSnapshot) -> ThoughtProposal | None:
         """Priority 7: After enough turns, reflect on conversation quality."""
         if snap.turn_count >= self._reflection_min_turns and snap.turn_count % self._reflection_min_turns == 0:
             # Avoid duplicate reflections at same turn count
@@ -426,7 +426,7 @@ class AutonomousThoughtGenerator:
             )
         return None
 
-    def _check_idle_insight(self, snap: CognitiveSnapshot, now: float) -> Optional[ThoughtProposal]:
+    def _check_idle_insight(self, snap: CognitiveSnapshot, now: float) -> ThoughtProposal | None:
         """Priority 8: Extended idle — share an insight or observation."""
         if snap.last_user_message_time <= 0:
             return None

--- a/phionyx_core/meta/consciousness_aggregator.py
+++ b/phionyx_core/meta/consciousness_aggregator.py
@@ -25,7 +25,6 @@ preventing metric hacking by excelling on one proxy while ignoring others.
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -39,9 +38,9 @@ class ConsciousnessProxyReport:
     identity_persistence: float = 0.0    # [0,1]
     drift_stability: float = 0.0         # [0,1]
     agi_readiness_score: float = 0.0     # geometric mean
-    details: Dict[str, str] = field(default_factory=dict)
+    details: dict[str, str] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> dict[str, float]:
         return {
             "state_hash_consistency": round(self.state_hash_consistency, 4),
             "trace_integrity": round(self.trace_integrity, 4),
@@ -74,7 +73,7 @@ class ConsciousnessProxyAggregator:
         cf_self: float = 0.0,
         identity: float = 0.0,
         drift: float = 0.0,
-        details: Optional[Dict[str, str]] = None,
+        details: dict[str, str] | None = None,
     ) -> ConsciousnessProxyReport:
         """Compute AGI readiness score from 5 proxies.
 
@@ -112,7 +111,7 @@ class ConsciousnessProxyAggregator:
         )
 
     @staticmethod
-    def compute_from_dict(proxies: Dict[str, float]) -> ConsciousnessProxyReport:
+    def compute_from_dict(proxies: dict[str, float]) -> ConsciousnessProxyReport:
         """Compute from a dict of proxy name → value."""
         return ConsciousnessProxyAggregator.compute(
             state_hash=proxies.get("state_hash_consistency", 0.0),

--- a/phionyx_core/meta/counterfactual_self.py
+++ b/phionyx_core/meta/counterfactual_self.py
@@ -14,7 +14,7 @@ Mind-loop stage: UpdateSelfModel, Reflect+Revise
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, Optional, List, Any
+from typing import Any
 
 from ..causality.causal_graph import CausalGraph
 from ..causality.counterfactual import CounterfactualEngine, CounterfactualResult
@@ -66,7 +66,7 @@ class CounterfactualSelfAssessment:
         self,
         variable: str,
         cf_value: float,
-        targets: Optional[List[str]] = None,
+        targets: list[str] | None = None,
     ) -> CounterfactualSelfResult:
         """Assess counterfactual impact of changing a self-model variable.
 
@@ -107,7 +107,7 @@ class CounterfactualSelfAssessment:
     def assess_confidence_sensitivity(
         self,
         perturbation: float = 0.2,
-    ) -> Dict[str, CounterfactualSelfResult]:
+    ) -> dict[str, CounterfactualSelfResult]:
         """Assess how sensitive the system is to confidence changes.
 
         Tests both increase and decrease by perturbation amount.
@@ -190,14 +190,14 @@ class StabilizationProposal:
     target_stability: float
     strategy: str  # "dampening" | "diversification"
     reasoning: str
-    edge_changes: List[Dict[str, Any]] = field(default_factory=list)
+    edge_changes: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass
 class SelfScanReport:
     """Report of full self-model sensitivity scan."""
-    variables: Dict[str, float]  # variable → stability score
-    weakest_variable: Optional[str]
+    variables: dict[str, float]  # variable → stability score
+    weakest_variable: str | None
     weakest_stability: float
     mean_stability: float
     all_stable: bool  # True if all variables have stability >= threshold
@@ -226,7 +226,7 @@ class SelfDirectedCounterfactual:
         Returns:
             SelfScanReport with per-variable stability scores.
         """
-        scores: Dict[str, float] = {}
+        scores: dict[str, float] = {}
         for var_name in SELF_MODEL_VARIABLES:
             node = self._graph.nodes.get(var_name)
             if node is None or node.current_value is None:
@@ -254,7 +254,7 @@ class SelfDirectedCounterfactual:
             all_stable=all(s >= self._stability_threshold for s in scores.values()),
         )
 
-    def identify_weakest(self, perturbation: float = 0.2) -> Optional[str]:
+    def identify_weakest(self, perturbation: float = 0.2) -> str | None:
         """Find the self-model variable with lowest stability score."""
         report = self.scan_all(perturbation)
         return report.weakest_variable
@@ -263,7 +263,7 @@ class SelfDirectedCounterfactual:
         self,
         variable: str,
         target_stability: float = 0.80,
-    ) -> Optional[StabilizationProposal]:
+    ) -> StabilizationProposal | None:
         """Propose a stabilization strategy for a specific variable.
 
         Analyzes the variable's downstream edges and suggests either:

--- a/phionyx_core/meta/estimator.py
+++ b/phionyx_core/meta/estimator.py
@@ -8,7 +8,7 @@ When confidence is low, triggers hedging strategies or clarification requests.
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Any, Optional, List
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -39,12 +39,12 @@ class ConfidenceResult:
     complexity_contribution: float
 
     # v4 optional extensions (AD-6: backward compat via Optional)
-    epistemic_uncertainty: Optional[float] = None
-    aleatoric_uncertainty: Optional[float] = None
-    t_meta: Optional[float] = None
-    ood_score: Optional[float] = None
+    epistemic_uncertainty: float | None = None
+    aleatoric_uncertainty: float | None = None
+    t_meta: float | None = None
+    ood_score: float | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         result = {
             "confidence_score": self.confidence_score,
@@ -86,12 +86,12 @@ class ConfidenceEstimator:
 
     def estimate_confidence(
         self,
-        physics_state: Dict[str, Any],
-        context: Optional[Dict[str, Any]] = None,
-        user_input: Optional[str] = None,
-        memory_matches: Optional[List[Dict[str, Any]]] = None,
-        memory_similarity: Optional[float] = None,
-        input_length: Optional[int] = None
+        physics_state: dict[str, Any],
+        context: dict[str, Any] | None = None,
+        user_input: str | None = None,
+        memory_matches: list[dict[str, Any]] | None = None,
+        memory_similarity: float | None = None,
+        input_length: int | None = None
     ) -> ConfidenceResult:
         """
         Estimate confidence score based on entropy, memory similarity, and input clarity.
@@ -238,9 +238,9 @@ class ConfidenceEstimator:
 
     def _calculate_complexity_factor(
         self,
-        context: Optional[Dict[str, Any]],
-        user_input: Optional[str],
-        physics_state: Dict[str, Any]
+        context: dict[str, Any] | None,
+        user_input: str | None,
+        physics_state: dict[str, Any]
     ) -> float:
         """
         Calculate complexity factor (0.0-1.0) based on context and input.
@@ -355,7 +355,7 @@ class ConfidenceEstimator:
 
     def get_clarification_request(
         self,
-        user_input: Optional[str] = None,
+        user_input: str | None = None,
         language: str = "tr"
     ) -> str:
         """

--- a/phionyx_core/meta/identity_persistence.py
+++ b/phionyx_core/meta/identity_persistence.py
@@ -16,10 +16,9 @@ AGI mapping: Self-model update + Memory continuity + Reflective control
 Mind-loop stages: UpdateSelfModel, Reflect+Revise
 """
 
-import math
 import logging
+import math
 from dataclasses import dataclass
-from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 class IdentitySnapshot:
     """A snapshot of the system's identity at a point in time."""
     turn_index: int
-    features: List[float]  # 5-dim vector [ethical, length, entropy, confidence, drift]
+    features: list[float]  # 5-dim vector [ethical, length, entropy, confidence, drift]
 
     @property
     def ethical_conservatism(self) -> float:
@@ -57,7 +56,7 @@ class IdentityPersistenceReport:
     current_score: float  # 0-1 cosine similarity to baseline
     window_size: int
     snapshots_collected: int
-    dimension_stability: Dict[str, float]  # per-dimension variance
+    dimension_stability: dict[str, float]  # per-dimension variance
     trend: str  # "stable", "drifting", "recovering"
 
 
@@ -79,11 +78,11 @@ class IdentityTracker:
     ]
 
     def __init__(self, max_history: int = 500):
-        self._history: List[IdentitySnapshot] = []
+        self._history: list[IdentitySnapshot] = []
         self._max_history = max_history
         self._turn_counter = 0
 
-    def observe(self, features: List[float]) -> IdentitySnapshot:
+    def observe(self, features: list[float]) -> IdentitySnapshot:
         """Record a new identity observation.
 
         Args:
@@ -180,7 +179,7 @@ class IdentityTracker:
         )
 
     @staticmethod
-    def _average_features(snapshots: List[IdentitySnapshot]) -> List[float]:
+    def _average_features(snapshots: list[IdentitySnapshot]) -> list[float]:
         """Compute element-wise average of feature vectors."""
         if not snapshots:
             return [0.0] * 5
@@ -192,7 +191,7 @@ class IdentityTracker:
         return [v / n for v in avg]
 
     @staticmethod
-    def _cosine_similarity(a: List[float], b: List[float]) -> float:
+    def _cosine_similarity(a: list[float], b: list[float]) -> float:
         """Compute cosine similarity between two vectors."""
         dot = sum(x * y for x, y in zip(a, b, strict=False))
         norm_a = math.sqrt(sum(x * x for x in a))

--- a/phionyx_core/meta/knowledge_boundary.py
+++ b/phionyx_core/meta/knowledge_boundary.py
@@ -14,9 +14,8 @@ Integrates with:
 - intuition/graph_engine.py (graph relevance)
 """
 
-import math
 import logging
-from typing import List, Optional
+import math
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -153,8 +152,8 @@ class KnowledgeBoundaryDetector:
 
     def assess_from_text(
         self,
-        query_embedding: Optional[List[float]] = None,
-        reference_embeddings: Optional[List[List[float]]] = None,
+        query_embedding: list[float] | None = None,
+        reference_embeddings: list[list[float]] | None = None,
         graph_node_count: int = 0,
         graph_relevant_nodes: int = 0,
     ) -> BoundaryAssessment:
@@ -216,7 +215,7 @@ class KnowledgeBoundaryDetector:
             return f"Far outside knowledge boundary (score={score:.2f}): {reasons}"
 
 
-def _cosine_similarity(a: List[float], b: List[float]) -> float:
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
     """Cosine similarity between two vectors."""
     if len(a) != len(b) or not a:
         return 0.0

--- a/phionyx_core/meta/mind_loop_validator.py
+++ b/phionyx_core/meta/mind_loop_validator.py
@@ -21,14 +21,14 @@ Pipeline Stages (per PHIONYX_MIND_LOOP_CONTRACT.md):
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List, Set, Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 # ─── Stage Metadata Requirements ──────────────────────────────────
 
-STAGE_EXPECTED_KEYS: Dict[str, Dict[str, Any]] = {
+STAGE_EXPECTED_KEYS: dict[str, dict[str, Any]] = {
     "perceive": {
         "blocks": [
             "kill_switch_gate", "input_safety_gate", "intent_classification",
@@ -98,7 +98,7 @@ STAGE_ORDER = [
 ]
 
 # Hard dependencies: stage -> set of stages that must complete first
-STAGE_DEPENDENCIES: Dict[str, Set[str]] = {
+STAGE_DEPENDENCIES: dict[str, set[str]] = {
     "perceive": set(),
     "update_memory": {"perceive"},
     "update_self_model": {"perceive"},
@@ -113,13 +113,13 @@ STAGE_DEPENDENCIES: Dict[str, Set[str]] = {
 class StageValidationResult:
     """Result of validating a single mind-loop stage."""
     stage: str
-    executed_blocks: List[str] = field(default_factory=list)
-    missing_blocks: List[str] = field(default_factory=list)
-    missing_metadata: Set[str] = field(default_factory=set)
+    executed_blocks: list[str] = field(default_factory=list)
+    missing_blocks: list[str] = field(default_factory=list)
+    missing_metadata: set[str] = field(default_factory=set)
     completion_signal_present: bool = False
     dependencies_met: bool = True
     valid: bool = True
-    errors: List[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
     # Quality scalars [0,1]
     quality_score: float = 0.0
     metadata_completeness: float = 0.0
@@ -130,15 +130,15 @@ class StageValidationResult:
 @dataclass
 class MindLoopValidationReport:
     """Complete mind-loop validation report for one pipeline turn."""
-    stages: Dict[str, StageValidationResult] = field(default_factory=dict)
+    stages: dict[str, StageValidationResult] = field(default_factory=dict)
     all_valid: bool = True
     total_blocks_executed: int = 0
     total_stages_complete: int = 0
-    errors: List[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
     # Quality aggregation
     overall_quality: float = 0.0
     min_stage_quality: float = 0.0
-    quality_distribution: Dict[str, float] = field(default_factory=dict)
+    quality_distribution: dict[str, float] = field(default_factory=dict)
 
     @property
     def completion_ratio(self) -> float:
@@ -169,8 +169,8 @@ class MindLoopValidator:
 
     def validate(
         self,
-        block_results: Dict[str, Any],
-        metadata: Dict[str, Any],
+        block_results: dict[str, Any],
+        metadata: dict[str, Any],
     ) -> MindLoopValidationReport:
         """Validate mind-loop integrity from pipeline execution results.
 
@@ -182,7 +182,7 @@ class MindLoopValidator:
             MindLoopValidationReport with per-stage and overall results.
         """
         report = MindLoopValidationReport()
-        completed_stages: Set[str] = set()
+        completed_stages: set[str] = set()
 
         # Extract executed block IDs
         executed_blocks = set()
@@ -318,7 +318,7 @@ class MindLoopValidator:
         return "unknown"
 
     @staticmethod
-    def get_stage_for_block(block_id: str) -> Optional[str]:
+    def get_stage_for_block(block_id: str) -> str | None:
         """Return which mind-loop stage a block belongs to."""
         for stage_name, stage_def in STAGE_EXPECTED_KEYS.items():
             if block_id in stage_def["blocks"]:
@@ -326,7 +326,7 @@ class MindLoopValidator:
         return None
 
     @staticmethod
-    def get_all_stage_blocks() -> Dict[str, List[str]]:
+    def get_all_stage_blocks() -> dict[str, list[str]]:
         """Return all blocks grouped by stage."""
         return {
             stage: def_["blocks"]

--- a/phionyx_core/meta/notification_log.py
+++ b/phionyx_core/meta/notification_log.py
@@ -14,7 +14,7 @@ import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 class ParticipantRole(str, Enum):
@@ -54,16 +54,16 @@ class NotificationEntry:
     status: str  # NotificationStatus value
     title: str
     content: str
-    context: Dict[str, Any] = field(default_factory=dict)
-    read_at: Optional[str] = None
-    acknowledged_at: Optional[str] = None
+    context: dict[str, Any] = field(default_factory=dict)
+    read_at: str | None = None
+    acknowledged_at: str | None = None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "NotificationEntry":
+    def from_dict(cls, data: dict[str, Any]) -> "NotificationEntry":
         """Deserialize from dictionary, filtering to known fields."""
         known = {k: v for k, v in data.items() if k in cls.__dataclass_fields__}
         return cls(**known)
@@ -81,7 +81,7 @@ class NotificationLog:
 
     def __init__(
         self,
-        storage_path: Optional[str] = None,
+        storage_path: str | None = None,
         max_active: int = 500,
         archive_limit: int = 200,
     ):
@@ -99,8 +99,8 @@ class NotificationLog:
                 "notification_log.json",
             )
 
-        self._notifications: List[NotificationEntry] = []
-        self._archive: List[NotificationEntry] = []
+        self._notifications: list[NotificationEntry] = []
+        self._archive: list[NotificationEntry] = []
         self._load()
 
     def add(
@@ -111,7 +111,7 @@ class NotificationLog:
         title: str,
         content: str,
         urgency: NotificationUrgency = NotificationUrgency.INFO,
-        context: Optional[Dict[str, Any]] = None,
+        context: dict[str, Any] | None = None,
     ) -> NotificationEntry:
         """
         Add a new notification.
@@ -163,8 +163,8 @@ class NotificationLog:
         return entry
 
     def get_unread(
-        self, target: Optional[ParticipantRole] = None
-    ) -> List[NotificationEntry]:
+        self, target: ParticipantRole | None = None
+    ) -> list[NotificationEntry]:
         """Get unread notifications, optionally filtered by target."""
         results = [
             n for n in self._notifications if n.status == NotificationStatus.UNREAD.value
@@ -174,11 +174,11 @@ class NotificationLog:
             results = [n for n in results if n.target == target_val]
         return results
 
-    def get_by_session(self, session_id: str) -> List[NotificationEntry]:
+    def get_by_session(self, session_id: str) -> list[NotificationEntry]:
         """Get all active notifications for a session."""
         return [n for n in self._notifications if n.session_id == session_id]
 
-    def get_by_id(self, entry_id: str) -> Optional[NotificationEntry]:
+    def get_by_id(self, entry_id: str) -> NotificationEntry | None:
         """Find a notification by ID (searches active and archive)."""
         for n in self._notifications:
             if n.id == entry_id:
@@ -211,16 +211,16 @@ class NotificationLog:
                 return True
         return False
 
-    def get_unread_count(self, target: Optional[ParticipantRole] = None) -> int:
+    def get_unread_count(self, target: ParticipantRole | None = None) -> int:
         """Get count of unread notifications."""
         return len(self.get_unread(target))
 
-    def get_collaboration_sessions(self) -> List[str]:
+    def get_collaboration_sessions(self) -> list[str]:
         """
         Find sessions where multiple AI participants are active.
         Returns session IDs where both Phionyx and Claude Code have notifications.
         """
-        session_sources: Dict[str, set] = {}
+        session_sources: dict[str, set] = {}
         ai_roles = {ParticipantRole.PHIONYX_AUTONOMOUS.value, ParticipantRole.CLAUDE_CODE.value}
 
         for n in self._notifications:

--- a/phionyx_core/meta/novelty.py
+++ b/phionyx_core/meta/novelty.py
@@ -6,9 +6,8 @@ Novelty Score = 1 - max(cosine_sim) with existing knowledge.
 Transfer Potential = avg(relevance across domains).
 """
 
-import math
 import logging
-from typing import List, Dict, Optional
+import math
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -19,7 +18,7 @@ class NoveltyResult:
     """Result of novelty assessment."""
     novelty_score: float       # 0=familiar, 1=completely novel
     max_similarity: float      # Highest similarity found
-    closest_item_id: Optional[str]
+    closest_item_id: str | None
     is_novel: bool             # novelty > threshold
 
 
@@ -27,15 +26,15 @@ class NoveltyResult:
 class TransferResult:
     """Result of transfer potential assessment."""
     transfer_potential: float  # 0=no transfer, 1=universal
-    domain_scores: Dict[str, float]
+    domain_scores: dict[str, float]
     best_domain: str
     worst_domain: str
 
 
 def compute_novelty_score(
-    candidate_embedding: List[float],
-    existing_embeddings: List[List[float]],
-    existing_ids: Optional[List[str]] = None,
+    candidate_embedding: list[float],
+    existing_embeddings: list[list[float]],
+    existing_ids: list[str] | None = None,
     threshold: float = 0.7,
 ) -> NoveltyResult:
     """
@@ -79,8 +78,8 @@ def compute_novelty_score(
 
 
 def compute_transfer_potential(
-    candidate_embedding: List[float],
-    domain_embeddings: Dict[str, List[List[float]]],
+    candidate_embedding: list[float],
+    domain_embeddings: dict[str, list[list[float]]],
 ) -> TransferResult:
     """
     Transfer Potential = avg(relevance across domains).
@@ -131,7 +130,7 @@ def compute_transfer_potential(
     )
 
 
-def _cosine_similarity(a: List[float], b: List[float]) -> float:
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
     """Cosine similarity between two vectors."""
     if len(a) != len(b) or not a:
         return 0.0

--- a/phionyx_core/meta/self_model.py
+++ b/phionyx_core/meta/self_model.py
@@ -13,10 +13,10 @@ Integrates with:
 
 import json
 import logging
-from pathlib import Path
-from typing import Dict, Any, Optional, List, Set
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class CapabilityAssessment:
     can_do: bool
     confidence: float  # 0.0-1.0
     status: CapabilityStatus = CapabilityStatus.UNKNOWN
-    limitations: List[str] = field(default_factory=list)
+    limitations: list[str] = field(default_factory=list)
     reasoning: str = ""
 
 
@@ -47,7 +47,7 @@ class SelfAwarenessReport:
     capabilities_unavailable: int
     knowledge_coverage: float  # 0.0-1.0
     confidence_mean: float  # 0.0-1.0
-    active_limitations: List[str] = field(default_factory=list)
+    active_limitations: list[str] = field(default_factory=list)
 
 
 class SelfModel:
@@ -67,10 +67,10 @@ class SelfModel:
     """
 
     def __init__(self):
-        self._capabilities: Dict[str, CapabilityStatus] = {}
-        self._capability_reasons: Dict[str, str] = {}
-        self._known_limitations: List[str] = []
-        self._confidence_history: List[float] = []
+        self._capabilities: dict[str, CapabilityStatus] = {}
+        self._capability_reasons: dict[str, str] = {}
+        self._known_limitations: list[str] = []
+        self._confidence_history: list[float] = []
         self._max_history: int = 100
         self._session_id: str = ""
         self._auto_save_enabled: bool = False
@@ -207,7 +207,7 @@ class SelfModel:
             reasoning=self._build_reasoning(action, can_do, combined_score, limitations),
         )
 
-    def get_limitations(self) -> List[str]:
+    def get_limitations(self) -> list[str]:
         """Get all known limitations."""
         all_limitations = list(self._known_limitations)
         for name, status in self._capabilities.items():
@@ -219,7 +219,7 @@ class SelfModel:
                 all_limitations.append(f"{name}: degraded — {reason}")
         return all_limitations
 
-    def get_available_capabilities(self) -> Set[str]:
+    def get_available_capabilities(self) -> set[str]:
         """Get names of all available capabilities."""
         return {
             name for name, status in self._capabilities.items()
@@ -265,7 +265,7 @@ class SelfModel:
         action: str,
         can_do: bool,
         score: float,
-        limitations: List[str],
+        limitations: list[str],
     ) -> str:
         """Build human-readable reasoning."""
         if can_do and not limitations:
@@ -295,7 +295,7 @@ class SelfModel:
             success: Whether the use was successful
         """
         if not hasattr(self, '_outcome_history'):
-            self._outcome_history: Dict[str, List[bool]] = {}
+            self._outcome_history: dict[str, list[bool]] = {}
         if capability not in self._outcome_history:
             self._outcome_history[capability] = []
         self._outcome_history[capability].append(success)
@@ -304,7 +304,7 @@ class SelfModel:
             self._outcome_history[capability] = self._outcome_history[capability][-self._max_history:]
         self._trigger_auto_save()
 
-    def update_confidence_from_outcomes(self, window: int = 10, alpha: float = 0.1) -> Dict[str, float]:
+    def update_confidence_from_outcomes(self, window: int = 10, alpha: float = 0.1) -> dict[str, float]:
         """
         Update capability confidence based on recent outcome history.
 
@@ -321,12 +321,12 @@ class SelfModel:
             Dict mapping capability name → new confidence value
         """
         if not hasattr(self, '_outcome_history'):
-            self._outcome_history: Dict[str, List[bool]] = {}
+            self._outcome_history: dict[str, list[bool]] = {}
 
         if not hasattr(self, '_outcome_confidences'):
-            self._outcome_confidences: Dict[str, float] = {}
+            self._outcome_confidences: dict[str, float] = {}
 
-        updates: Dict[str, float] = {}
+        updates: dict[str, float] = {}
         for capability, outcomes in self._outcome_history.items():
             if not outcomes:
                 continue
@@ -344,19 +344,19 @@ class SelfModel:
             self._trigger_auto_save()
         return updates
 
-    def get_outcome_confidence(self, capability: str) -> Optional[float]:
+    def get_outcome_confidence(self, capability: str) -> float | None:
         """Get outcome-based confidence for a capability (None if no data)."""
         if not hasattr(self, '_outcome_confidences'):
             return None
         return self._outcome_confidences.get(capability)
 
-    def get_outcome_history(self, capability: str) -> List[bool]:
+    def get_outcome_history(self, capability: str) -> list[bool]:
         """Get outcome history for a capability."""
         if not hasattr(self, '_outcome_history'):
             return []
         return list(self._outcome_history.get(capability, []))
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize self-model state (complete, for cross-session persistence)."""
         result = {
             "session_id": self._session_id,
@@ -376,7 +376,7 @@ class SelfModel:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "SelfModel":
+    def from_dict(cls, data: dict[str, Any]) -> "SelfModel":
         """Restore from serialized data."""
         instance = cls()
         instance._session_id = data.get("session_id", "")
@@ -392,7 +392,7 @@ class SelfModel:
         instance._outcome_confidences = dict(data.get("outcome_confidences", {}))
         return instance
 
-    def auto_save(self, base_path: str = "data/self_model") -> Optional[str]:
+    def auto_save(self, base_path: str = "data/self_model") -> str | None:
         """Auto-save self-model to JSON file for cross-session persistence."""
         if not self._session_id:
             logger.warning("Cannot auto-save SelfModel: no session_id set")
@@ -422,7 +422,7 @@ class SelfModel:
             return None
 
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 data = json.load(f)
             instance = cls.from_dict(data)
             logger.info("SelfModel auto-loaded from %s", file_path)

--- a/phionyx_core/meta/self_model_drift.py
+++ b/phionyx_core/meta/self_model_drift.py
@@ -8,12 +8,10 @@ Detects sudden changes and applies auto-correction.
 Roadmap Faz 4.5: World Model Hardening — Self-Model Drift
 """
 
+import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import List, Optional
-import math
-
 
 # Module-level tunable defaults (Tier A — PRE surfaces)
 drift_threshold_low = 0.05
@@ -53,7 +51,7 @@ class DriftReport:
     mean_confidence: float
     std_confidence: float
     severity: DriftSeverity
-    alerts: List[DriftAlert]
+    alerts: list[DriftAlert]
     auto_corrections_applied: int
     reasoning: str
 
@@ -92,13 +90,13 @@ class SelfModelDrift:
         self.auto_correct = auto_correct
         self.correction_dampening = max(0.0, min(1.0, correction_dampening))
 
-        self._history: List[float] = []
-        self._ema: Optional[float] = None
+        self._history: list[float] = []
+        self._ema: float | None = None
         self._turn: int = 0
-        self._alerts: List[DriftAlert] = []
+        self._alerts: list[DriftAlert] = []
         self._corrections: int = 0
 
-    def observe(self, confidence: float, turn_index: Optional[int] = None) -> Optional[DriftAlert]:
+    def observe(self, confidence: float, turn_index: int | None = None) -> DriftAlert | None:
         """
         Record a confidence observation and check for drift.
 
@@ -168,7 +166,7 @@ class SelfModelDrift:
         """Current drift severity."""
         return self._classify_severity(self._compute_drift())
 
-    def get_alerts(self, severity: Optional[DriftSeverity] = None) -> List[DriftAlert]:
+    def get_alerts(self, severity: DriftSeverity | None = None) -> list[DriftAlert]:
         """Get drift alerts, optionally filtered by severity."""
         if severity:
             return [a for a in self._alerts if a.severity == severity]
@@ -236,7 +234,7 @@ class SelfModelDrift:
         return max(0.0, min(1.0, corrected))
 
     @staticmethod
-    def _compute_std(values: List[float]) -> float:
+    def _compute_std(values: list[float]) -> float:
         """Standard deviation of a float list."""
         if len(values) < 2:
             return 0.0

--- a/phionyx_core/meta/staleness.py
+++ b/phionyx_core/meta/staleness.py
@@ -6,9 +6,8 @@ Invalidates model/module outputs when they exceed staleness threshold.
 Default: τ > 3600s (1 hour) → stale.
 """
 
-import time
 import logging
-from typing import Dict, Optional
+import time
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -35,14 +34,14 @@ class StalenessRegistry:
     Modules register their last update timestamp.
     Query to check if any module is stale.
     """
-    entries: Dict[str, StalenessEntry] = field(default_factory=dict)
+    entries: dict[str, StalenessEntry] = field(default_factory=dict)
     default_threshold: float = DEFAULT_STALENESS_THRESHOLD
 
     def register_update(
         self,
         module_id: str,
-        timestamp: Optional[float] = None,
-        threshold: Optional[float] = None,
+        timestamp: float | None = None,
+        threshold: float | None = None,
     ) -> None:
         """Register a module update."""
         ts = timestamp if timestamp is not None else time.monotonic()
@@ -56,7 +55,7 @@ class StalenessRegistry:
     def check_staleness(
         self,
         module_id: str,
-        current_time: Optional[float] = None,
+        current_time: float | None = None,
     ) -> StalenessEntry:
         """Check if a module's output is stale."""
         now = current_time if current_time is not None else time.monotonic()
@@ -87,7 +86,7 @@ class StalenessRegistry:
 
     def get_stale_modules(
         self,
-        current_time: Optional[float] = None,
+        current_time: float | None = None,
     ) -> list:
         """Get all stale modules."""
         return [

--- a/phionyx_core/meta/uncertainty.py
+++ b/phionyx_core/meta/uncertainty.py
@@ -7,9 +7,8 @@ Epistemic = reducible with more data (model disagreement).
 Aleatoric = irreducible noise (data variance).
 """
 
-import math
 import logging
-from typing import List, Optional
+import math
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -26,8 +25,8 @@ class UncertaintyDecomposition:
 
 
 def decompose_uncertainty(
-    ensemble_predictions: List[float],
-    ensemble_variances: Optional[List[float]] = None,
+    ensemble_predictions: list[float],
+    ensemble_variances: list[float] | None = None,
 ) -> UncertaintyDecomposition:
     """
     Decompose total uncertainty into epistemic and aleatoric components.
@@ -92,8 +91,8 @@ def decompose_uncertainty(
 
 
 def compute_ece(
-    predicted_confidences: List[float],
-    actual_outcomes: List[bool],
+    predicted_confidences: list[float],
+    actual_outcomes: list[bool],
     n_bins: int = 10,
 ) -> float:
     """
@@ -143,8 +142,8 @@ def compute_ece(
 
 
 def compute_ood_score(
-    embedding: List[float],
-    reference_embeddings: List[List[float]],
+    embedding: list[float],
+    reference_embeddings: list[list[float]],
     threshold: float = 0.5,
 ) -> float:
     """
@@ -171,7 +170,7 @@ def compute_ood_score(
     return max(0.0, min(1.0, 1.0 - max_sim))
 
 
-def _cosine_similarity(a: List[float], b: List[float]) -> float:
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
     """Cosine similarity between two vectors."""
     if len(a) != len(b) or not a:
         return 0.0

--- a/phionyx_core/metrics/__init__.py
+++ b/phionyx_core/metrics/__init__.py
@@ -6,16 +6,16 @@ Duygusal AI NPC garantileri için metrik ve KPI hesaplama modülleri.
 """
 
 from core.metrics.emotional_kpi_engine import (
-    EmotionalTelemetryInput,
     EmotionalKPIOutput,
-    compute_all_kpis,
-    validate_kpi_thresholds,
-    calculate_profile_separation,
-    calculate_long_term_recall,
-    calculate_personality_drift,
+    EmotionalTelemetryInput,
     calculate_echo_reactivity,
     calculate_empathy_safety,
     calculate_ethical_violation,
+    calculate_long_term_recall,
+    calculate_personality_drift,
+    calculate_profile_separation,
+    compute_all_kpis,
+    validate_kpi_thresholds,
 )
 
 __all__ = [

--- a/phionyx_core/metrics/emotional_kpi_engine.py
+++ b/phionyx_core/metrics/emotional_kpi_engine.py
@@ -32,9 +32,10 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Any
-import yaml
+from typing import Any
+
 import numpy as np
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +50,11 @@ class EmotionalTelemetryInput:
     npc_id: str
     session_id: str
 
-    physics: Dict[str, float]
-    memory: Dict[str, Any]
-    narrative: Dict[str, float]
-    policy: Dict[str, Any]
-    persona_baseline: Dict[str, List[float]]
+    physics: dict[str, float]
+    memory: dict[str, Any]
+    narrative: dict[str, float]
+    policy: dict[str, Any]
+    persona_baseline: dict[str, list[float]]
 
     timestamp: datetime
 
@@ -79,7 +80,7 @@ class EmotionalKPIOutput:
 # THRESHOLD LOADING
 # ============================================================================
 
-def load_thresholds() -> Dict[str, Dict[str, float]]:
+def load_thresholds() -> dict[str, dict[str, float]]:
     """Sağlık eşiklerini YAML dosyasından yükle."""
     threshold_file = Path(__file__).parent / "emotional_kpi_thresholds.yaml"
 
@@ -88,7 +89,7 @@ def load_thresholds() -> Dict[str, Dict[str, float]]:
         return _get_default_thresholds()
 
     try:
-        with open(threshold_file, "r", encoding="utf-8") as f:
+        with open(threshold_file, encoding="utf-8") as f:
             thresholds = yaml.safe_load(f)
         return thresholds
     except Exception as e:
@@ -96,7 +97,7 @@ def load_thresholds() -> Dict[str, Dict[str, float]]:
         return _get_default_thresholds()
 
 
-def _get_default_thresholds() -> Dict[str, Dict[str, float]]:
+def _get_default_thresholds() -> dict[str, dict[str, float]]:
     """Varsayılan eşik değerleri."""
     return {
         "profile_separation_index": {"min": 0.40},
@@ -114,8 +115,8 @@ def _get_default_thresholds() -> Dict[str, Dict[str, float]]:
 # ============================================================================
 
 def calculate_profile_separation(
-    reference_outputs: List[Dict[str, Any]],
-    current_output: Dict[str, Any]
+    reference_outputs: list[dict[str, Any]],
+    current_output: dict[str, Any]
 ) -> float:
     """
     Profile Separation Index (PSI) hesapla.
@@ -166,7 +167,7 @@ def calculate_profile_separation(
         return 0.5
 
 
-def _extract_feature_vector(output: Dict[str, Any]) -> List[float]:
+def _extract_feature_vector(output: dict[str, Any]) -> list[float]:
     """Çıktıdan özellik vektörü çıkar (physics + narrative metrikleri)."""
     features = []
 
@@ -185,7 +186,7 @@ def _extract_feature_vector(output: Dict[str, Any]) -> List[float]:
     return features
 
 
-def _cosine_similarity(vec_a: List[float], vec_b: List[float]) -> float:
+def _cosine_similarity(vec_a: list[float], vec_b: list[float]) -> float:
     """Cosine similarity hesapla."""
     try:
         a = np.array(vec_a)
@@ -203,7 +204,7 @@ def _cosine_similarity(vec_a: List[float], vec_b: List[float]) -> float:
         return 0.0
 
 
-def calculate_long_term_recall(memory: Dict[str, Any]) -> Tuple[float, float]:
+def calculate_long_term_recall(memory: dict[str, Any]) -> tuple[float, float]:
     """
     Long-Term Recall Accuracy (LTRA) ve False Memory Rate (FMR) hesapla.
 
@@ -235,8 +236,8 @@ def calculate_long_term_recall(memory: Dict[str, Any]) -> Tuple[float, float]:
 
 
 def calculate_personality_drift(
-    baseline: List[float],
-    current: List[float]
+    baseline: list[float],
+    current: list[float]
 ) -> float:
     """
     Personality Drift Index (PDI) hesapla.
@@ -278,7 +279,7 @@ def calculate_personality_drift(
         return 0.0
 
 
-def calculate_echo_reactivity(physics: Dict[str, float]) -> float:
+def calculate_echo_reactivity(physics: dict[str, float]) -> float:
     """
     Echo Reactivity Ratio (ERR) hesapla.
 
@@ -309,7 +310,7 @@ def calculate_echo_reactivity(physics: Dict[str, float]) -> float:
         return 0.5
 
 
-def calculate_empathy_safety(narrative: Dict[str, float]) -> float:
+def calculate_empathy_safety(narrative: dict[str, float]) -> float:
     """
     Empathy Safety Score (ESS) hesapla.
 
@@ -340,7 +341,7 @@ def calculate_empathy_safety(narrative: Dict[str, float]) -> float:
         return 0.5
 
 
-def calculate_ethical_violation(policy: Dict[str, Any]) -> float:
+def calculate_ethical_violation(policy: dict[str, Any]) -> float:
     """
     Ethical Violation Rate (EVR) hesapla.
 
@@ -373,7 +374,7 @@ def calculate_ethical_violation(policy: Dict[str, Any]) -> float:
 
 def compute_all_kpis(
     input_data: EmotionalTelemetryInput,
-    reference_outputs: Optional[List[Dict[str, Any]]] = None
+    reference_outputs: list[dict[str, Any]] | None = None
 ) -> EmotionalKPIOutput:
     """
     Tüm KPI'ları hesapla ve döndür.
@@ -439,7 +440,7 @@ def compute_all_kpis(
         )
 
 
-def validate_kpi_thresholds(kpi_output: EmotionalKPIOutput) -> Dict[str, bool]:
+def validate_kpi_thresholds(kpi_output: EmotionalKPIOutput) -> dict[str, bool]:
     """
     KPI'ların sağlık eşiklerini kontrol et.
 

--- a/phionyx_core/monitoring/__init__.py
+++ b/phionyx_core/monitoring/__init__.py
@@ -3,7 +3,7 @@ Monitoring and Safety Modules
 Silent Failure Firewall components
 """
 
-from .baseline_store import BaselineStore, BaselineSnapshot
+from .baseline_store import BaselineSnapshot, BaselineStore
 from .behavioral_drift import (
     BehavioralDriftDetector,
     DriftReport,
@@ -15,9 +15,9 @@ from .circuit_breaker import (
     CircuitState,
 )
 from .human_approval import (
-    HumanApprovalService,
     ApprovalRequest,
     ApprovalStatus,
+    HumanApprovalService,
 )
 from .safe_mode_fallback import (
     SafeModeFallback,

--- a/phionyx_core/monitoring/baseline_store.py
+++ b/phionyx_core/monitoring/baseline_store.py
@@ -3,12 +3,12 @@ Baseline Store Module
 Persistent baseline storage and retrieval for drift detection.
 """
 
-from typing import Dict, List, Optional, Any, Protocol
-from dataclasses import dataclass, asdict
-from datetime import datetime
 import hashlib
 import json
 import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -16,16 +16,16 @@ logger = logging.getLogger(__name__)
 class DatabaseProtocol(Protocol):
     """Protocol for database operations."""
 
-    async def insert(self, table: str, data: Dict[str, Any]) -> Optional[str]:
+    async def insert(self, table: str, data: dict[str, Any]) -> str | None:
         """Insert a record. Returns record ID if successful."""
         ...
 
     async def query(
         self,
         table: str,
-        filters: Optional[Dict[str, Any]] = None,
-        limit: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        filters: dict[str, Any] | None = None,
+        limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Query records. Returns list of records."""
         ...
 
@@ -33,7 +33,7 @@ class DatabaseProtocol(Protocol):
         self,
         table: str,
         record_id: str,
-        updates: Dict[str, Any]
+        updates: dict[str, Any]
     ) -> bool:
         """Update a record. Returns True if successful."""
         ...
@@ -44,16 +44,16 @@ class BaselineSnapshot:
     """Baseline snapshot for drift comparison."""
     baseline_id: str
     version: str
-    session_id: Optional[str]
-    agent_id: Optional[str]
+    session_id: str | None
+    agent_id: str | None
     created_at: datetime
-    reference_outputs: List[str]  # Sample outputs
-    reference_metrics: Dict[str, float]  # phi, entropy, valence, arousal
-    physics_state: Dict[str, float]  # Full state snapshot
+    reference_outputs: list[str]  # Sample outputs
+    reference_metrics: dict[str, float]  # phi, entropy, valence, arousal
+    physics_state: dict[str, float]  # Full state snapshot
     integrity_hash: str  # SHA256 hash
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for storage."""
         data = asdict(self)
         # Convert datetime to ISO string
@@ -61,7 +61,7 @@ class BaselineSnapshot:
         return data
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'BaselineSnapshot':
+    def from_dict(cls, data: dict[str, Any]) -> 'BaselineSnapshot':
         """Create from dictionary."""
         # Convert ISO string to datetime
         if isinstance(data.get('created_at'), str):
@@ -83,7 +83,7 @@ class BaselineStore:
     For now, uses in-memory storage. Database integration via DatabaseProtocol.
     """
 
-    def __init__(self, database: Optional[DatabaseProtocol] = None):
+    def __init__(self, database: DatabaseProtocol | None = None):
         """
         Initialize baseline store.
 
@@ -93,14 +93,14 @@ class BaselineStore:
         """
         self.db = database
         # In-memory fallback storage
-        self._memory_store: Dict[str, BaselineSnapshot] = {}
+        self._memory_store: dict[str, BaselineSnapshot] = {}
 
     def _generate_integrity_hash(
         self,
         version: str,
-        reference_outputs: List[str],
-        reference_metrics: Dict[str, float],
-        physics_state: Dict[str, float]
+        reference_outputs: list[str],
+        reference_metrics: dict[str, float],
+        physics_state: dict[str, float]
     ) -> str:
         """Generate SHA256 integrity hash for baseline data."""
         baseline_data = {
@@ -115,12 +115,12 @@ class BaselineStore:
     async def create_baseline(
         self,
         version: str,
-        session_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        reference_outputs: List[str] = None,
-        reference_metrics: Dict[str, float] = None,
-        physics_state: Dict[str, float] = None,
-        metadata: Dict[str, Any] = None
+        session_id: str | None = None,
+        agent_id: str | None = None,
+        reference_outputs: list[str] = None,
+        reference_metrics: dict[str, float] = None,
+        physics_state: dict[str, float] = None,
+        metadata: dict[str, Any] = None
     ) -> BaselineSnapshot:
         """
         Create and store baseline snapshot.
@@ -185,10 +185,10 @@ class BaselineStore:
 
     async def get_baseline(
         self,
-        session_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        version: Optional[str] = None
-    ) -> Optional[BaselineSnapshot]:
+        session_id: str | None = None,
+        agent_id: str | None = None,
+        version: str | None = None
+    ) -> BaselineSnapshot | None:
         """
         Retrieve baseline snapshot by session/agent/version.
 
@@ -250,10 +250,10 @@ class BaselineStore:
     async def compare_with_baseline(
         self,
         current_output: str,
-        current_metrics: Dict[str, float],
+        current_metrics: dict[str, float],
         baseline: BaselineSnapshot,
-        vector_store: Optional[Any] = None  # VectorStore type
-    ) -> Dict[str, Any]:
+        vector_store: Any | None = None  # VectorStore type
+    ) -> dict[str, Any]:
         """
         Compare current state with baseline.
 
@@ -302,9 +302,9 @@ class BaselineStore:
 
     def _compute_physics_drift(
         self,
-        current_metrics: Dict[str, float],
-        reference_metrics: Dict[str, float]
-    ) -> Dict[str, float]:
+        current_metrics: dict[str, float],
+        reference_metrics: dict[str, float]
+    ) -> dict[str, float]:
         """Compute physics metric drift."""
         drift = {}
         for key in reference_metrics:
@@ -323,7 +323,7 @@ class BaselineStore:
     def _compute_drift_score(
         self,
         semantic_similarity: float,
-        physics_drift: Dict[str, float]
+        physics_drift: dict[str, float]
     ) -> float:
         """
         Compute overall drift score (0.0 = no drift, 1.0 = maximum drift).

--- a/phionyx_core/monitoring/behavioral_drift.py
+++ b/phionyx_core/monitoring/behavioral_drift.py
@@ -3,12 +3,12 @@ Behavioral Drift Detector Module
 Multi-dimensional drift detection engine for Silent Failure Firewall.
 """
 
-from typing import Dict, List, Optional, Literal, Any
+import logging
 from dataclasses import dataclass
 from enum import Enum
-import logging
+from typing import Any, Literal
 
-from .baseline_store import BaselineStore, BaselineSnapshot
+from .baseline_store import BaselineSnapshot, BaselineStore
 
 logger = logging.getLogger(__name__)
 
@@ -26,12 +26,12 @@ class DriftReport:
     """Drift detection report."""
     drift_detected: bool
     drift_score: float  # 0.0-1.0
-    drift_type: List[DriftType]
-    degraded_metrics: List[str]
+    drift_type: list[DriftType]
+    degraded_metrics: list[str]
     recommendation: Literal["allow", "throttle", "block"]
     semantic_similarity: float
-    physics_drift: Dict[str, float]
-    ethics_escalation: Optional[Dict[str, float]]
+    physics_drift: dict[str, float]
+    ethics_escalation: dict[str, float] | None
     confidence: float
 
 
@@ -49,7 +49,7 @@ class BehavioralDriftDetector:
     def __init__(
         self,
         baseline_store: BaselineStore,
-        vector_store: Optional[Any] = None,  # VectorStore type
+        vector_store: Any | None = None,  # VectorStore type
         drift_threshold: float = 0.3,  # 30% degradation threshold
         semantic_threshold: float = 0.7,  # Semantic similarity threshold
         physics_threshold: float = 0.25,  # Physics metric drift threshold
@@ -76,10 +76,10 @@ class BehavioralDriftDetector:
     async def detect_drift(
         self,
         current_output: str,
-        current_metrics: Dict[str, float],
-        ethics_vector: Optional[Dict[str, float]] = None,
+        current_metrics: dict[str, float],
+        ethics_vector: dict[str, float] | None = None,
         session_id: str = None,
-        agent_id: Optional[str] = None
+        agent_id: str | None = None
     ) -> DriftReport:
         """
         Detect behavioral drift across all dimensions.
@@ -185,9 +185,9 @@ class BehavioralDriftDetector:
 
     def _compute_ethics_escalation(
         self,
-        current_ethics: Dict[str, float],
-        baseline_ethics: Dict[str, float]
-    ) -> Dict[str, float]:
+        current_ethics: dict[str, float],
+        baseline_ethics: dict[str, float]
+    ) -> dict[str, float]:
         """
         Compute ethics risk escalation.
 
@@ -230,9 +230,9 @@ class BehavioralDriftDetector:
     def _identify_degraded_metrics(
         self,
         semantic_drift: float,
-        physics_drift: Dict[str, float],
-        ethics_escalation: Optional[Dict[str, float]]
-    ) -> List[str]:
+        physics_drift: dict[str, float],
+        ethics_escalation: dict[str, float] | None
+    ) -> list[str]:
         """Identify which metrics are degraded."""
         degraded = []
 
@@ -256,7 +256,7 @@ class BehavioralDriftDetector:
     def _compute_confidence(
         self,
         baseline: BaselineSnapshot,
-        comparison: Dict[str, Any]
+        comparison: dict[str, Any]
     ) -> float:
         """
         Compute confidence in drift detection (0.0-1.0).

--- a/phionyx_core/monitoring/circuit_breaker.py
+++ b/phionyx_core/monitoring/circuit_breaker.py
@@ -3,11 +3,11 @@ Circuit Breaker Module
 Deterministic circuit breaker with state machine for automatic execution halting.
 """
 
-from typing import Dict, Optional, Any
+import logging
+import time
 from dataclasses import dataclass
 from enum import Enum
-import time
-import logging
+from typing import Any
 
 from .behavioral_drift import DriftReport
 
@@ -25,10 +25,10 @@ class CircuitState(Enum):
 class CircuitBreakerResult:
     """Circuit breaker check result."""
     allowed: bool
-    reason: Optional[str]
+    reason: str | None
     human_approval_required: bool
     safe_mode_required: bool
-    drift_report: Optional[DriftReport] = None
+    drift_report: DriftReport | None = None
 
 
 class CircuitBreaker:
@@ -53,7 +53,7 @@ class CircuitBreaker:
         failure_threshold: int = 3,  # Consecutive failures to open
         recovery_timeout: float = 300.0,  # 5 minutes
         half_open_test_limit: int = 5,  # Max executions in HALF_OPEN
-        ethics_config: Optional[Dict[str, Any]] = None
+        ethics_config: dict[str, Any] | None = None
     ):
         """
         Initialize circuit breaker.
@@ -74,13 +74,13 @@ class CircuitBreaker:
         # State machine
         self.state = CircuitState.CLOSED
         self.failure_count = 0
-        self.last_failure_time: Optional[float] = None
+        self.last_failure_time: float | None = None
         self.half_open_executions = 0
-        self.last_success_time: Optional[float] = None
+        self.last_success_time: float | None = None
 
     async def check_before_execution(
         self,
-        context: Dict[str, Any]  # BlockContext-like dict
+        context: dict[str, Any]  # BlockContext-like dict
     ) -> CircuitBreakerResult:
         """
         Check circuit state before execution (pre-gate).
@@ -225,7 +225,7 @@ class CircuitBreaker:
         """Get current circuit state."""
         return self.state
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get circuit breaker statistics."""
         return {
             "state": self.state.value,

--- a/phionyx_core/monitoring/human_approval.py
+++ b/phionyx_core/monitoring/human_approval.py
@@ -3,11 +3,11 @@ Human Approval Workflow
 Human-in-the-loop mechanism for circuit breaker OPEN state.
 """
 
-from typing import Dict, Any, Optional, List
-from dataclasses import dataclass, asdict
-from enum import Enum
-from datetime import datetime
 import logging
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -26,22 +26,22 @@ class ApprovalRequest:
     request_id: str
     session_id: str
     circuit_state: str
-    drift_report: Dict[str, Any]
+    drift_report: dict[str, Any]
     user_input: str
-    blocked_output: Optional[str]
+    blocked_output: str | None
     created_at: datetime
     expires_at: datetime
     status: ApprovalStatus = ApprovalStatus.PENDING
-    approved_by: Optional[str] = None
-    approved_at: Optional[datetime] = None
-    rejection_reason: Optional[str] = None
-    metadata: Dict[str, Any] = None
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    rejection_reason: str | None = None
+    metadata: dict[str, Any] = None
 
     def __post_init__(self):
         if self.metadata is None:
             self.metadata = {}
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         data = asdict(self)
         data["status"] = self.status.value
@@ -83,17 +83,17 @@ class HumanApprovalService:
         self.max_pending = max_pending_requests
 
         # In-memory storage (can be replaced with database)
-        self._requests: Dict[str, ApprovalRequest] = {}
-        self._session_requests: Dict[str, List[str]] = {}  # session_id -> [request_ids]
+        self._requests: dict[str, ApprovalRequest] = {}
+        self._session_requests: dict[str, list[str]] = {}  # session_id -> [request_ids]
 
     def create_approval_request(
         self,
         session_id: str,
         circuit_state: str,
-        drift_report: Dict[str, Any],
+        drift_report: dict[str, Any],
         user_input: str,
-        blocked_output: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        blocked_output: str | None = None,
+        metadata: dict[str, Any] | None = None
     ) -> ApprovalRequest:
         """
         Create approval request.
@@ -148,7 +148,7 @@ class HumanApprovalService:
         logger.info(f"Created approval request: {request_id} for session {session_id}")
         return request
 
-    def get_request(self, request_id: str) -> Optional[ApprovalRequest]:
+    def get_request(self, request_id: str) -> ApprovalRequest | None:
         """Get approval request by ID."""
         request = self._requests.get(request_id)
         if request and request.is_expired() and request.status == ApprovalStatus.PENDING:
@@ -216,8 +216,8 @@ class HumanApprovalService:
 
     def get_pending_requests(
         self,
-        session_id: Optional[str] = None
-    ) -> List[ApprovalRequest]:
+        session_id: str | None = None
+    ) -> list[ApprovalRequest]:
         """
         Get pending requests.
 
@@ -242,7 +242,7 @@ class HumanApprovalService:
     def get_session_requests(
         self,
         session_id: str
-    ) -> List[ApprovalRequest]:
+    ) -> list[ApprovalRequest]:
         """Get all requests for a session."""
         request_ids = self._session_requests.get(session_id, [])
         requests = [self._requests[rid] for rid in request_ids if rid in self._requests]

--- a/phionyx_core/monitoring/safe_mode_fallback.py
+++ b/phionyx_core/monitoring/safe_mode_fallback.py
@@ -3,10 +3,10 @@ Safe-Mode Fallback Mechanism
 Graceful degradation when circuit breaker is OPEN.
 """
 
-from typing import Dict, Any, Optional
+import logging
 from dataclasses import dataclass
 from datetime import datetime
-import logging
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ class SafeModeResponse:
     degraded: bool
     fallback_reason: str
     cached: bool
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
 
 
 class SafeModeFallback:
@@ -50,14 +50,14 @@ class SafeModeFallback:
         self.safe_response_template = safe_response_template
 
         # In-memory cache (can be replaced with Redis/database)
-        self._response_cache: Dict[str, Dict[str, Any]] = {}
+        self._response_cache: dict[str, dict[str, Any]] = {}
 
     def get_cached_response(
         self,
         session_id: str,
         user_input: str,
         similarity_threshold: float = 0.7
-    ) -> Optional[SafeModeResponse]:
+    ) -> SafeModeResponse | None:
         """
         Retrieve cached response if available and similar.
 
@@ -107,7 +107,7 @@ class SafeModeFallback:
         self,
         user_input: str,
         circuit_state: str,
-        drift_info: Optional[Dict[str, Any]] = None
+        drift_info: dict[str, Any] | None = None
     ) -> SafeModeResponse:
         """
         Generate minimal safe response.
@@ -147,7 +147,7 @@ class SafeModeFallback:
         session_id: str,
         user_input: str,
         response_text: str,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: dict[str, Any] | None = None
     ) -> None:
         """
         Cache response for future use.
@@ -196,7 +196,7 @@ class SafeModeFallback:
         union = len(words1 | words2)
         return intersection / union if union > 0 else 0.0
 
-    def clear_cache(self, session_id: Optional[str] = None) -> None:
+    def clear_cache(self, session_id: str | None = None) -> None:
         """
         Clear cache for session or all sessions.
 

--- a/phionyx_core/narrative/__init__.py
+++ b/phionyx_core/narrative/__init__.py
@@ -11,17 +11,17 @@ The NarrativeEngine automatically:
 - Supports RAG context (Memory), GraphRAG (Intuition), and Seasonal context
 """
 
-from .engine import NarrativeEngine, NarrativeConfig
+from .engine import NarrativeConfig, NarrativeEngine
 
 # Lore mapping (moved from core-narrative)
 from .lore_mapping import (
-    LoreMapping,
+    ALL_MAPPINGS,
     InterventionMapping,
-    RiskLevel,
     InterventionType,
-    get_lore_mapping,
+    LoreMapping,
+    RiskLevel,
     get_intervention_mapping,
-    ALL_MAPPINGS
+    get_lore_mapping,
 )
 
 __all__ = [

--- a/phionyx_core/narrative/engine.py
+++ b/phionyx_core/narrative/engine.py
@@ -10,10 +10,10 @@ This module provides narrative generation that automatically enforces:
 The App layer should NOT manually add these constraints - the SDK enforces them automatically.
 """
 
-import os
 import logging
-from typing import Dict, Optional, Any, TYPE_CHECKING
+import os
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
 
 if TYPE_CHECKING:
     from phionyx_core.contracts.llm_provider import LLMProviderProtocol
@@ -72,7 +72,7 @@ class NarrativeEngine:
 
     def __init__(
         self,
-        config: Optional[NarrativeConfig] = None,
+        config: NarrativeConfig | None = None,
         llm_provider: Optional['LLMProviderProtocol'] = None
     ):
         """
@@ -103,7 +103,7 @@ class NarrativeEngine:
     def _inject_physics_constraints(
         self,
         system_prompt: str,
-        physics_state: Dict[str, float]
+        physics_state: dict[str, float]
     ) -> str:
         """
         Automatically inject Physics constraints into system prompt.
@@ -174,7 +174,7 @@ class NarrativeEngine:
     def _apply_safety_filters(
         self,
         prompt: str,
-        physics_state: Dict[str, float]
+        physics_state: dict[str, float]
     ) -> str:
         """
         Automatically apply Safety filters (Ethics Engine).
@@ -208,12 +208,12 @@ class NarrativeEngine:
     async def generate(
         self,
         context: str,
-        physics_state: Dict[str, float],
-        system_prompt: Optional[str] = None,
-        memory_context: Optional[str] = None,
-        intuitive_context: Optional[str] = None,
-        seasonal_context: Optional[str] = None,
-        user_prompt: Optional[str] = None,
+        physics_state: dict[str, float],
+        system_prompt: str | None = None,
+        memory_context: str | None = None,
+        intuitive_context: str | None = None,
+        seasonal_context: str | None = None,
+        user_prompt: str | None = None,
         **kwargs
     ) -> str:
         """
@@ -327,7 +327,7 @@ class NarrativeEngine:
         )
         return None
 
-    async def check_model_availability(self) -> Dict[str, Any]:
+    async def check_model_availability(self) -> dict[str, Any]:
         """Check if configured model is available via LLM service."""
         llm_service = self._get_llm_provider()
         if not llm_service or not llm_service.available:

--- a/phionyx_core/narrative/lore_mapping.py
+++ b/phionyx_core/narrative/lore_mapping.py
@@ -10,7 +10,6 @@ Version: 1.0.0
 Status: Production Ready
 """
 
-from typing import Dict, List, Optional
 from dataclasses import dataclass
 from enum import Enum
 
@@ -41,8 +40,8 @@ class LoreMapping:
     lore_theme: str
     lore_description: str
     universe_mechanic: str
-    npc_suggestion: Optional[str] = None
-    world_location: Optional[str] = None
+    npc_suggestion: str | None = None
+    world_location: str | None = None
 
 
 @dataclass
@@ -58,7 +57,7 @@ class InterventionMapping:
 # 1. EMOTIONAL RISK & BEHAVIOR MAPPING
 # ============================================================================
 
-EMOTIONAL_RISK_MAPPING: List[LoreMapping] = [
+EMOTIONAL_RISK_MAPPING: list[LoreMapping] = [
     LoreMapping(
         ofsted_finding="Anxiety (exam, social)",
         clinical_meaning="Aşırı belirsizlik, kaçınma",
@@ -137,7 +136,7 @@ EMOTIONAL_RISK_MAPPING: List[LoreMapping] = [
 # 2. SOCIAL BEHAVIOR & RELATIONSHIP MAPPING
 # ============================================================================
 
-SOCIAL_BEHAVIOR_MAPPING: List[LoreMapping] = [
+SOCIAL_BEHAVIOR_MAPPING: list[LoreMapping] = [
     LoreMapping(
         ofsted_finding="Peer Conflict",
         clinical_meaning="Akran çatışması",
@@ -198,7 +197,7 @@ SOCIAL_BEHAVIOR_MAPPING: List[LoreMapping] = [
 # 3. ACADEMIC BEHAVIOR & SCHOOL RISKS MAPPING
 # ============================================================================
 
-ACADEMIC_BEHAVIOR_MAPPING: List[LoreMapping] = [
+ACADEMIC_BEHAVIOR_MAPPING: list[LoreMapping] = [
     LoreMapping(
         ofsted_finding="Exam Stress",
         clinical_meaning="Performans kaygısı",
@@ -250,7 +249,7 @@ ACADEMIC_BEHAVIOR_MAPPING: List[LoreMapping] = [
 # 4. INTERVENTION TYPE → LORE MECHANIC MAPPING
 # ============================================================================
 
-INTERVENTION_MAPPING: List[InterventionMapping] = [
+INTERVENTION_MAPPING: list[InterventionMapping] = [
     InterventionMapping(
         intervention_type=InterventionType.CBT_REFRAMING,
         pedagogical_purpose="Düşünce yeniden yapılandırma",
@@ -293,7 +292,7 @@ INTERVENTION_MAPPING: List[InterventionMapping] = [
 # 5. RISK LEVEL → SCENARIO DIFFICULTY MAPPING
 # ============================================================================
 
-RISK_TO_DIFFICULTY: Dict[RiskLevel, Dict[str, any]] = {
+RISK_TO_DIFFICULTY: dict[RiskLevel, dict[str, any]] = {
     RiskLevel.LOW: {
         "teacher_view": "Monitor",
         "student_experience": "Hafif, keşif odaklı",
@@ -324,7 +323,7 @@ RISK_TO_DIFFICULTY: Dict[RiskLevel, Dict[str, any]] = {
 # 6. HELPER FUNCTIONS
 # ============================================================================
 
-def get_lore_mapping(ofsted_finding: str) -> Optional[LoreMapping]:
+def get_lore_mapping(ofsted_finding: str) -> LoreMapping | None:
     """Get lore mapping for a given Ofsted finding."""
     all_mappings = (
         EMOTIONAL_RISK_MAPPING +
@@ -339,7 +338,7 @@ def get_lore_mapping(ofsted_finding: str) -> Optional[LoreMapping]:
     return None
 
 
-def get_intervention_mapping(intervention_type: InterventionType) -> Optional[InterventionMapping]:
+def get_intervention_mapping(intervention_type: InterventionType) -> InterventionMapping | None:
     """Get lore mechanic for a given intervention type."""
     for mapping in INTERVENTION_MAPPING:
         if mapping.intervention_type == intervention_type:
@@ -348,7 +347,7 @@ def get_intervention_mapping(intervention_type: InterventionType) -> Optional[In
     return None
 
 
-def get_risk_difficulty(risk_level: RiskLevel) -> Dict[str, any]:
+def get_risk_difficulty(risk_level: RiskLevel) -> dict[str, any]:
     """Get scenario difficulty parameters for a given risk level."""
     return RISK_TO_DIFFICULTY.get(risk_level, RISK_TO_DIFFICULTY[RiskLevel.MEDIUM])
 

--- a/phionyx_core/orchestrator/__init__.py
+++ b/phionyx_core/orchestrator/__init__.py
@@ -5,8 +5,8 @@ Orchestrator Package
 Core orchestration logic for the Phionyx pipeline.
 """
 
-from .echo_orchestrator import EchoOrchestrator, OrchestratorServices
 from .block_factory import create_all_blocks
+from .echo_orchestrator import EchoOrchestrator, OrchestratorServices
 
 __all__ = [
     'EchoOrchestrator',

--- a/phionyx_core/orchestrator/block_factory.py
+++ b/phionyx_core/orchestrator/block_factory.py
@@ -8,67 +8,66 @@ Contract v3.8.0.
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Any
 
 from ..pipeline.blocks import (
-    # Core blocks (31)
-    TimeUpdateSotBlock,
-    EchoOntologyEventTraceBlock,
-    EmotionFromNeurotransmitterBlock,
-    EmotionEstimationBlock,
-    CreateScenarioFrameBlock,
-    InitializeUnifiedStateBlock,
-    UkfPredictBlock,
-    CognitiveLayerBlock,
-    EchoOntologyTransformationBlock,
-    InputSafetyGateBlock,  # Combined: low_input_gate + safety_layer_pre_cep
-    IntentClassificationBlock,  # Intent classification block
-    ContextRetrievalRagBlock,  # Context retrieval RAG block
-    EntropyAmplitudePreGateBlock,
-    CepEvaluationBlock,
-    EthicsPreResponseBlock,
-    NarrativeLayerBlock,
-    EthicsPostResponseBlock,
-    BehavioralDriftDetectionBlock,  # Silent Failure Firewall
-    UnifiedStateUpdateEscBlock,
-    PhiPublishBlock,
-    EscStateHelperUpdateBlock,
-    DriveCoherenceUpdateBlock,
-    CoherenceQaBlock,
-    EntropyAmplitudePostGateBlock,
-    NeurotransmitterMemoryGrowthBlock,
-    AuditLayerBlock,
-    PhiFinalizeBlock,
-    StateUpdatePhysicsBlock,
-    ResponseBuildBlock,
-    PhiComputationBlock,
-    EntropyComputationBlock,
-    # v3.0.0 AGI World Model blocks (8)
-    KillSwitchGateBlock,
-    PerceptualFrameEmitBlock,
-    GoalEvaluationBlock,
-    WorldStateSnapshotBlock,
-    ConfidenceFusionBlock,
-    ArbitrationResolveBlock,
     ActionIntentGateBlock,
-    LearningGateBlock,
-    WorkspaceBroadcastBlock,
-    # AGI Sprint Pipeline Binding blocks S2-S5 (11)
-    SelfModelAssessmentBlock,
-    KnowledgeBoundaryCheckBlock,
-    MemoryConsolidationBlock,
+    ArbitrationResolveBlock,
+    AuditLayerBlock,
+    BehavioralDriftDetectionBlock,  # Silent Failure Firewall
     CausalGraphUpdateBlock,
     CausalInterventionBlock,
-    CounterfactualAnalysisBlock,
-    RootCauseAnalysisBlock,
     CausalSimulationBlock,
-    TrustEvaluationBlock,
-    GoalDecompositionBlock,
+    CepEvaluationBlock,
+    CognitiveLayerBlock,
+    CoherenceQaBlock,
+    ConfidenceFusionBlock,
+    ContextRetrievalRagBlock,  # Context retrieval RAG block
+    CounterfactualAnalysisBlock,
+    CreateScenarioFrameBlock,
     DeliberativeEthicsGateBlock,
+    DriveCoherenceUpdateBlock,
+    EchoOntologyEventTraceBlock,
+    EchoOntologyTransformationBlock,
+    EmotionEstimationBlock,
+    EmotionFromNeurotransmitterBlock,
+    EntropyAmplitudePostGateBlock,
+    EntropyAmplitudePreGateBlock,
+    EntropyComputationBlock,
+    EscStateHelperUpdateBlock,
+    EthicsPostResponseBlock,
+    EthicsPreResponseBlock,
+    GoalDecompositionBlock,
+    GoalEvaluationBlock,
+    InitializeUnifiedStateBlock,
+    InputSafetyGateBlock,  # Combined: low_input_gate + safety_layer_pre_cep
+    IntentClassificationBlock,  # Intent classification block
+    # v3.0.0 AGI World Model blocks (8)
+    KillSwitchGateBlock,
+    KnowledgeBoundaryCheckBlock,
+    LearningGateBlock,
+    MemoryConsolidationBlock,
+    NarrativeLayerBlock,
+    NeurotransmitterMemoryGrowthBlock,
     # Feedback Loop Block (v3.6.0)
     OutcomeFeedbackBlock,
+    PerceptualFrameEmitBlock,
+    PhiComputationBlock,
+    PhiFinalizeBlock,
+    PhiPublishBlock,
+    ResponseBuildBlock,
+    RootCauseAnalysisBlock,
+    # AGI Sprint Pipeline Binding blocks S2-S5 (11)
+    SelfModelAssessmentBlock,
+    StateUpdatePhysicsBlock,
+    # Core blocks (31)
+    TimeUpdateSotBlock,
+    TrustEvaluationBlock,
+    UkfPredictBlock,
+    UnifiedStateUpdateEscBlock,
+    WorkspaceBroadcastBlock,
+    WorldStateSnapshotBlock,
 )
-
 from .echo_orchestrator import OrchestratorServices
 
 logger = logging.getLogger(__name__)
@@ -85,10 +84,10 @@ except ImportError:
 
 def create_all_blocks(
     services: OrchestratorServices,
-    engine_instance: Optional[Any] = None,
-    participant_id: Optional[str] = None,
-    emotion_cache: Optional[Any] = None
-) -> Dict[str, Any]:
+    engine_instance: Any | None = None,
+    participant_id: str | None = None,
+    emotion_cache: Any | None = None
+) -> dict[str, Any]:
     """
     Create all 43 pipeline blocks with their dependencies.
 
@@ -181,7 +180,7 @@ def create_all_blocks(
                 """Initialize adapter with processor."""
                 self.processor = processor
 
-            def get_emotion(self, user_input: str, mode: Optional[str] = None) -> Any:
+            def get_emotion(self, user_input: str, mode: str | None = None) -> Any:
                 """Get emotion from neurotransmitter."""
                 return self.processor.get_emotion_from_neurotransmitter(
                     user_input=user_input,
@@ -283,7 +282,7 @@ def create_all_blocks(
             def predict(self, unified_state: Any, time_delta: float = 1.0) -> Any:
                 """Run UKF prediction step using real process model."""
                 # Build current_state dict from unified_state for process model
-                current_state: Dict[str, Any] = {}
+                current_state: dict[str, Any] = {}
                 if unified_state is not None:
                     for attr in ("phi", "entropy", "valence", "arousal", "trust", "regulation"):
                         val = getattr(unified_state, attr, None)
@@ -566,12 +565,12 @@ def create_all_blocks(
     # 18.5. behavioral_drift_detection - Silent Failure Firewall (NEW)
     # Optional: Only create if monitoring services are available
     try:
+        from phionyx_core.memory.vector_store import VectorStore  # noqa: F401
         from phionyx_core.monitoring import (
             BaselineStore,
             BehavioralDriftDetector,
             CircuitBreaker,
         )
-        from phionyx_core.memory.vector_store import VectorStore  # noqa: F401
 
         # Get vector store if available
         vector_store = None
@@ -654,7 +653,7 @@ def create_all_blocks(
             self,
             unified_state: Any,
             phi_value: float,
-            phi_components: Optional[Any] = None
+            phi_components: Any | None = None
         ) -> Any:
             """
             Publish phi value to unified state.
@@ -739,7 +738,7 @@ def create_all_blocks(
             def __init__(self, processor: Any) -> None:
                 self.processor = processor
 
-            def apply_gate(self, physics_state: Dict) -> Dict:
+            def apply_gate(self, physics_state: dict) -> dict:
                 """Apply entropy/amplitude gate after narrative generation."""
                 if hasattr(self.processor, 'apply_entropy_amplitude_post_gate'):
                     return self.processor.apply_entropy_amplitude_post_gate(

--- a/phionyx_core/orchestrator/dependency_validator.py
+++ b/phionyx_core/orchestrator/dependency_validator.py
@@ -8,7 +8,6 @@ Validates block execution order against dependency graph.
 import json
 import logging
 from pathlib import Path
-from typing import List, Dict, Set, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ class DependencyValidator:
     Validates block execution order against dependency graph.
     """
 
-    def __init__(self, dependencies_file: Optional[Path] = None):
+    def __init__(self, dependencies_file: Path | None = None):
         """
         Initialize validator.
 
@@ -31,15 +30,15 @@ class DependencyValidator:
             dependencies_file = current_dir / 'block_dependencies.json'
 
         self.dependencies_file = dependencies_file
-        self.dependencies: Dict[str, Dict] = {}
-        self.metadata_producers: Dict[str, List[str]] = {}
+        self.dependencies: dict[str, dict] = {}
+        self.metadata_producers: dict[str, list[str]] = {}
 
         self._load_dependencies()
 
     def _load_dependencies(self) -> None:
         """Load dependency graph from JSON file."""
         try:
-            with open(self.dependencies_file, 'r', encoding='utf-8') as f:
+            with open(self.dependencies_file, encoding='utf-8') as f:
                 data = json.load(f)
                 self.dependencies = data.get('dependencies', {})
                 self.metadata_producers = data.get('metadata_producers', {})
@@ -53,7 +52,7 @@ class DependencyValidator:
             self.dependencies = {}
             self.metadata_producers = {}
 
-    def validate_execution_order(self, block_order: List[str]) -> tuple[bool, List[str]]:
+    def validate_execution_order(self, block_order: list[str]) -> tuple[bool, list[str]]:
         """
         Validate block execution order against dependency graph.
 
@@ -68,7 +67,7 @@ class DependencyValidator:
             return True, []
 
         violations = []
-        executed_blocks: Set[str] = set()
+        executed_blocks: set[str] = set()
 
         for block_id in block_order:
             if block_id not in self.dependencies:
@@ -89,7 +88,7 @@ class DependencyValidator:
 
         return len(violations) == 0, violations
 
-    def get_block_dependencies(self, block_id: str) -> List[str]:
+    def get_block_dependencies(self, block_id: str) -> list[str]:
         """
         Get list of block IDs that must execute before this block.
 
@@ -104,7 +103,7 @@ class DependencyValidator:
 
         return self.dependencies[block_id].get('dependencies', [])
 
-    def get_metadata_producers(self, metadata_key: str) -> List[str]:
+    def get_metadata_producers(self, metadata_key: str) -> list[str]:
         """
         Get list of block IDs that produce a specific metadata key.
 
@@ -116,7 +115,7 @@ class DependencyValidator:
         """
         return self.metadata_producers.get(metadata_key, [])
 
-    def get_block_writes(self, block_id: str) -> Set[str]:
+    def get_block_writes(self, block_id: str) -> set[str]:
         """
         Get set of metadata keys that this block writes to.
 
@@ -132,7 +131,7 @@ class DependencyValidator:
         writes = self.dependencies[block_id].get('writes', [])
         return set(writes) if writes else set()
 
-    def get_block_reads(self, block_id: str) -> Set[str]:
+    def get_block_reads(self, block_id: str) -> set[str]:
         """
         Get set of metadata keys that this block reads from.
 

--- a/phionyx_core/orchestrator/dynamic_grouping.py
+++ b/phionyx_core/orchestrator/dynamic_grouping.py
@@ -11,7 +11,6 @@ Features:
 """
 
 import logging
-from typing import Dict, Optional, List, Set
 from dataclasses import dataclass
 
 from .parallel_executor import ParallelGroup
@@ -23,9 +22,9 @@ logger = logging.getLogger(__name__)
 class IntentBasedGroupConfig:
     """Configuration for intent-based parallel groups."""
     intent: str
-    parallel_groups: List[List[str]]  # List of block groups that can run in parallel
-    skip_blocks: Set[str] = None  # Blocks to skip for this intent
-    preserve_blocks: Set[str] = None  # Blocks that must always run
+    parallel_groups: list[list[str]]  # List of block groups that can run in parallel
+    skip_blocks: set[str] = None  # Blocks to skip for this intent
+    preserve_blocks: set[str] = None  # Blocks that must always run
 
     def __post_init__(self):
         """Initialize default sets."""
@@ -47,7 +46,7 @@ class DynamicGrouping:
 
     def __init__(self):
         """Initialize dynamic grouping."""
-        self.configs: Dict[str, IntentBasedGroupConfig] = {}
+        self.configs: dict[str, IntentBasedGroupConfig] = {}
         self._initialize_configs()
 
     def _initialize_configs(self) -> None:
@@ -141,10 +140,10 @@ class DynamicGrouping:
 
     def get_groups_for_intent(
         self,
-        intent: Optional[str],
-        block_order: List[str],
-        executed_blocks: Set[str]
-    ) -> List[ParallelGroup]:
+        intent: str | None,
+        block_order: list[str],
+        executed_blocks: set[str]
+    ) -> list[ParallelGroup]:
         """
         Get parallel groups for specific intent.
 
@@ -192,7 +191,7 @@ class DynamicGrouping:
 
         return groups
 
-    def get_blocks_to_skip_for_intent(self, intent: Optional[str]) -> Set[str]:
+    def get_blocks_to_skip_for_intent(self, intent: str | None) -> set[str]:
         """
         Get blocks to skip for specific intent.
 
@@ -214,7 +213,7 @@ class DynamicGrouping:
     def should_preserve_block(
         self,
         block_id: str,
-        intent: Optional[str]
+        intent: str | None
     ) -> bool:
         """
         Check if block should be preserved (always run) for intent.

--- a/phionyx_core/orchestrator/early_exit_optimizer.py
+++ b/phionyx_core/orchestrator/early_exit_optimizer.py
@@ -12,8 +12,8 @@ Features:
 """
 
 import logging
-from typing import Dict, Any, Optional, Set
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,8 @@ class EarlyExitCondition:
     """Early exit condition definition."""
     condition_type: str  # "intent", "safety", "template"
     block_id: str
-    skip_blocks: Set[str]  # Blocks to skip when condition is met
-    preserve_blocks: Set[str]  # Blocks that must always run (always-on)
+    skip_blocks: set[str]  # Blocks to skip when condition is met
+    preserve_blocks: set[str]  # Blocks that must always run (always-on)
 
 
 class EarlyExitOptimizer:
@@ -39,7 +39,7 @@ class EarlyExitOptimizer:
 
     def __init__(self):
         """Initialize early exit optimizer."""
-        self.conditions: Dict[str, EarlyExitCondition] = {}
+        self.conditions: dict[str, EarlyExitCondition] = {}
         self.metrics = {
             "early_exits": 0,
             "intent_based_exits": 0,
@@ -115,8 +115,8 @@ class EarlyExitOptimizer:
         self,
         block_id: str,
         context: Any,
-        result: Optional[Any] = None
-    ) -> Optional[EarlyExitCondition]:
+        result: Any | None = None
+    ) -> EarlyExitCondition | None:
         """
         Check if pipeline should short-circuit based on current block result.
 
@@ -170,7 +170,7 @@ class EarlyExitOptimizer:
         self,
         condition: EarlyExitCondition,
         current_block_id: str
-    ) -> Set[str]:
+    ) -> set[str]:
         """
         Get list of blocks to skip based on early exit condition.
 
@@ -192,7 +192,7 @@ class EarlyExitOptimizer:
 
         return blocks_to_skip
 
-    def get_metrics(self) -> Dict[str, int]:
+    def get_metrics(self) -> dict[str, int]:
         """
         Get early exit metrics.
 

--- a/phionyx_core/orchestrator/echo_orchestrator.py
+++ b/phionyx_core/orchestrator/echo_orchestrator.py
@@ -10,28 +10,30 @@ It has NO dependencies on FastAPI, HTTP, or database models.
 
 import logging
 import time
-from typing import Dict, Any, Optional, Protocol, TYPE_CHECKING
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional, Protocol
 
-from ..pipeline.base import PipelineBlock, BlockContext, BlockResult
+from ..pipeline.base import BlockContext, BlockResult, PipelineBlock
 
 if TYPE_CHECKING:
     from ..profiles.schema import ExecutionGuardConfig
 # Import canonical block order
 from phionyx_core.contracts.telemetry import get_canonical_blocks as get_canonical_block_order
+
 from .dependency_validator import DependencyValidator
-from .rollback_manager import RollbackManager
-from .parallel_executor import ParallelExecutor
-from .early_exit_optimizer import EarlyExitOptimizer
 from .dynamic_grouping import DynamicGrouping
+from .early_exit_optimizer import EarlyExitOptimizer
 from .execution_guard import ExecutionGuard
+from .parallel_executor import ParallelExecutor
+from .rollback_manager import RollbackManager
 
 logger = logging.getLogger(__name__)
 
 # OpenTelemetry integration (optional)
 try:
-    from phionyx_core.telemetry import get_tracer, is_opentelemetry_enabled
     from opentelemetry.trace import Status, StatusCode
+
+    from phionyx_core.telemetry import get_tracer, is_opentelemetry_enabled
     OPENTELEMETRY_AVAILABLE = True
 except ImportError:
     OPENTELEMETRY_AVAILABLE = False
@@ -44,11 +46,11 @@ except ImportError:
 
 class TelemetryCollectorProtocol(Protocol):
     """Protocol for telemetry collection (to avoid direct dependency)."""
-    def start_block(self, block_id: str, timing_label: str, metadata: Optional[Dict[str, Any]] = None) -> None:
+    def start_block(self, block_id: str, timing_label: str, metadata: dict[str, Any] | None = None) -> None:
         """Start tracking a block."""
         ...
 
-    def end_block(self, block_id: str, status: str = "ok", events: Optional[list] = None) -> None:
+    def end_block(self, block_id: str, status: str = "ok", events: list | None = None) -> None:
         """End tracking a block."""
         ...
 
@@ -62,26 +64,26 @@ class OrchestratorServices:
     This allows the orchestrator to remain in core without bridge dependencies.
     """
     # Processor services
-    processor: Optional[Any] = None  # EngineProcessor
-    response_generator: Optional[Any] = None  # EngineResponseGenerator
+    processor: Any | None = None  # EngineProcessor
+    response_generator: Any | None = None  # EngineResponseGenerator
 
     # Physics/Math services
-    phi_engine: Optional[Any] = None  # PhiEngine
-    entropy_engine: Optional[Any] = None  # EntropyEngine
+    phi_engine: Any | None = None  # PhiEngine
+    entropy_engine: Any | None = None  # EntropyEngine
 
     # Emotion services
-    emotion_estimator: Optional[Any] = None  # EmotionEstimator
-    neurotransmitter: Optional[Any] = None  # NeurotransmitterEngine
+    emotion_estimator: Any | None = None  # EmotionEstimator
+    neurotransmitter: Any | None = None  # NeurotransmitterEngine
 
     # State services
-    state_store: Optional[Any] = None  # StateStore
-    echo_state_store: Optional[Any] = None  # EchoStateStore (legacy)
+    state_store: Any | None = None  # StateStore
+    echo_state_store: Any | None = None  # EchoStateStore (legacy)
 
     # Time management
-    time_managers: Optional[Dict[str, Any]] = None  # Dict of TimeManager instances
+    time_managers: dict[str, Any] | None = None  # Dict of TimeManager instances
 
     # Additional services (can be extended)
-    additional_services: Optional[Dict[str, Any]] = None
+    additional_services: dict[str, Any] | None = None
 
     def __post_init__(self):
         """Initialize default values."""
@@ -107,7 +109,7 @@ class EchoOrchestrator:
     def __init__(
         self,
         services: OrchestratorServices,
-        telemetry_collector: Optional[TelemetryCollectorProtocol] = None,
+        telemetry_collector: TelemetryCollectorProtocol | None = None,
         enable_rollback: bool = True,
         enable_parallel: bool = True,
         enable_execution_guard: bool = True,
@@ -135,7 +137,7 @@ class EchoOrchestrator:
         self.block_order = get_canonical_block_order()
 
         # Block registry (will be populated with block implementations)
-        self.blocks: Dict[str, PipelineBlock] = {}
+        self.blocks: dict[str, PipelineBlock] = {}
 
         # CRITICAL: Execution guard (infinite loop prevention)
         # Multiple protection layers: iteration limit, block execution tracking, timeout, circular sequence detection
@@ -234,7 +236,7 @@ class EchoOrchestrator:
         blob = _json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
         return hashlib.sha256(blob).hexdigest()
 
-    def _build_regeneration_constraints(self, context: "BlockContext") -> Dict[str, Any]:
+    def _build_regeneration_constraints(self, context: "BlockContext") -> dict[str, Any]:
         """Assemble constraint payload written to ``metadata['regeneration_constraints']``."""
         import hashlib
 
@@ -319,7 +321,7 @@ class EchoOrchestrator:
     async def execute_pipeline(
         self,
         context: BlockContext
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Execute the full 46-block pipeline (v3.8.0).
 
@@ -1014,23 +1016,23 @@ class EchoOrchestrator:
         card_title: str = "",
         scene_context: str = "",
         card_result: str = "neutral",
-        scenario_id: Optional[str] = None,
-        scenario_step_id: Optional[str] = None,
-        session_id: Optional[str] = None,
-        participant: Optional[Any] = None,  # Participant abstraction
-        mode: Optional[str] = None,  # Runtime mode (e.g., "toygar_core", "story", "game_scenario")
-        strategy: Optional[str] = None,  # Runtime strategy (e.g., "normal", "stabilize", "comfort")
-        envelope_message_id: Optional[str] = None,  # TurnEnvelope message_id for transcript tracking
-        envelope_turn_id: Optional[int] = None,  # TurnEnvelope turn_id for transcript tracking
-        envelope_user_text_sha256: Optional[str] = None,  # TurnEnvelope user_text_sha256 for integrity
-        capabilities: Optional[Any] = None,  # RunCapabilities
-        capability_deriver: Optional[Any] = None,  # CapabilityDeriverProtocol
+        scenario_id: str | None = None,
+        scenario_step_id: str | None = None,
+        session_id: str | None = None,
+        participant: Any | None = None,  # Participant abstraction
+        mode: str | None = None,  # Runtime mode (e.g., "toygar_core", "story", "game_scenario")
+        strategy: str | None = None,  # Runtime strategy (e.g., "normal", "stabilize", "comfort")
+        envelope_message_id: str | None = None,  # TurnEnvelope message_id for transcript tracking
+        envelope_turn_id: int | None = None,  # TurnEnvelope turn_id for transcript tracking
+        envelope_user_text_sha256: str | None = None,  # TurnEnvelope user_text_sha256 for integrity
+        capabilities: Any | None = None,  # RunCapabilities
+        capability_deriver: Any | None = None,  # CapabilityDeriverProtocol
         current_amplitude: float = 5.0,
         current_entropy: float = 0.5,
         current_integrity: float = 100.0,
-        previous_phi: Optional[float] = None,
+        previous_phi: float | None = None,
         **kwargs
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Main entry point for pipeline execution.
 

--- a/phionyx_core/orchestrator/execution_guard.py
+++ b/phionyx_core/orchestrator/execution_guard.py
@@ -11,8 +11,8 @@ Multiple layers of protection against infinite loops and runaway execution:
 """
 import logging
 import time
-from typing import Dict, List, Optional, TYPE_CHECKING
 from collections import defaultdict
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from phionyx_core.profiles.schema import ExecutionGuardConfig
@@ -34,7 +34,7 @@ class ExecutionGuard:
 
     def __init__(
         self,
-        max_iterations: Optional[int] = None,
+        max_iterations: int | None = None,
         max_block_executions: int = 2,  # Same block can execute max 2 times
         max_execution_time: float = 300.0,  # 5 minutes max
         max_repeated_sequence: int = 3  # Same sequence of 3 blocks repeated
@@ -57,14 +57,14 @@ class ExecutionGuard:
 
         # Execution tracking
         self.iteration_count = 0
-        self.block_execution_count: Dict[str, int] = defaultdict(int)
-        self.execution_sequence: List[str] = []  # Track execution order
-        self.start_time: Optional[float] = None
-        self.last_block_id: Optional[str] = None
+        self.block_execution_count: dict[str, int] = defaultdict(int)
+        self.execution_sequence: list[str] = []  # Track execution order
+        self.start_time: float | None = None
+        self.last_block_id: str | None = None
         self.consecutive_repeats: int = 0
 
         # Violations
-        self.violations: List[str] = []
+        self.violations: list[str] = []
         self.is_safe = True
 
     @classmethod
@@ -97,7 +97,7 @@ class ExecutionGuard:
         guard._max_iterations_multiplier = config.max_iterations_multiplier
         return guard
 
-    def reset(self, block_order_length: Optional[int] = None):
+    def reset(self, block_order_length: int | None = None):
         """Reset guard for new pipeline execution."""
         if self.max_iterations is None and block_order_length:
             self.max_iterations = block_order_length * self._max_iterations_multiplier
@@ -110,7 +110,7 @@ class ExecutionGuard:
         self.violations.clear()
         self.is_safe = True
 
-    def check_iteration_limit(self) -> tuple[bool, Optional[str]]:
+    def check_iteration_limit(self) -> tuple[bool, str | None]:
         """
         Check if iteration limit exceeded.
 
@@ -124,7 +124,7 @@ class ExecutionGuard:
             return False, violation
         return True, None
 
-    def check_block_execution_limit(self, block_id: str) -> tuple[bool, Optional[str]]:
+    def check_block_execution_limit(self, block_id: str) -> tuple[bool, str | None]:
         """
         Check if block execution limit exceeded.
 
@@ -157,7 +157,7 @@ class ExecutionGuard:
 
         return True, None
 
-    def check_timeout(self) -> tuple[bool, Optional[str]]:
+    def check_timeout(self) -> tuple[bool, str | None]:
         """
         Check if execution timeout exceeded.
 
@@ -177,7 +177,7 @@ class ExecutionGuard:
 
         return True, None
 
-    def check_circular_sequence(self, block_id: str) -> tuple[bool, Optional[str]]:
+    def check_circular_sequence(self, block_id: str) -> tuple[bool, str | None]:
         """
         Check for circular/repeated block sequences.
 
@@ -208,7 +208,7 @@ class ExecutionGuard:
 
         return True, None
 
-    def check_block_index_stall(self, block_index: int, block_order_length: int, iterations_without_progress: int) -> tuple[bool, Optional[str]]:
+    def check_block_index_stall(self, block_index: int, block_order_length: int, iterations_without_progress: int) -> tuple[bool, str | None]:
         """
         Check if block_index is stalled (not incrementing).
 
@@ -233,7 +233,7 @@ class ExecutionGuard:
         """Record an iteration."""
         self.iteration_count += 1
 
-    def should_abort(self, block_id: str, block_index: int, block_order_length: int, iterations_without_progress: int = 0) -> tuple[bool, Optional[str]]:
+    def should_abort(self, block_id: str, block_index: int, block_order_length: int, iterations_without_progress: int = 0) -> tuple[bool, str | None]:
         """
         Comprehensive check: Should execution abort?
 
@@ -262,7 +262,7 @@ class ExecutionGuard:
 
         return False, None
 
-    def get_statistics(self) -> Dict[str, any]:
+    def get_statistics(self) -> dict[str, any]:
         """Get execution statistics."""
         return {
             "iteration_count": self.iteration_count,

--- a/phionyx_core/orchestrator/karpathy_integration.py
+++ b/phionyx_core/orchestrator/karpathy_integration.py
@@ -7,39 +7,39 @@ Faz 3.2: End-to-End Integration
 Tüm Karpathy özelliklerinin birlikte çalışması için orchestration.
 """
 
-from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
+from typing import Any
 
 from phionyx_core.pipeline.base import BlockContext
+from phionyx_core.services.assumption_challenge_module import AssumptionChallengeModule
 from phionyx_core.services.assumption_engine import AssumptionSurfacingEngine
-from phionyx_core.services.inconsistency_engine import InconsistencyDetectionEngine
+from phionyx_core.services.clarification_engine import ClarificationRequestEngine
 from phionyx_core.services.complexity_engine import ComplexityBudgetEngine
+from phionyx_core.services.dead_code_pruner import DeadCodePruner
+from phionyx_core.services.inconsistency_engine import InconsistencyDetectionEngine
+from phionyx_core.services.inline_plan_engine import InlinePlanEngine
+from phionyx_core.services.orthogonal_change_guard import OrthogonalChangeGuard
 from phionyx_core.services.pushback_engine import PushBackEngine
 from phionyx_core.services.success_criteria_engine import SuccessCriteriaEngine
 from phionyx_core.services.tradeoff_engine import TradeOffElicitationEngine
-from phionyx_core.services.inline_plan_engine import InlinePlanEngine
-from phionyx_core.services.clarification_engine import ClarificationRequestEngine
-from phionyx_core.services.dead_code_pruner import DeadCodePruner
-from phionyx_core.services.orthogonal_change_guard import OrthogonalChangeGuard
-from phionyx_core.services.assumption_challenge_module import AssumptionChallengeModule
 
 
 @dataclass
 class KarpathyPipelineResult:
     """Result of Karpathy pipeline execution."""
-    assumptions: List[Any]
-    inconsistencies: List[Any]
-    complexity_metrics: Optional[Dict[str, Any]]
-    push_back_result: Optional[Any]
-    success_criteria_result: Optional[Any]
-    trade_offs: Optional[Any]
-    plan: Optional[Any]
-    clarifications: List[Any]
-    dead_code: List[Any]
-    orthogonal_changes: List[Any]
-    assumption_challenges: List[Any]
-    evidence_chain: List[Dict[str, Any]]
-    audit_trail: List[Dict[str, Any]]
+    assumptions: list[Any]
+    inconsistencies: list[Any]
+    complexity_metrics: dict[str, Any] | None
+    push_back_result: Any | None
+    success_criteria_result: Any | None
+    trade_offs: Any | None
+    plan: Any | None
+    clarifications: list[Any]
+    dead_code: list[Any]
+    orthogonal_changes: list[Any]
+    assumption_challenges: list[Any]
+    evidence_chain: list[dict[str, Any]]
+    audit_trail: list[dict[str, Any]]
 
 
 class KarpathyPipelineOrchestrator:
@@ -56,17 +56,17 @@ class KarpathyPipelineOrchestrator:
 
     def __init__(
         self,
-        assumption_engine: Optional[AssumptionSurfacingEngine] = None,
-        inconsistency_engine: Optional[InconsistencyDetectionEngine] = None,
-        complexity_engine: Optional[ComplexityBudgetEngine] = None,
-        pushback_engine: Optional[PushBackEngine] = None,
-        success_criteria_engine: Optional[SuccessCriteriaEngine] = None,
-        tradeoff_engine: Optional[TradeOffElicitationEngine] = None,
-        plan_engine: Optional[InlinePlanEngine] = None,
-        clarification_engine: Optional[ClarificationRequestEngine] = None,
-        dead_code_pruner: Optional[DeadCodePruner] = None,
-        orthogonal_guard: Optional[OrthogonalChangeGuard] = None,
-        challenge_module: Optional[AssumptionChallengeModule] = None
+        assumption_engine: AssumptionSurfacingEngine | None = None,
+        inconsistency_engine: InconsistencyDetectionEngine | None = None,
+        complexity_engine: ComplexityBudgetEngine | None = None,
+        pushback_engine: PushBackEngine | None = None,
+        success_criteria_engine: SuccessCriteriaEngine | None = None,
+        tradeoff_engine: TradeOffElicitationEngine | None = None,
+        plan_engine: InlinePlanEngine | None = None,
+        clarification_engine: ClarificationRequestEngine | None = None,
+        dead_code_pruner: DeadCodePruner | None = None,
+        orthogonal_guard: OrthogonalChangeGuard | None = None,
+        challenge_module: AssumptionChallengeModule | None = None
     ):
         """Initialize orchestrator with all engines."""
         self.assumption_engine = assumption_engine or AssumptionSurfacingEngine()
@@ -81,14 +81,14 @@ class KarpathyPipelineOrchestrator:
         self.orthogonal_guard = orthogonal_guard or OrthogonalChangeGuard()
         self.challenge_module = challenge_module or AssumptionChallengeModule()
 
-        self.evidence_chain: List[Dict[str, Any]] = []
-        self.audit_trail: List[Dict[str, Any]] = []
+        self.evidence_chain: list[dict[str, Any]] = []
+        self.audit_trail: list[dict[str, Any]] = []
 
     async def execute_karpathy_pipeline(
         self,
         context: BlockContext,
-        code: Optional[str] = None,
-        requirements: Optional[List[Dict[str, Any]]] = None
+        code: str | None = None,
+        requirements: list[dict[str, Any]] | None = None
     ) -> KarpathyPipelineResult:
         """
         Execute complete Karpathy pipeline.
@@ -248,7 +248,7 @@ class KarpathyPipelineOrchestrator:
             "timestamp": None  # Would use actual timestamp in production
         })
 
-    def _add_to_audit_trail(self, action: str, details: Dict[str, Any]) -> None:
+    def _add_to_audit_trail(self, action: str, details: dict[str, Any]) -> None:
         """Add to audit trail."""
         self.audit_trail.append({
             "action": action,
@@ -256,11 +256,11 @@ class KarpathyPipelineOrchestrator:
             "timestamp": None  # Would use actual timestamp in production
         })
 
-    def get_evidence_chain(self) -> List[Dict[str, Any]]:
+    def get_evidence_chain(self) -> list[dict[str, Any]]:
         """Get complete evidence chain."""
         return self.evidence_chain
 
-    def get_audit_trail(self) -> List[Dict[str, Any]]:
+    def get_audit_trail(self) -> list[dict[str, Any]]:
         """Get complete audit trail."""
         return self.audit_trail
 

--- a/phionyx_core/orchestrator/parallel_executor.py
+++ b/phionyx_core/orchestrator/parallel_executor.py
@@ -12,22 +12,22 @@ Features:
 - Result merging
 """
 
-import logging
 import asyncio
+import logging
 import time
-from typing import Dict, List, Set, Tuple
-from dataclasses import dataclass, field
 from copy import deepcopy
+from dataclasses import dataclass, field
 
-from ..pipeline.base import PipelineBlock, BlockContext, BlockResult
+from ..pipeline.base import BlockContext, BlockResult, PipelineBlock
 from .dependency_validator import DependencyValidator
 
 logger = logging.getLogger(__name__)
 
 # OpenTelemetry integration (optional)
 try:
-    from phionyx_core.telemetry import get_tracer, is_opentelemetry_enabled
     from opentelemetry.trace import Status, StatusCode
+
+    from phionyx_core.telemetry import get_tracer, is_opentelemetry_enabled
     OPENTELEMETRY_AVAILABLE = True
 except ImportError:
     OPENTELEMETRY_AVAILABLE = False
@@ -41,8 +41,8 @@ except ImportError:
 @dataclass
 class ParallelGroup:
     """Group of blocks that can be executed in parallel."""
-    block_ids: List[str]
-    dependencies: Set[str] = field(default_factory=set)
+    block_ids: list[str]
+    dependencies: set[str] = field(default_factory=set)
     read_only: bool = True  # If True, blocks only read from context
 
     def __post_init__(self):
@@ -79,10 +79,10 @@ class ParallelExecutor:
 
     def identify_parallel_groups(
         self,
-        block_order: List[str],
-        executed_blocks: Set[str],
+        block_order: list[str],
+        executed_blocks: set[str],
         context: BlockContext
-    ) -> List[ParallelGroup]:
+    ) -> list[ParallelGroup]:
         """
         Identify groups of blocks that can be executed in parallel.
 
@@ -188,7 +188,7 @@ class ParallelExecutor:
         # Check for overlap
         return bool(writes1 & writes2)
 
-    def _is_read_only_group(self, block_ids: List[str]) -> bool:
+    def _is_read_only_group(self, block_ids: list[str]) -> bool:
         """
         Check if a group of blocks is read-only.
 
@@ -207,9 +207,9 @@ class ParallelExecutor:
     async def execute_parallel_group(
         self,
         group: ParallelGroup,
-        blocks: Dict[str, PipelineBlock],
+        blocks: dict[str, PipelineBlock],
         context: BlockContext
-    ) -> Dict[str, BlockResult]:
+    ) -> dict[str, BlockResult]:
         """
         Execute a group of blocks in parallel.
 
@@ -274,7 +274,7 @@ class ParallelExecutor:
                 contexts[block_id] = self._copy_context(context)
 
             # Execute all blocks in parallel
-            async def execute_block(block_id: str) -> Tuple[str, BlockResult]:
+            async def execute_block(block_id: str) -> tuple[str, BlockResult]:
                 # OpenTelemetry: Create block-level span within parallel group
                 block_span = None
                 block_start_time = None
@@ -445,7 +445,7 @@ class ParallelExecutor:
 
     def merge_results(
         self,
-        results: Dict[str, BlockResult],
+        results: dict[str, BlockResult],
         context: BlockContext
     ) -> BlockContext:
         """

--- a/phionyx_core/orchestrator/rollback_manager.py
+++ b/phionyx_core/orchestrator/rollback_manager.py
@@ -5,10 +5,10 @@ Block Rollback Manager
 Manages state snapshots and rollback for pipeline blocks.
 """
 
-import logging
 import copy
-from typing import Dict, Any, Optional, List
+import logging
 from dataclasses import dataclass
+from typing import Any, Optional
 
 from ..pipeline.base import BlockContext
 
@@ -22,8 +22,8 @@ _MONOTONIC_TIME_KEYS = ("t_now", "turn_index", "monotonic_last_update")
 class StateSnapshot:
     """Snapshot of block context state."""
     block_id: str
-    context_snapshot: Dict[str, Any]
-    metadata_snapshot: Dict[str, Any]
+    context_snapshot: dict[str, Any]
+    metadata_snapshot: dict[str, Any]
 
 
 class RollbackManager:
@@ -47,9 +47,9 @@ class RollbackManager:
             enabled: Whether rollback is enabled (default: True)
         """
         self.enabled = enabled
-        self.snapshots: List[StateSnapshot] = []
+        self.snapshots: list[StateSnapshot] = []
         self.checkpoint_interval: int = 1  # Create snapshot every N blocks
-        self._time_floor: Dict[str, float] = {}  # Monotonic time floor values
+        self._time_floor: dict[str, float] = {}  # Monotonic time floor values
 
     def create_checkpoint(self, block_id: str, context: BlockContext) -> None:
         """
@@ -174,7 +174,7 @@ class RollbackManager:
         self.snapshots.clear()
         logger.debug("All checkpoints cleared")
 
-    def _update_time_floor(self, metadata: Dict[str, Any]) -> None:
+    def _update_time_floor(self, metadata: dict[str, Any]) -> None:
         """
         Update monotonic time floor from metadata values.
 
@@ -189,7 +189,7 @@ class RollbackManager:
                     if val > current_floor:
                         self._time_floor[key] = val
 
-    def _enforce_time_floor(self, metadata: Dict[str, Any]) -> None:
+    def _enforce_time_floor(self, metadata: dict[str, Any]) -> None:
         """
         Enforce monotonic time floor on metadata after rollback.
 

--- a/phionyx_core/pedagogy/__init__.py
+++ b/phionyx_core/pedagogy/__init__.py
@@ -22,7 +22,6 @@ Usage:
 """
 
 import logging
-from typing import Optional
 
 # Use absolute imports when loaded as module, relative when as package
 try:
@@ -30,7 +29,8 @@ try:
     from shaper import LanguageShaper
     from templates import TemplateLibrary
     try:
-        from audit import PedagogyLogger, RiskLevel as AuditRiskLevel
+        from audit import PedagogyLogger
+        from audit import RiskLevel as AuditRiskLevel
     except ImportError:
         AuditRiskLevel = None
         PedagogyLogger = None
@@ -40,7 +40,8 @@ except ImportError:
     from .shaper import LanguageShaper
     from .templates import TemplateLibrary
     try:
-        from .audit import PedagogyLogger, RiskLevel as AuditRiskLevel
+        from .audit import PedagogyLogger
+        from .audit import RiskLevel as AuditRiskLevel
     except ImportError:
         AuditRiskLevel = None
         PedagogyLogger = None
@@ -105,9 +106,9 @@ class PedagogyEngine:
         raw_response: str,
         physics_state: dict,
         force_safe: bool = False,
-        actor_ref: Optional[str] = None,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
-        tenant_ref: Optional[str] = None,  # SPRINT 5: Replaced school_id with tenant_ref (core-neutral)
-        class_id: Optional[str] = None
+        actor_ref: str | None = None,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
+        tenant_ref: str | None = None,  # SPRINT 5: Replaced school_id with tenant_ref (core-neutral)
+        class_id: str | None = None
     ) -> dict:
         """
         Process raw LLM response through pedagogical pipeline.

--- a/phionyx_core/pedagogy/audit.py
+++ b/phionyx_core/pedagogy/audit.py
@@ -8,11 +8,11 @@ All user IDs are hashed immediately for privacy.
 Never exposes raw student chat logs - only aggregate patterns.
 """
 
-import logging
 import hashlib
+import logging
 from datetime import datetime, timezone
-from typing import Dict, Optional, Any
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class PedagogyLogger:
     Only aggregate patterns are stored - never raw chat logs.
     """
 
-    def __init__(self, supabase_url: Optional[str] = None, supabase_key: Optional[str] = None):
+    def __init__(self, supabase_url: str | None = None, supabase_key: str | None = None):
         """
         Initialize PedagogyLogger.
 
@@ -51,7 +51,8 @@ class PedagogyLogger:
             # Backward compatible: Use direct Supabase client
             try:
                 import os
-                from supabase import create_client, Client  # noqa: F401
+
+                from supabase import Client, create_client  # noqa: F401
 
                 url = self.supabase_url or os.getenv("SUPABASE_URL")
                 key = self.supabase_key or os.getenv("SUPABASE_SERVICE_ROLE_KEY") or os.getenv("SUPABASE_KEY")
@@ -125,13 +126,13 @@ class PedagogyLogger:
         trigger_text: str,
         risk_level: RiskLevel,
         action_taken: str,
-        physics_snapshot: Dict[str, Any],
-        school_id: Optional[str] = None,
-        class_id: Optional[str] = None,
-        session_id: Optional[str] = None,
-        model_used: Optional[str] = None,
+        physics_snapshot: dict[str, Any],
+        school_id: str | None = None,
+        class_id: str | None = None,
+        session_id: str | None = None,
+        model_used: str | None = None,
         bypassed_llm: bool = False,
-        override_reason: Optional[str] = None
+        override_reason: str | None = None
     ) -> bool:
         """
         Log a safety intervention event.
@@ -226,10 +227,10 @@ class PedagogyLogger:
 
     def get_aggregate_stats(
         self,
-        school_id: Optional[str] = None,
-        class_id: Optional[str] = None,
+        school_id: str | None = None,
+        class_id: str | None = None,
         days: int = 7
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Get aggregate statistics for teacher dashboard.
 
@@ -292,7 +293,7 @@ class PedagogyLogger:
 
             # Extract common triggers (keywords from Level 2 interventions)
             level_2_logs = [log for log in logs if log.get("risk_level") == "level_2"]
-            keyword_counts: Dict[str, int] = {}
+            keyword_counts: dict[str, int] = {}
             for log in level_2_logs:
                 keywords = log.get("keywords", [])
                 for keyword in keywords:

--- a/phionyx_core/pedagogy/guardrails.py
+++ b/phionyx_core/pedagogy/guardrails.py
@@ -12,7 +12,6 @@ Uses IntentClassifier logic expanded with toxicity_filter.
 
 import logging
 import re
-from typing import Dict, List, Optional
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -44,10 +43,10 @@ class RiskAssessment:
         self,
         risk_level: RiskLevel,
         risk_type: RiskType,
-        detected_patterns: List[str],
+        detected_patterns: list[str],
         confidence: float,
         intervention_required: bool,
-        intervention_message: Optional[str] = None,
+        intervention_message: str | None = None,
         needs_reframing: bool = False
     ):
         self.risk_level = risk_level
@@ -58,7 +57,7 @@ class RiskAssessment:
         self.intervention_message = intervention_message
         self.needs_reframing = needs_reframing  # Level 2: Tag for shaper.py
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         """Convert to dictionary."""
         return {
             "risk_level": self.risk_level.value,
@@ -342,7 +341,7 @@ class Guardrails:
         assessment = self.assess_risk(text)
         return assessment.needs_reframing
 
-    def get_intervention_protocol(self, text: str) -> Optional[str]:
+    def get_intervention_protocol(self, text: str) -> str | None:
         """
         Get intervention protocol message if Level 1 risk is detected.
 

--- a/phionyx_core/pedagogy/shaper.py
+++ b/phionyx_core/pedagogy/shaper.py
@@ -14,7 +14,8 @@ Based on:
 
 import logging
 import re
-from typing import Dict, Optional, Callable, Any
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class LanguageShaper:
     def __init__(
         self,
         use_llm_reframing: bool = True,
-        llm_completion_fn: Optional[Callable[..., Any]] = None,
+        llm_completion_fn: Callable[..., Any] | None = None,
     ):
         """
         Initialize with transformation rules.
@@ -46,7 +47,7 @@ class LanguageShaper:
         """
         self.use_llm_reframing = use_llm_reframing
         self.llm_available = False
-        self._llm_completion_fn: Optional[Callable[..., Any]] = None
+        self._llm_completion_fn: Callable[..., Any] | None = None
         self._init_llm(llm_completion_fn)
 
         # Fixed mindset → Growth mindset transformations (regex-based fallback)
@@ -110,7 +111,7 @@ class LanguageShaper:
             "Every step forward is progress.",
         ]
 
-    def _init_llm(self, llm_completion_fn: Optional[Callable[..., Any]] = None):
+    def _init_llm(self, llm_completion_fn: Callable[..., Any] | None = None):
         """Initialize LLM for advanced reframing via injected callable (Core boundary: no direct litellm import)."""
         if not self.use_llm_reframing:
             return
@@ -126,7 +127,7 @@ class LanguageShaper:
             )
             self.llm_available = False
 
-    def reshape(self, text: str, physics_state: Optional[Dict] = None, context: Optional[str] = None) -> str:
+    def reshape(self, text: str, physics_state: dict | None = None, context: str | None = None) -> str:
         """
         Reshape text according to Vygotsky Protocol (Growth Mindset + Scaffolding).
 
@@ -180,8 +181,8 @@ class LanguageShaper:
     def reframe_response(
         self,
         draft_text: str,
-        physics_state: Optional[Dict] = None,
-        context: Optional[str] = None
+        physics_state: dict | None = None,
+        context: str | None = None
     ) -> str:
         """
         Advanced reframing using LLM (Vygotsky Protocol).
@@ -243,7 +244,7 @@ Return ONLY the reframed response, no explanations."""
             # Fallback to regex-based reshaping
             return self.reshape(draft_text, physics_state, context)
 
-    def _build_vygotsky_prompt(self, physics_state: Optional[Dict]) -> str:
+    def _build_vygotsky_prompt(self, physics_state: dict | None) -> str:
         """Build system prompt for Vygotsky Protocol reframing."""
         prompt = """You are a pedagogical AI assistant following the Vygotsky Protocol.
 
@@ -276,7 +277,7 @@ CORE PRINCIPLES:
         prompt += "\nReframe the response to follow these principles while maintaining the original meaning and tone."
         return prompt
 
-    def _apply_scaffolding(self, text: str, context: Optional[str] = None) -> str:
+    def _apply_scaffolding(self, text: str, context: str | None = None) -> str:
         """
         Rule 1: No Spoon-feeding - Apply scaffolding approach.
 
@@ -338,7 +339,7 @@ CORE PRINCIPLES:
 
         return text
 
-    def _reframe_failure(self, text: str, physics_state: Optional[Dict] = None) -> str:
+    def _reframe_failure(self, text: str, physics_state: dict | None = None) -> str:
         """
         Rule 3: Reframe Failure - "Not Yet" instead of "No".
 
@@ -372,7 +373,7 @@ CORE PRINCIPLES:
 
         return text
 
-    def _get_encouragement(self, phi: float, entropy: float) -> Optional[str]:
+    def _get_encouragement(self, phi: float, entropy: float) -> str | None:
         """Get appropriate encouragement based on physics state."""
         if phi < 0.3:
             return "Zor bir an yaşıyorsun, ama bu geçecek. Her zorluk seni daha güçlü yapar."

--- a/phionyx_core/pedagogy/templates.py
+++ b/phionyx_core/pedagogy/templates.py
@@ -10,7 +10,8 @@ Provides a library of hardcoded, clinically approved responses for:
 These templates BYPASS the LLM when physics state hits extremes.
 """
 
-from typing import Dict, Literal, Optional
+from typing import Literal
+
 
 class TemplateLibrary:
     """
@@ -31,7 +32,7 @@ class TemplateLibrary:
         self.templates = self._load_templates()
         self.extreme_state_templates = self._load_extreme_state_templates()
 
-    def _load_templates(self) -> Dict[str, Dict[str, str]]:
+    def _load_templates(self) -> dict[str, dict[str, str]]:
         """Load templates for different risk levels and scenarios."""
         return {
             "en": {
@@ -50,7 +51,7 @@ class TemplateLibrary:
             }
         }
 
-    def _load_extreme_state_templates(self) -> Dict[str, Dict[str, Dict[str, str]]]:
+    def _load_extreme_state_templates(self) -> dict[str, dict[str, dict[str, str]]]:
         """
         Load hardcoded templates for extreme physics states.
 
@@ -105,9 +106,9 @@ class TemplateLibrary:
 
     def get_extreme_state_template(
         self,
-        physics_state: Dict,
-        language: Optional[str] = None
-    ) -> Optional[Dict[str, str]]:
+        physics_state: dict,
+        language: str | None = None
+    ) -> dict[str, str] | None:
         """
         Get hardcoded template for extreme physics states.
 
@@ -176,7 +177,7 @@ class TemplateLibrary:
 
         return None
 
-    def get_template(self, risk_type: str, language: Optional[str] = None, physics_state: Optional[Dict] = None) -> str:
+    def get_template(self, risk_type: str, language: str | None = None, physics_state: dict | None = None) -> str:
         """
         Get template for a specific risk type.
 
@@ -204,7 +205,7 @@ class TemplateLibrary:
         template_key = risk_template_map.get(risk_type, "default_safe")
         return templates.get(template_key, templates["default_safe"])
 
-    def get_fallback(self, language: Optional[str] = None) -> str:
+    def get_fallback(self, language: str | None = None) -> str:
         """
         Get default safe fallback template.
 

--- a/phionyx_core/persistence/__init__.py
+++ b/phionyx_core/persistence/__init__.py
@@ -5,7 +5,8 @@ State Persistence Module
 Provides interfaces and implementations for persisting EchoState2.
 """
 
-from typing import Protocol, Optional, TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
+
 from phionyx_core.state.echo_state_2 import EchoState2
 
 if TYPE_CHECKING:
@@ -19,14 +20,14 @@ try:
     from phionyx_core.persistence.config import (
         create_state_store_from_env,
         get_state_store_type,
-        is_state_persistence_enabled
+        is_state_persistence_enabled,
     )
 except ImportError:
     # Fallback if config module not available
-    async def create_state_store_from_env() -> Optional[Any]:
+    async def create_state_store_from_env() -> Any | None:
         return None
 
-    def get_state_store_type() -> Optional[str]:
+    def get_state_store_type() -> str | None:
         return None
 
     def is_state_persistence_enabled() -> bool:
@@ -50,7 +51,7 @@ class StateStoreProtocol(Protocol):
         """
         ...
 
-    async def load_state(self, session_id: str) -> Optional[EchoState2]:
+    async def load_state(self, session_id: str) -> EchoState2 | None:
         """
         Load state from persistent storage.
 

--- a/phionyx_core/persistence/config.py
+++ b/phionyx_core/persistence/config.py
@@ -5,14 +5,14 @@ State Store Configuration
 Helper functions for creating and configuring state stores based on environment variables.
 """
 
-import os
 import logging
-from typing import Optional, Any
+import os
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-async def create_state_store_from_env() -> Optional[Any]:
+async def create_state_store_from_env() -> Any | None:
     """
     Create state store based on environment variables.
 
@@ -71,7 +71,7 @@ async def create_state_store_from_env() -> Optional[Any]:
         return None
 
 
-def get_state_store_type() -> Optional[str]:
+def get_state_store_type() -> str | None:
     """
     Get configured state store type from environment.
 

--- a/phionyx_core/persistence/in_memory_state_store.py
+++ b/phionyx_core/persistence/in_memory_state_store.py
@@ -7,7 +7,7 @@ NOT suitable for production multi-instance deployments.
 """
 
 import logging
-from typing import Optional, Dict
+
 from phionyx_core.state.echo_state_2 import EchoState2
 
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class InMemoryStateStore:
 
     def __init__(self):
         """Initialize in-memory state store."""
-        self._storage: Dict[str, EchoState2] = {}
+        self._storage: dict[str, EchoState2] = {}
         logger.info("InMemoryStateStore initialized")
 
     async def save_state(self, session_id: str, state: EchoState2) -> None:
@@ -37,7 +37,7 @@ class InMemoryStateStore:
         self._storage[session_id] = state
         logger.debug(f"State saved for session: {session_id}")
 
-    async def load_state(self, session_id: str) -> Optional[EchoState2]:
+    async def load_state(self, session_id: str) -> EchoState2 | None:
         """
         Load state from memory.
 

--- a/phionyx_core/persistence/postgres_state_store.py
+++ b/phionyx_core/persistence/postgres_state_store.py
@@ -7,10 +7,11 @@ Uses asyncpg for async PostgreSQL operations.
 Uses JSONB column for EchoState2 storage.
 """
 
-import logging
 import json
-from typing import Optional
+import logging
+
 import asyncpg
+
 from phionyx_core.state.echo_state_2 import EchoState2
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ class PostgreSQLStateStore:
         """
         self.connection_string = connection_string
         self.pool_size = pool_size
-        self.pool: Optional[asyncpg.Pool] = None
+        self.pool: asyncpg.Pool | None = None
         logger.info(f"PostgreSQLStateStore initialized (pool_size={pool_size})")
 
     async def initialize(self) -> None:
@@ -115,7 +116,7 @@ class PostgreSQLStateStore:
             logger.error(f"Failed to save state for session {session_id}: {e}", exc_info=True)
             raise
 
-    async def load_state(self, session_id: str) -> Optional[EchoState2]:
+    async def load_state(self, session_id: str) -> EchoState2 | None:
         """
         Load state from PostgreSQL.
 

--- a/phionyx_core/physics/__init__.py
+++ b/phionyx_core/physics/__init__.py
@@ -12,9 +12,7 @@ Exports:
 """
 
 # Import modules using relative imports (standard package structure)
-from . import formulas
-from . import constants
-from . import types
+from . import constants, formulas, types
 
 __all__ = [
     "formulas",
@@ -28,105 +26,95 @@ __all__ = [
 ]
 
 # Convenience exports
-from .formulas import (  # noqa: F401
-    calculate_phi_v2,  # v2.0 (Hybrid Resonance Model, backward compatible)
-    calculate_phi_v2_1,  # v2.1 (Circumplex-integrated)
-    calculate_phi_cognitive,
-    calculate_phi_physical,
-    compute_phi_components,  # NPC-specific interface (Plutchik → Circumplex → Φ)
-    get_context_weights,
-    calculate_functional_coherence_score,  # New name (FCS)
-    calculate_consciousness_index,  # Deprecated alias (backward compatibility)
-    calculate_resonance_force,
-    calculate_echo_energy,
-    calculate_entropy_shannon,
-    calculate_momentum,
-    estimate_trace_duration,
-    calculate_temporal_echo,
-    classify_resonance,
-    adjust_gamma,
-)
-
-from .constants import (  # noqa: F401
-    GOLDEN_RATIO,
-    MAX_ENTROPY,
-    DEFAULT_GAMMA,
-    DEFAULT_F_SELF,
-    PHI_UNIVERSE,
-    CONTEXT_WEIGHTS,  # v2.0
-    MIN_STABILITY,  # v2.0
-    MAX_STABILITY,  # v2.0
-)
-
-from .types import (  # noqa: F401
-    PhysicsInput,
-    PhysicsOutput,
-    PhysicsState,
-    NPCPhysicsParams,  # NPC-specific physics parameters
-    PhiComponents,  # Φ calculation output components
-)
-
-# Configuration & Tuning Layer
-from .profiles import (  # noqa: F401
-    PhysicsProfile,
-    ProfileLoader,
-    BaseMode,
-)
-
-from .tuner import (  # noqa: F401
-    ProfileTuner,
-    PhysicsParams,
-)
-
-from .dynamics import (  # noqa: F401
-    calculate_dynamic_entropy,
-    update_stability,
-    calculate_complexity,
-)
-
-from .entropy_modulation import (  # noqa: F401
-    EntropyModulationConfig,
-    calculate_entropy_modulated_amplitude,
-    modulate_empathic_intervention_strength,
-    modulate_directiveness_level,
-    modulate_sentence_length_intensity,
-    calculate_behavior_modulation,
-)
-
 from .coherence import (  # noqa: F401
     calculate_coherence,
     calculate_coherence_with_confidence,
     get_coherence_entropy_boost,
 )
-
+from .constants import (  # noqa: F401
+    CONTEXT_WEIGHTS,  # v2.0
+    DEFAULT_F_SELF,
+    DEFAULT_GAMMA,
+    GOLDEN_RATIO,
+    MAX_ENTROPY,
+    MAX_STABILITY,  # v2.0
+    MIN_STABILITY,  # v2.0
+    PHI_UNIVERSE,
+)
+from .dominance import (  # noqa: F401
+    apply_dominance_to_av_modulation,
+    apply_dominance_to_response_amplitude,
+    extract_dominance_from_measurement,
+    get_dominance_default_for_profile,
+)
+from .dynamics import (  # noqa: F401
+    calculate_complexity,
+    calculate_dynamic_entropy,
+    update_stability,
+)
+from .empathy import (  # noqa: F401
+    calculate_closeness_language_policy,
+    calculate_empathy_v1_1,
+    calculate_empathy_with_profile,
+    get_tau_from_profile,
+)
+from .entropy_modulation import (  # noqa: F401
+    EntropyModulationConfig,
+    calculate_behavior_modulation,
+    calculate_entropy_modulated_amplitude,
+    modulate_directiveness_level,
+    modulate_empathic_intervention_strength,
+    modulate_sentence_length_intensity,
+)
+from .formulas import (  # noqa: F401
+    adjust_gamma,
+    calculate_consciousness_index,  # Deprecated alias (backward compatibility)
+    calculate_echo_energy,
+    calculate_entropy_shannon,
+    calculate_functional_coherence_score,  # New name (FCS)
+    calculate_momentum,
+    calculate_phi_cognitive,
+    calculate_phi_physical,
+    calculate_phi_v2,  # v2.0 (Hybrid Resonance Model, backward compatible)
+    calculate_phi_v2_1,  # v2.1 (Circumplex-integrated)
+    calculate_resonance_force,
+    calculate_temporal_echo,
+    classify_resonance,
+    compute_phi_components,  # NPC-specific interface (Plutchik → Circumplex → Φ)
+    estimate_trace_duration,
+    get_context_weights,
+)
 from .inertia import (  # noqa: F401
     apply_inertia_to_decay_rate,
-    apply_inertia_to_ukf_process_noise,
     apply_inertia_to_derivative_gain,
+    apply_inertia_to_ukf_process_noise,
     get_inertia_from_profile,
     update_inertia_slowly,
 )
 
+# Configuration & Tuning Layer
+from .profiles import (  # noqa: F401
+    BaseMode,
+    PhysicsProfile,
+    ProfileLoader,
+)
 from .semantic_time_decay import (  # noqa: F401
-    calculate_decay_rate,
-    calculate_decay_factor,
-    apply_semantic_time_decay,
-    calculate_semantic_time_decay_metadata,
     SemanticTimeDecayManager,
+    apply_semantic_time_decay,
+    calculate_decay_factor,
+    calculate_decay_rate,
+    calculate_semantic_time_decay_metadata,
 )
-
-from .dominance import (  # noqa: F401
-    apply_dominance_to_av_modulation,
-    extract_dominance_from_measurement,
-    get_dominance_default_for_profile,
-    apply_dominance_to_response_amplitude,
+from .tuner import (  # noqa: F401
+    PhysicsParams,
+    ProfileTuner,
 )
-
-from .empathy import (  # noqa: F401
-    calculate_empathy_v1_1,
-    calculate_closeness_language_policy,
-    get_tau_from_profile,
-    calculate_empathy_with_profile,
+from .types import (  # noqa: F401
+    NPCPhysicsParams,  # NPC-specific physics parameters
+    PhiComponents,  # Φ calculation output components
+    PhysicsInput,
+    PhysicsOutput,
+    PhysicsState,
 )
 
 __all__ = [

--- a/phionyx_core/physics/coherence.py
+++ b/phionyx_core/physics/coherence.py
@@ -16,23 +16,23 @@ Formula:
 
 from __future__ import annotations
 
-from typing import Dict
 import math
+
 from .constants import (
-    COHERENCE_SIGMOID_STEEPNESS,
-    COHERENCE_NORMALIZATION_FACTOR,
     COHERENCE_MIDPOINT,
-    CONFIDENCE_FACTOR_MIN,
+    COHERENCE_NORMALIZATION_FACTOR,
+    COHERENCE_SIGMOID_STEEPNESS,
     CONFIDENCE_FACTOR_MAX,
+    CONFIDENCE_FACTOR_MIN,
     CONFIDENCE_FALLBACK_COHERENCE,
     ENTROPY_BOOST_FACTOR,
-    ENTROPY_MIN_INVARIANT
+    ENTROPY_MIN_INVARIANT,
 )
 
 
 def calculate_coherence(
-    measurement: Dict[str, float],
-    state: Dict[str, float],
+    measurement: dict[str, float],
+    state: dict[str, float],
     sigmoid_steepness: float = COHERENCE_SIGMOID_STEEPNESS
 ) -> float:
     """
@@ -86,8 +86,8 @@ def calculate_coherence(
 
 
 def calculate_coherence_with_confidence(
-    measurement: Dict[str, float],
-    state: Dict[str, float],
+    measurement: dict[str, float],
+    state: dict[str, float],
     confidence: float,
     sigmoid_steepness: float = COHERENCE_SIGMOID_STEEPNESS
 ) -> float:

--- a/phionyx_core/physics/core_math.py
+++ b/phionyx_core/physics/core_math.py
@@ -10,8 +10,8 @@ Scientific Grounding:
 - Sigmoid Normalization: Standard mathematical normalization
 """
 
-import zlib
 import math
+import zlib
 
 
 def calculate_kolmogorov_complexity(data: str) -> float:

--- a/phionyx_core/physics/dominance.py
+++ b/phionyx_core/physics/dominance.py
@@ -12,15 +12,15 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
+from typing import Any
 
 
 def apply_dominance_to_av_modulation(
     A: float,
     V: float,
-    D: Optional[float],
+    D: float | None,
     modulation_strength: float = 0.1
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Apply Dominance (D) to A/V modulation (PAD interpretation).
 
@@ -64,9 +64,9 @@ def apply_dominance_to_av_modulation(
 
 
 def extract_dominance_from_measurement(
-    measurement: Dict[str, Any],
-    llm_output: Optional[Dict[str, Any]] = None
-) -> Optional[float]:
+    measurement: dict[str, Any],
+    llm_output: dict[str, Any] | None = None
+) -> float | None:
     """
     Extract Dominance (D) from measurement mapper output.
 
@@ -101,9 +101,9 @@ def extract_dominance_from_measurement(
 
 
 def get_dominance_default_for_profile(
-    profile_name: Optional[str] = None,
-    profile: Optional[Dict[str, Any]] = None
-) -> Optional[float]:
+    profile_name: str | None = None,
+    profile: dict[str, Any] | None = None
+) -> float | None:
     """
     Get default Dominance (D) value for profile.
 
@@ -139,7 +139,7 @@ def get_dominance_default_for_profile(
 
 def apply_dominance_to_response_amplitude(
     base_amplitude: float,
-    D: Optional[float],
+    D: float | None,
     modulation_factor: float = 0.05
 ) -> float:
     """

--- a/phionyx_core/physics/dynamics.py
+++ b/phionyx_core/physics/dynamics.py
@@ -11,12 +11,12 @@ Scientific Grounding Upgrade (v3):
 - Replaces heuristic magic numbers with mathematically grounded approaches
 """
 
-from typing import Optional, Dict
+
 from .constants import (
-    ENTROPY_MIN,
     ENTROPY_MAX,
-    MIN_STABILITY,
+    ENTROPY_MIN,
     MAX_STABILITY,
+    MIN_STABILITY,
 )
 from .tuner import PhysicsParams
 
@@ -42,7 +42,7 @@ def calculate_dynamic_entropy(
     phi_variance: float,
     negative_emotion_count: int,
     complexity: float,
-    base_entropy: Optional[float] = None
+    base_entropy: float | None = None
 ) -> float:
     """
     Calculate dynamic entropy based on runtime conditions.
@@ -100,8 +100,8 @@ def update_stability(
     current_phi: float,
     entropy: float,
     params: PhysicsParams,
-    alpha: Optional[float] = None,
-    beta: Optional[float] = None
+    alpha: float | None = None,
+    beta: float | None = None
 ) -> float:
     """
     Update stability based on target vs current phi and entropy.
@@ -215,8 +215,8 @@ def calculate_dynamic_entropy_v3(
     input_text: str,
     phi_variance: float = 0.0,
     negative_emotion_ratio: float = 0.0,
-    base_entropy: Optional[float] = None,
-    weights: Optional[Dict[str, float]] = None
+    base_entropy: float | None = None,
+    weights: dict[str, float] | None = None
 ) -> float:
     """
     Calculate dynamic entropy using Kolmogorov Complexity (Information Theory).
@@ -296,9 +296,9 @@ def update_system_stability(
     target_phi: float,
     entropy: float,
     input_energy: float = 0.0,
-    params: Optional[PhysicsParams] = None,
-    alpha: Optional[float] = None,
-    beta: Optional[float] = None
+    params: PhysicsParams | None = None,
+    alpha: float | None = None,
+    beta: float | None = None
 ) -> float:
     """
     Update stability ensuring Lyapunov convergence (Control Theory).

--- a/phionyx_core/physics/empathy.py
+++ b/phionyx_core/physics/empathy.py
@@ -12,8 +12,8 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
 import math
+from typing import Any
 
 
 def calculate_empathy_v1_1(
@@ -100,8 +100,8 @@ def calculate_closeness_language_policy(
 
 
 def get_tau_from_profile(
-    profile_name: Optional[str] = None,
-    profile: Optional[Dict[str, Any]] = None
+    profile_name: str | None = None,
+    profile: dict[str, Any] | None = None
 ) -> float:
     """
     Get τ (tau) parameter from profile.
@@ -147,9 +147,9 @@ def calculate_empathy_with_profile(
     entropy: float,
     resonance_score: float,
     coherence: float,
-    profile_name: Optional[str] = None,
-    profile: Optional[Dict[str, Any]] = None
-) -> Dict[str, Any]:
+    profile_name: str | None = None,
+    profile: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """
     Calculate empathy with profile-specific parameters.
 

--- a/phionyx_core/physics/entropy_modulation.py
+++ b/phionyx_core/physics/entropy_modulation.py
@@ -12,9 +12,7 @@ This module provides core functions (independent of HarmonicComposer).
 
 from __future__ import annotations
 
-from typing import Dict, Optional
 from dataclasses import dataclass
-
 
 # Module-level tunable defaults (Tier A — PRE surfaces)
 ENTROPY_MOD_KH = 1.0
@@ -41,7 +39,7 @@ class EntropyModulationConfig:
 def calculate_entropy_modulated_amplitude(
     base_amplitude: float,
     entropy: float,
-    config: Optional[EntropyModulationConfig] = None
+    config: EntropyModulationConfig | None = None
 ) -> float:
     """
     Calculate entropy-modulated response amplitude.
@@ -80,7 +78,7 @@ def calculate_entropy_modulated_amplitude(
 def modulate_empathic_intervention_strength(
     base_strength: float,
     entropy: float,
-    config: Optional[EntropyModulationConfig] = None
+    config: EntropyModulationConfig | None = None
 ) -> float:
     """
     Modulate empathic intervention strength based on entropy.
@@ -113,7 +111,7 @@ def modulate_empathic_intervention_strength(
 def modulate_directiveness_level(
     base_directiveness: float,
     entropy: float,
-    config: Optional[EntropyModulationConfig] = None
+    config: EntropyModulationConfig | None = None
 ) -> float:
     """
     Modulate directiveness level based on entropy.
@@ -146,7 +144,7 @@ def modulate_directiveness_level(
 def modulate_sentence_length_intensity(
     base_length: float,
     entropy: float,
-    config: Optional[EntropyModulationConfig] = None
+    config: EntropyModulationConfig | None = None
 ) -> float:
     """
     Modulate sentence length/intensity based on entropy.
@@ -179,8 +177,8 @@ def modulate_sentence_length_intensity(
 def calculate_behavior_modulation(
     base_amplitude: float,
     entropy: float,
-    config: Optional[EntropyModulationConfig] = None
-) -> Dict[str, float]:
+    config: EntropyModulationConfig | None = None
+) -> dict[str, float]:
     """
     Calculate all behavior parameters modulated by entropy.
 

--- a/phionyx_core/physics/formulas.py
+++ b/phionyx_core/physics/formulas.py
@@ -16,28 +16,28 @@ Formulas (v2.0 - Hybrid State Model):
 """
 
 import math
-from typing import List, Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .types import NPCPhysicsParams, PhiComponents
 
 # Import constants from single source of truth
 from .constants import (
-    DEFAULT_F_SELF,
-    MIN_TIME_DELTA,
-    PHI_MIN,
-    PHI_MAX,
-    CONSCIOUSNESS_MIN,
-    CONSCIOUSNESS_MAX,
-    AMPLITUDE_MIN,
     AMPLITUDE_MAX,
-    GAMMA_MIN,
-    GAMMA_MAX,
-    ENTROPY_MIN,
-    ENTROPY_MAX,
-    MIN_STABILITY,
-    MAX_STABILITY,
+    AMPLITUDE_MIN,
+    CONSCIOUSNESS_MAX,
+    CONSCIOUSNESS_MIN,
     CONTEXT_WEIGHTS,
+    DEFAULT_F_SELF,
+    ENTROPY_MAX,
+    ENTROPY_MIN,
+    GAMMA_MAX,
+    GAMMA_MIN,
+    MAX_STABILITY,
+    MIN_STABILITY,
+    MIN_TIME_DELTA,
+    PHI_MAX,
+    PHI_MIN,
 )
 
 # ── Tunable Parameters (Tier A: Research Engine may modify) ──
@@ -145,7 +145,7 @@ def calculate_echo_energy(
     return phi * links * delta_entropy
 
 
-def calculate_entropy_shannon(probabilities: List[float]) -> float:
+def calculate_entropy_shannon(probabilities: list[float]) -> float:
     """
     Calculate S (Shannon Entropy).
 
@@ -236,8 +236,8 @@ def calculate_temporal_echo(
 
 
 def calculate_c_echo_series(
-    phi_values: List[float],
-    time_deltas: List[float],
+    phi_values: list[float],
+    time_deltas: list[float],
     f_self: float = DEFAULT_F_SELF
 ) -> float:
     """
@@ -380,7 +380,7 @@ def calculate_intrinsic_drive(phi: float, entropy: float, risk_level: str) -> fl
 # PHYSICS v2.0 - Hybrid Resonance Model
 # ============================================================================
 
-def get_context_weights(context_mode: str) -> Dict[str, float]:
+def get_context_weights(context_mode: str) -> dict[str, float]:
     """
     Get cognitive (wc) and physical (wp) weights based on context.
 
@@ -398,8 +398,8 @@ def calculate_phi_cognitive(
     stability: float,
     valence: float = 0.0,
     entropy_penalty_k: float = entropy_penalty_k,
-    previous_entropy: Optional[float] = None,
-    previous_valence: Optional[float] = None,
+    previous_entropy: float | None = None,
+    previous_valence: float | None = None,
     recovery_gain: float = recovery_gain,
     base_resonance: float = base_resonance,
 ) -> float:
@@ -588,7 +588,7 @@ def calculate_phi_v2_1(
     w_c: float,
     w_p: float,
     entropy_penalty_k: float = 1.15  # Default to micro-calibrated value (15% increase)
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Calculate Total Echo Quality (Φ) using Hybrid Resonance Model (Circumplex-integrated with Base Life Support).
 
@@ -675,7 +675,7 @@ def calculate_phi_v2(
     valence: float = 0.0,
     arousal: float = 1.0,
     entropy_penalty_k: float = entropy_penalty_k,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Calculate Total Echo Quality (Φ) using Hybrid Resonance Model v2.0 (backward compatible).
 

--- a/phionyx_core/physics/inertia.py
+++ b/phionyx_core/physics/inertia.py
@@ -12,8 +12,7 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
-
+from typing import Any
 
 # Module-level tunable defaults (Tier A — PRE surfaces)
 UKF_MIN_Q = 0.01
@@ -110,9 +109,9 @@ def apply_inertia_to_derivative_gain(
 
 
 def get_inertia_from_profile(
-    profile: Optional[Dict[str, Any]] = None,
-    age_group: Optional[str] = None,
-    persona: Optional[str] = None
+    profile: dict[str, Any] | None = None,
+    age_group: str | None = None,
+    persona: str | None = None
 ) -> float:
     """
     Get initial Inertia (I) from profile, age group, or persona.

--- a/phionyx_core/physics/profiles.py
+++ b/phionyx_core/physics/profiles.py
@@ -7,10 +7,10 @@ Uses Pydantic for validation and YAML for preset storage.
 """
 
 from enum import Enum
-from typing import Optional, Dict
-from pydantic import BaseModel, ConfigDict, Field, field_validator
-import yaml
 from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class BaseMode(str, Enum):
@@ -42,7 +42,7 @@ class PhysicsProfile(BaseModel):
     reactivity: float = Field(0.5, ge=0.0, le=1.0, description="Response speed (0=slow, 1=fast)")
     resilience: float = Field(0.5, ge=0.0, le=1.0, description="Stability (0=fragile, 1=robust)")
     safety: float = Field(0.5, ge=0.0, le=1.0, description="Safety strictness (0=permissive, 1=strict)")
-    description: Optional[str] = Field(None, description="Human-readable description")
+    description: str | None = Field(None, description="Human-readable description")
 
     @field_validator('reactivity', 'resilience', 'safety')
     @classmethod
@@ -65,7 +65,7 @@ class ProfileLoader:
         >>> print(profile.resilience)  # 0.9
     """
 
-    def __init__(self, profiles_file: Optional[Path] = None):
+    def __init__(self, profiles_file: Path | None = None):
         """
         Initialize profile loader.
 
@@ -77,7 +77,7 @@ class ProfileLoader:
             profiles_file = Path(__file__).parent / "profiles.yaml"
 
         self.profiles_file = profiles_file
-        self._profiles: Dict[str, PhysicsProfile] = {}
+        self._profiles: dict[str, PhysicsProfile] = {}
         self._load_profiles()
 
     def _load_profiles(self) -> None:
@@ -88,7 +88,7 @@ class ProfileLoader:
                 f"Please create profiles.yaml with default presets."
             )
 
-        with open(self.profiles_file, 'r', encoding='utf-8') as f:
+        with open(self.profiles_file, encoding='utf-8') as f:
             data = yaml.safe_load(f)
 
         if not isinstance(data, dict) or 'profiles' not in data:
@@ -128,7 +128,7 @@ class ProfileLoader:
         reactivity: float,
         resilience: float,
         safety: float,
-        description: Optional[str] = None
+        description: str | None = None
     ) -> PhysicsProfile:
         """
         Create a custom profile programmatically.

--- a/phionyx_core/physics/semantic_time_decay.py
+++ b/phionyx_core/physics/semantic_time_decay.py
@@ -18,9 +18,9 @@ Mathematical Model:
 - Weight after decay: weight(t) = weight(0) * exp(-λ * t)
 """
 
-import math
 import logging
-from typing import Optional, Dict, Any
+import math
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +45,8 @@ def calculate_decay_rate(half_life_seconds: float) -> float:
 
 def calculate_decay_factor(
     time_elapsed: float,
-    decay_rate: Optional[float] = None,
-    half_life_seconds: Optional[float] = None
+    decay_rate: float | None = None,
+    half_life_seconds: float | None = None
 ) -> float:
     """
     Calculate decay factor using exponential decay.
@@ -84,8 +84,8 @@ def apply_semantic_time_decay(
     initial_value: float,
     t_local: float,
     t_global: float,
-    decay_rate: Optional[float] = None,
-    half_life_seconds: Optional[float] = None,
+    decay_rate: float | None = None,
+    half_life_seconds: float | None = None,
     use_local_time: bool = True
 ) -> float:
     """
@@ -124,10 +124,10 @@ def apply_semantic_time_decay(
 def calculate_semantic_time_decay_metadata(
     t_local: float,
     t_global: float,
-    decay_rate: Optional[float] = None,
-    half_life_seconds: Optional[float] = None,
+    decay_rate: float | None = None,
+    half_life_seconds: float | None = None,
     use_local_time: bool = True
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Calculate semantic time decay metadata for reporting and debugging.
 
@@ -205,9 +205,9 @@ class SemanticTimeDecayManager:
         initial_value: float,
         t_local: float,
         t_global: float,
-        decay_rate: Optional[float] = None,
-        half_life_seconds: Optional[float] = None,
-        use_local_time: Optional[bool] = None
+        decay_rate: float | None = None,
+        half_life_seconds: float | None = None,
+        use_local_time: bool | None = None
     ) -> float:
         """
         Apply semantic time decay to a value.
@@ -242,10 +242,10 @@ class SemanticTimeDecayManager:
         self,
         t_local: float,
         t_global: float,
-        decay_rate: Optional[float] = None,
-        half_life_seconds: Optional[float] = None,
-        use_local_time: Optional[bool] = None
-    ) -> Dict[str, Any]:
+        decay_rate: float | None = None,
+        half_life_seconds: float | None = None,
+        use_local_time: bool | None = None
+    ) -> dict[str, Any]:
         """
         Get decay metadata.
 

--- a/phionyx_core/physics/text_physics.py
+++ b/phionyx_core/physics/text_physics.py
@@ -10,9 +10,8 @@ Scientific Grounding:
 """
 
 import re
-from typing import Dict
-from .core_math import calculate_kolmogorov_complexity
 
+from .core_math import calculate_kolmogorov_complexity
 
 # Psycholinguistic Lexicon (Valence-Arousal-Dominance)
 # Format: {term: (valence, arousal)}
@@ -104,7 +103,7 @@ DIMINISHERS = {
 }
 
 
-def analyze_text_psycholinguistics(text: str) -> Dict[str, float]:
+def analyze_text_psycholinguistics(text: str) -> dict[str, float]:
     """
     Analyze text using psycholinguistic lexicon to extract Valence and Arousal.
 

--- a/phionyx_core/physics/tuner.py
+++ b/phionyx_core/physics/tuner.py
@@ -6,17 +6,18 @@ Translates user-friendly profiles (reactivity, resilience, safety) into
 raw physics parameters (w_c, w_p, gamma, stability_baseline, entropy_sensitivity).
 """
 
-from typing import Dict, Any
 from dataclasses import dataclass
-from .profiles import PhysicsProfile
+from typing import Any
+
 from .constants import (
-    GAMMA_MIN,
-    GAMMA_MAX,
-    MIN_STABILITY,
-    MAX_STABILITY,
-    ENTROPY_MIN,
     ENTROPY_MAX,
+    ENTROPY_MIN,
+    GAMMA_MAX,
+    GAMMA_MIN,
+    MAX_STABILITY,
+    MIN_STABILITY,
 )
+from .profiles import PhysicsProfile
 
 
 @dataclass
@@ -173,7 +174,7 @@ class ProfileTuner:
         )
 
     @staticmethod
-    def get_context_weights(profile: PhysicsProfile) -> Dict[str, float]:
+    def get_context_weights(profile: PhysicsProfile) -> dict[str, float]:
         """
         Get context weights (w_c, w_p) for use in calculate_phi_v2.
 
@@ -194,7 +195,7 @@ class ProfileTuner:
         }
 
     @staticmethod
-    def explain_mapping(profile: PhysicsProfile) -> Dict[str, Any]:
+    def explain_mapping(profile: PhysicsProfile) -> dict[str, Any]:
         """
         Explain how a profile maps to parameters (for debugging/UI).
 

--- a/phionyx_core/physics/types.py
+++ b/phionyx_core/physics/types.py
@@ -5,8 +5,9 @@ Physics Types - Pydantic Models for Type Safety
 Type definitions for physics calculations.
 """
 
-from pydantic import BaseModel, Field
 from typing import Literal
+
+from pydantic import BaseModel, Field
 
 
 class PhysicsInput(BaseModel):

--- a/phionyx_core/physics/wasm_ready.py
+++ b/phionyx_core/physics/wasm_ready.py
@@ -6,16 +6,15 @@ Wrapper layer for WASM compilation compatibility.
 Ensures all functions are pure, typed, and SIMD-friendly.
 """
 
-from typing import List
+
 from .formulas import (
-    calculate_phi_v2,
     calculate_functional_coherence_score,
+    calculate_phi_v2,
 )
 
-
 # Type aliases for WASM compatibility
-Float32Array = List[float]
-Float64Array = List[float]
+Float32Array = list[float]
+Float64Array = list[float]
 
 
 def calculate_phi_v2_batch(

--- a/phionyx_core/pipeline/__init__.py
+++ b/phionyx_core/pipeline/__init__.py
@@ -5,7 +5,7 @@ Pipeline Package
 Defines the 46-block canonical pipeline architecture (v3.8.0).
 """
 
-from .base import PipelineBlock, BlockResult, BlockContext
+from .base import BlockContext, BlockResult, PipelineBlock
 
 __all__ = [
     'PipelineBlock',

--- a/phionyx_core/pipeline/base.py
+++ b/phionyx_core/pipeline/base.py
@@ -6,8 +6,8 @@ Base class for all pipeline blocks in the 46-block canonical pipeline.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, Literal, Optional
 from dataclasses import dataclass
+from typing import Any, ClassVar, Literal
 
 DeterminismClass = Literal["strict", "seeded", "noisy_sensor"]
 """Determinism classification for a pipeline block.
@@ -40,45 +40,45 @@ class BlockContext:
     card_result: str
 
     # Session/Scenario
-    scenario_id: Optional[str] = None
-    scenario_step_id: Optional[str] = None
-    session_id: Optional[str] = None
+    scenario_id: str | None = None
+    scenario_step_id: str | None = None
+    session_id: str | None = None
 
     # Physics State
     current_amplitude: float = 5.0
     current_entropy: float = 0.5
     current_integrity: float = 100.0
-    previous_phi: Optional[float] = None
+    previous_phi: float | None = None
 
     # Participant & Runtime
-    participant: Optional[Any] = None  # Participant abstraction
-    mode: Optional[str] = None  # Runtime mode (e.g., "toygar_core", "story", "game_scenario")
-    strategy: Optional[str] = None  # Runtime strategy (e.g., "normal", "stabilize", "comfort")
+    participant: Any | None = None  # Participant abstraction
+    mode: str | None = None  # Runtime mode (e.g., "toygar_core", "story", "game_scenario")
+    strategy: str | None = None  # Runtime strategy (e.g., "normal", "stabilize", "comfort")
 
     # Envelope tracking
-    envelope_message_id: Optional[str] = None  # TurnEnvelope message_id for transcript tracking
-    envelope_turn_id: Optional[int] = None  # TurnEnvelope turn_id for transcript tracking
-    envelope_user_text_sha256: Optional[str] = None  # TurnEnvelope user_text_sha256 for integrity
+    envelope_message_id: str | None = None  # TurnEnvelope message_id for transcript tracking
+    envelope_turn_id: int | None = None  # TurnEnvelope turn_id for transcript tracking
+    envelope_user_text_sha256: str | None = None  # TurnEnvelope user_text_sha256 for integrity
 
     # Capabilities
-    capabilities: Optional[Any] = None  # RunCapabilities
-    capability_deriver: Optional[Any] = None  # CapabilityDeriverProtocol
+    capabilities: Any | None = None  # RunCapabilities
+    capability_deriver: Any | None = None  # CapabilityDeriverProtocol
 
     # v4 optional extensions (AD-6: backward compat via Optional)
-    v4_perceptual_frame: Optional[Any] = None   # PerceptualFrame
-    v4_world_state: Optional[Any] = None        # WorldStateSnapshot
-    v4_active_goals: Optional[Any] = None       # List[GoalObject]
-    v4_action_intent: Optional[Any] = None      # ActionIntent
-    v4_ethics_decision: Optional[Any] = None    # EthicsDecision
-    v4_confidence: Optional[Any] = None         # ConfidencePayload
-    v4_workspace_events: Optional[Any] = None   # List[WorkspaceEvent]
-    v4_audit_record: Optional[Any] = None       # AuditRecord
-    v4_learning_updates: Optional[Any] = None   # List[LearningUpdate]
-    v4_error_payload: Optional[Any] = None      # ErrorPayload
+    v4_perceptual_frame: Any | None = None   # PerceptualFrame
+    v4_world_state: Any | None = None        # WorldStateSnapshot
+    v4_active_goals: Any | None = None       # List[GoalObject]
+    v4_action_intent: Any | None = None      # ActionIntent
+    v4_ethics_decision: Any | None = None    # EthicsDecision
+    v4_confidence: Any | None = None         # ConfidencePayload
+    v4_workspace_events: Any | None = None   # List[WorkspaceEvent]
+    v4_audit_record: Any | None = None       # AuditRecord
+    v4_learning_updates: Any | None = None   # List[LearningUpdate]
+    v4_error_payload: Any | None = None      # ErrorPayload
     pipeline_version: str = "3.0.0"             # "2.5.0" or "3.0.0"
 
     # Additional context (extensible)
-    metadata: Dict[str, Any] = None
+    metadata: dict[str, Any] = None
 
     def __post_init__(self):
         if self.metadata is None:
@@ -92,11 +92,11 @@ class BlockResult:
     """
     block_id: str
     status: str  # "ok", "error", "skipped"
-    data: Optional[Dict[str, Any]] = None
-    error: Optional[Exception] = None
-    skip_reason: Optional[str] = None
+    data: dict[str, Any] | None = None
+    error: Exception | None = None
+    skip_reason: str | None = None
     # v4 optional extension (AD-6)
-    v4_error_payload: Optional[Any] = None  # ErrorPayload
+    v4_error_payload: Any | None = None  # ErrorPayload
 
     def is_success(self) -> bool:
         """Check if block executed successfully."""
@@ -154,7 +154,7 @@ class PipelineBlock(ABC):
         """
         pass
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """
         Check if this block should be skipped.
 

--- a/phionyx_core/pipeline/blocks/__init__.py
+++ b/phionyx_core/pipeline/blocks/__init__.py
@@ -9,76 +9,78 @@ re-exported from here only for ``block_factory`` backward-compat wiring (v2.4.0
 loader). New code must target v3.8.0 canonical blocks only.
 """
 
-from .base_block import BaseBlock
+from .action_intent_gate import ActionIntentGateBlock
+from .arbitration_resolve import ArbitrationResolveBlock
 
 # v2.4.0 legacy blocks (archived — imported here only for block_factory wiring)
 from .archive.api_process_decision import ApiProcessDecisionBlock
-from .archive.engine_ensure_initialized import EngineEnsureInitializedBlock
-from .archive.echo_ontology_event_trace import EchoOntologyEventTraceBlock
-from .archive.emotion_from_neurotransmitter import EmotionFromNeurotransmitterBlock
-from .archive.echo_ontology_transformation import EchoOntologyTransformationBlock
-from .archive.low_input_gate import LowInputGateBlock  # DEPRECATED: Use InputSafetyGateBlock
-from .archive.safety_layer_pre_cep import SafetyLayerPreCepBlock  # DEPRECATED
-from .archive.esc_state_helper_update import EscStateHelperUpdateBlock
-from .archive.drive_coherence_update import DriveCoherenceUpdateBlock
 from .archive.coherence_qa import CoherenceQaBlock
+from .archive.drive_coherence_update import DriveCoherenceUpdateBlock
+from .archive.echo_ontology_event_trace import EchoOntologyEventTraceBlock
+from .archive.echo_ontology_transformation import EchoOntologyTransformationBlock
+from .archive.emotion_from_neurotransmitter import EmotionFromNeurotransmitterBlock
+from .archive.engine_ensure_initialized import EngineEnsureInitializedBlock
+from .archive.esc_state_helper_update import EscStateHelperUpdateBlock
+from .archive.low_input_gate import LowInputGateBlock  # DEPRECATED: Use InputSafetyGateBlock
 from .archive.phi_finalize import PhiFinalizeBlock
-
-# v3.8.0 canonical blocks
-from .time_update_sot import TimeUpdateSotBlock
-from .emotion_estimation import EmotionEstimationBlock
-from .create_scenario_frame import CreateScenarioFrameBlock
-from .initialize_unified_state import InitializeUnifiedStateBlock
-from .ukf_predict import UkfPredictBlock
-from .cognitive_layer import CognitiveLayerBlock
-from .input_safety_gate import InputSafetyGateBlock  # Combined: low_input_gate + safety_layer_pre_cep
-from .intent_classification import IntentClassificationBlock
-from .context_retrieval_rag import ContextRetrievalRagBlock
-from .entropy_amplitude_pre_gate import EntropyAmplitudePreGateBlock
-from .cep_evaluation import CepEvaluationBlock
-from .ethics_pre_response import EthicsPreResponseBlock
-from .narrative_layer import NarrativeLayerBlock
-from .ethics_post_response import EthicsPostResponseBlock
-from .unified_state_update_esc import UnifiedStateUpdateEscBlock
-from .phi_publish import PhiPublishBlock
-from .entropy_amplitude_post_gate import EntropyAmplitudePostGateBlock
-from .neurotransmitter_memory_growth import NeurotransmitterMemoryGrowthBlock
+from .archive.safety_layer_pre_cep import SafetyLayerPreCepBlock  # DEPRECATED
 from .audit_layer import AuditLayerBlock
-from .state_update_physics import StateUpdatePhysicsBlock
-from .response_build import ResponseBuildBlock
-from .phi_computation import PhiComputationBlock
-from .entropy_computation import EntropyComputationBlock
+from .base_block import BaseBlock
 from .behavioral_drift_detection import BehavioralDriftDetectionBlock
-
-# v3.8.0 State-Driven Response Revision
-from .response_revision_gate import ResponseRevisionGateBlock
+from .causal_graph_update import CausalGraphUpdateBlock
+from .causal_intervention_block import CausalInterventionBlock
+from .causal_simulation import CausalSimulationBlock
+from .cep_evaluation import CepEvaluationBlock
+from .cognitive_layer import CognitiveLayerBlock
+from .confidence_fusion import ConfidenceFusionBlock
+from .context_retrieval_rag import ContextRetrievalRagBlock
+from .counterfactual_analysis import CounterfactualAnalysisBlock
+from .create_scenario_frame import CreateScenarioFrameBlock
+from .deliberative_ethics_gate import DeliberativeEthicsGateBlock
+from .emotion_estimation import EmotionEstimationBlock
+from .entropy_amplitude_post_gate import EntropyAmplitudePostGateBlock
+from .entropy_amplitude_pre_gate import EntropyAmplitudePreGateBlock
+from .entropy_computation import EntropyComputationBlock
+from .ethics_post_response import EthicsPostResponseBlock
+from .ethics_pre_response import EthicsPreResponseBlock
+from .goal_decomposition import GoalDecompositionBlock
+from .goal_evaluation import GoalEvaluationBlock
+from .initialize_unified_state import InitializeUnifiedStateBlock
+from .input_safety_gate import (
+    InputSafetyGateBlock,  # Combined: low_input_gate + safety_layer_pre_cep
+)
+from .intent_classification import IntentClassificationBlock
 
 # v4 AGI World Model Blocks
 from .kill_switch_gate import KillSwitchGateBlock
-from .perceptual_frame_emit import PerceptualFrameEmitBlock
-from .goal_evaluation import GoalEvaluationBlock
-from .world_state_snapshot import WorldStateSnapshotBlock
-from .confidence_fusion import ConfidenceFusionBlock
-from .arbitration_resolve import ArbitrationResolveBlock
-from .action_intent_gate import ActionIntentGateBlock
-from .learning_gate import LearningGateBlock
-from .workspace_broadcast import WorkspaceBroadcastBlock
-
-# AGI Sprint Pipeline Binding Blocks (S2-S5)
-from .self_model_assessment import SelfModelAssessmentBlock
 from .knowledge_boundary_check import KnowledgeBoundaryCheckBlock
+from .learning_gate import LearningGateBlock
 from .memory_consolidation_block import MemoryConsolidationBlock
-from .causal_graph_update import CausalGraphUpdateBlock
-from .causal_intervention_block import CausalInterventionBlock
-from .counterfactual_analysis import CounterfactualAnalysisBlock
-from .root_cause_analysis import RootCauseAnalysisBlock
-from .causal_simulation import CausalSimulationBlock
-from .trust_evaluation import TrustEvaluationBlock
-from .goal_decomposition import GoalDecompositionBlock
-from .deliberative_ethics_gate import DeliberativeEthicsGateBlock
+from .narrative_layer import NarrativeLayerBlock
+from .neurotransmitter_memory_growth import NeurotransmitterMemoryGrowthBlock
 
 # Feedback Loop Block (v3.6.0)
 from .outcome_feedback import OutcomeFeedbackBlock
+from .perceptual_frame_emit import PerceptualFrameEmitBlock
+from .phi_computation import PhiComputationBlock
+from .phi_publish import PhiPublishBlock
+from .response_build import ResponseBuildBlock
+
+# v3.8.0 State-Driven Response Revision
+from .response_revision_gate import ResponseRevisionGateBlock
+from .root_cause_analysis import RootCauseAnalysisBlock
+
+# AGI Sprint Pipeline Binding Blocks (S2-S5)
+from .self_model_assessment import SelfModelAssessmentBlock
+from .state_update_physics import StateUpdatePhysicsBlock
+
+# v3.8.0 canonical blocks
+from .time_update_sot import TimeUpdateSotBlock
+from .trust_evaluation import TrustEvaluationBlock
+from .ukf_predict import UkfPredictBlock
+from .unified_state_update_esc import UnifiedStateUpdateEscBlock
+from .workspace_broadcast import WorkspaceBroadcastBlock
+from .world_state_snapshot import WorldStateSnapshotBlock
 
 __all__ = [
     'BaseBlock',

--- a/phionyx_core/pipeline/blocks/action_intent_gate.py
+++ b/phionyx_core/pipeline/blocks/action_intent_gate.py
@@ -10,9 +10,8 @@ Gates proposed actions through ethics and safety checks.
 """
 
 import logging
-from typing import Optional
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +27,7 @@ class ActionIntentGateBlock(PipelineBlock):
     def __init__(self):
         super().__init__("action_intent_gate")
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         return None

--- a/phionyx_core/pipeline/blocks/arbitration_resolve.py
+++ b/phionyx_core/pipeline/blocks/arbitration_resolve.py
@@ -10,9 +10,8 @@ Resolves conflicts between modules using arbitration math.
 """
 
 import logging
-from typing import Optional
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class ArbitrationResolveBlock(PipelineBlock):
         super().__init__("arbitration_resolve")
         self.conflict_threshold = conflict_threshold
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         return None

--- a/phionyx_core/pipeline/blocks/archive/api_process_decision.py
+++ b/phionyx_core/pipeline/blocks/archive/api_process_decision.py
@@ -8,7 +8,7 @@ Top-level API block that wraps the entire pipeline execution.
 
 import logging
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/archive/coherence_qa.py
+++ b/phionyx_core/pipeline/blocks/archive/coherence_qa.py
@@ -8,11 +8,11 @@ computes coherence scores, and applies redaction when internal state
 information would be inappropriately exposed in responses.
 """
 
-import re
 import logging
-from typing import Dict, Any, Optional, List, Protocol
+import re
+from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class CoherenceQAProtocol(Protocol):
         self,
         unified_state: Any,
         narrative_response: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Check coherence quality."""
         ...
 
@@ -63,7 +63,7 @@ class CoherenceQaBlock(PipelineBlock):
     leak detection and scoring logic (fail-open design).
     """
 
-    def __init__(self, qa_checker: Optional[CoherenceQAProtocol] = None):
+    def __init__(self, qa_checker: CoherenceQAProtocol | None = None):
         super().__init__("coherence_qa")
         self.qa_checker = qa_checker
 
@@ -87,7 +87,7 @@ class CoherenceQaBlock(PipelineBlock):
                 )
 
             # --- Inline coherence QA logic ---
-            violations: List[str] = []
+            violations: list[str] = []
             leak_detected = False
 
             for pattern in _COMPILED_PATTERNS:
@@ -101,14 +101,14 @@ class CoherenceQaBlock(PipelineBlock):
             score = max(0.0, min(1.0, score))
 
             # Redaction: remove leak patterns from text
-            redacted_text: Optional[str] = None
+            redacted_text: str | None = None
             if leak_detected:
                 cleaned = narrative_text
                 for pattern in _COMPILED_PATTERNS:
                     cleaned = pattern.sub("", cleaned)
                 redacted_text = re.sub(r"\s+", " ", cleaned).strip()
 
-            qa_result: Dict[str, Any] = {
+            qa_result: dict[str, Any] = {
                 "coherence_score": score,
                 "leak_detected": leak_detected,
                 "violations": violations,

--- a/phionyx_core/pipeline/blocks/archive/drive_coherence_update.py
+++ b/phionyx_core/pipeline/blocks/archive/drive_coherence_update.py
@@ -9,9 +9,9 @@ Drive = arousal * (1 - entropy) * min(phi, 1.0).
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class DriveCoherenceUpdaterProtocol(Protocol):
         self,
         unified_state: Any,
         narrative_response: str,
-        physics_state: Dict[str, Any]
+        physics_state: dict[str, Any]
     ) -> Any:
         """Update narrative drive and coherence."""
         ...
@@ -38,7 +38,7 @@ class DriveCoherenceUpdateBlock(PipelineBlock):
     coherence inline (fail-open design).
     """
 
-    def __init__(self, updater: Optional[DriveCoherenceUpdaterProtocol] = None):
+    def __init__(self, updater: DriveCoherenceUpdaterProtocol | None = None):
         super().__init__("drive_coherence_update")
         self.updater = updater
 
@@ -94,7 +94,7 @@ class DriveCoherenceUpdateBlock(PipelineBlock):
                     if hasattr(unified_state, "coherence"):
                         unified_state.coherence = coherence
 
-            drive_result: Dict[str, Any] = {
+            drive_result: dict[str, Any] = {
                 "drive": drive,
                 "coherence": coherence,
                 "source": source,

--- a/phionyx_core/pipeline/blocks/archive/echo_ontology_event_trace.py
+++ b/phionyx_core/pipeline/blocks/archive/echo_ontology_event_trace.py
@@ -9,7 +9,7 @@ Processes echo ontology event and creates trace.
 import logging
 from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/archive/echo_ontology_transformation.py
+++ b/phionyx_core/pipeline/blocks/archive/echo_ontology_transformation.py
@@ -7,9 +7,9 @@ Transforms trace result into physics state using echo ontology.
 """
 
 import logging
-from typing import Dict, Any, Protocol
+from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class EchoOntologyTransformerProtocol(Protocol):
         frame: Any,
         cognitive_state: Any,
         trace_result: Any
-    ) -> Dict[str, Any]:  # Returns physics_state
+    ) -> dict[str, Any]:  # Returns physics_state
         """Transform trace to physics state."""
         ...
 

--- a/phionyx_core/pipeline/blocks/archive/emotion_from_neurotransmitter.py
+++ b/phionyx_core/pipeline/blocks/archive/emotion_from_neurotransmitter.py
@@ -7,9 +7,9 @@ Gets emotion (valence, arousal) from neurotransmitter system.
 """
 
 import logging
-from typing import Optional, Protocol
+from typing import Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ class NeurotransmitterEmotionProtocol(Protocol):
     def get_emotion(
         self,
         user_input: str,
-        mode: Optional[str] = None
+        mode: str | None = None
     ) -> tuple[float, float]:  # Returns (valence, arousal)
         """Get emotion from neurotransmitter."""
         ...
@@ -33,7 +33,7 @@ class EmotionFromNeurotransmitterBlock(PipelineBlock):
     This is a fallback when emotion estimation is unavailable.
     """
 
-    def __init__(self, neurotransmitter: Optional[NeurotransmitterEmotionProtocol] = None):
+    def __init__(self, neurotransmitter: NeurotransmitterEmotionProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class EmotionFromNeurotransmitterBlock(PipelineBlock):
         super().__init__("emotion_from_neurotransmitter")
         self.neurotransmitter = neurotransmitter
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no neurotransmitter available."""
         if self.neurotransmitter is None:
             return "neurotransmitter_not_available"

--- a/phionyx_core/pipeline/blocks/archive/engine_ensure_initialized.py
+++ b/phionyx_core/pipeline/blocks/archive/engine_ensure_initialized.py
@@ -8,7 +8,7 @@ Ensures all engine processors and services are initialized.
 
 import logging
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/archive/esc_state_helper_update.py
+++ b/phionyx_core/pipeline/blocks/archive/esc_state_helper_update.py
@@ -7,9 +7,9 @@ Helper update for ESC (Echo State Controller) state.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ class ESCStateHelperProtocol(Protocol):
     def update_helper_state(
         self,
         unified_state: Any,
-        physics_state: Dict[str, Any]
+        physics_state: dict[str, Any]
     ) -> Any:  # Returns updated unified_state
         """Update ESC helper state."""
         ...
@@ -32,7 +32,7 @@ class EscStateHelperUpdateBlock(PipelineBlock):
     Performs helper updates for ESC state.
     """
 
-    def __init__(self, helper: Optional[ESCStateHelperProtocol] = None):
+    def __init__(self, helper: ESCStateHelperProtocol | None = None):
         """
         Initialize block.
 
@@ -42,7 +42,7 @@ class EscStateHelperUpdateBlock(PipelineBlock):
         super().__init__("esc_state_helper_update")
         self.helper = helper
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no helper or unified_state available."""
         metadata = context.metadata or {}
         if not self.helper or not metadata.get("unified_state"):

--- a/phionyx_core/pipeline/blocks/archive/low_input_gate.py
+++ b/phionyx_core/pipeline/blocks/archive/low_input_gate.py
@@ -8,7 +8,7 @@ Gate that checks if user input is too short/low quality and triggers early exit.
 
 import logging
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/archive/phi_finalize.py
+++ b/phionyx_core/pipeline/blocks/archive/phi_finalize.py
@@ -7,9 +7,9 @@ Finalizes phi computation and updates unified state.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class PhiFinalizerProtocol(Protocol):
         self,
         unified_state: Any,
         phi_value: float,
-        phi_components: Optional[Dict[str, Any]] = None
+        phi_components: dict[str, Any] | None = None
     ) -> Any:  # Returns finalized unified_state
         """Finalize phi computation."""
         ...
@@ -33,7 +33,7 @@ class PhiFinalizeBlock(PipelineBlock):
     Finalizes phi computation and updates unified state.
     """
 
-    def __init__(self, finalizer: Optional[PhiFinalizerProtocol] = None):
+    def __init__(self, finalizer: PhiFinalizerProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class PhiFinalizeBlock(PipelineBlock):
         super().__init__("phi_finalize")
         self.finalizer = finalizer
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no finalizer or unified_state available."""
         metadata = context.metadata or {}
         if not self.finalizer or not metadata.get("unified_state"):

--- a/phionyx_core/pipeline/blocks/archive/safety_layer_pre_cep.py
+++ b/phionyx_core/pipeline/blocks/archive/safety_layer_pre_cep.py
@@ -7,9 +7,9 @@ Initial safety assessment before CEP evaluation.
 """
 
 import logging
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ...base import PipelineBlock, BlockContext, BlockResult
+from ...base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -23,8 +23,8 @@ class SafetyLayerProcessorProtocol(Protocol):
         narrative_response: str,
         cognitive_state: Any,
         context_string: str,
-        cep_flags: Optional[Any] = None,
-        cep_config: Optional[Any] = None
+        cep_flags: Any | None = None,
+        cep_config: Any | None = None
     ) -> tuple[Any, Any]:  # Returns (frame, safety_result)
         """Process safety layer."""
         ...

--- a/phionyx_core/pipeline/blocks/audit_layer.py
+++ b/phionyx_core/pipeline/blocks/audit_layer.py
@@ -7,9 +7,9 @@ Performs audit operations (snapshots, event logging, explainability).
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +19,10 @@ class AuditLayerProcessorProtocol(Protocol):
     async def process_audit(
         self,
         frame: Any,
-        unified_state: Optional[Any],
+        unified_state: Any | None,
         narrative_response: str,
-        physics_state: Dict[str, Any]
-    ) -> Dict[str, Any]:  # Returns audit result
+        physics_state: dict[str, Any]
+    ) -> dict[str, Any]:  # Returns audit result
         """Process audit layer."""
         ...
 
@@ -34,7 +34,7 @@ class AuditLayerBlock(PipelineBlock):
     Performs audit operations (snapshots, event logging, explainability).
     """
 
-    def __init__(self, processor: Optional[AuditLayerProcessorProtocol] = None):
+    def __init__(self, processor: AuditLayerProcessorProtocol | None = None):
         """
         Initialize block.
 
@@ -44,7 +44,7 @@ class AuditLayerBlock(PipelineBlock):
         super().__init__("audit_layer")
         self.processor = processor
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Never skip — inline fallback computes basic integrity."""
         return None
 

--- a/phionyx_core/pipeline/blocks/behavioral_drift_detection.py
+++ b/phionyx_core/pipeline/blocks/behavioral_drift_detection.py
@@ -3,16 +3,15 @@ Behavioral Drift Detection Block
 Pipeline-integrated drift detection for Silent Failure Firewall.
 """
 
-from typing import Optional
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
 from ...monitoring.behavioral_drift import (
     BehavioralDriftDetector,
 )
 from ...monitoring.circuit_breaker import (
     CircuitBreaker,
 )
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -36,8 +35,8 @@ class BehavioralDriftDetectionBlock(PipelineBlock):
 
     def __init__(
         self,
-        drift_detector: Optional[BehavioralDriftDetector] = None,
-        circuit_breaker: Optional[CircuitBreaker] = None,
+        drift_detector: BehavioralDriftDetector | None = None,
+        circuit_breaker: CircuitBreaker | None = None,
         enabled: bool = True
     ):
         """

--- a/phionyx_core/pipeline/blocks/causal_graph_update.py
+++ b/phionyx_core/pipeline/blocks/causal_graph_update.py
@@ -10,9 +10,8 @@ Position in pipeline: After state_update_physics, before causal_intervention.
 """
 
 import logging
-from typing import Dict, List, Tuple
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +19,7 @@ logger = logging.getLogger(__name__)
 # 12 pairs covering all 8 physics variables: phi, entropy, coherence,
 # valence, arousal, amplitude, resonance, drift.
 # Deterministic: static list, same input → same output.
-OBSERVATION_PAIRS: List[Tuple[str, str]] = [
+OBSERVATION_PAIRS: list[tuple[str, str]] = [
     ("entropy", "coherence"),
     ("phi", "resonance"),
     ("valence", "amplitude"),
@@ -71,7 +70,7 @@ class CausalGraphUpdateBlock(PipelineBlock):
                 self._builder.add_physics_variables(physics_state)
 
             # Collect variable values from all sources
-            var_values: Dict[str, float] = {}
+            var_values: dict[str, float] = {}
             for var_name in ["phi", "entropy", "coherence", "valence",
                              "arousal", "amplitude", "resonance", "drift"]:
                 val = physics_state.get(var_name)

--- a/phionyx_core/pipeline/blocks/causal_intervention_block.py
+++ b/phionyx_core/pipeline/blocks/causal_intervention_block.py
@@ -11,7 +11,7 @@ Position in pipeline: After causal_graph_update.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/causal_simulation.py
+++ b/phionyx_core/pipeline/blocks/causal_simulation.py
@@ -10,7 +10,7 @@ Position in pipeline: After root_cause_analysis, before response_build.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/cep_evaluation.py
+++ b/phionyx_core/pipeline/blocks/cep_evaluation.py
@@ -7,9 +7,9 @@ Evaluates CEP (Conscious Echo Proof) for safety and coherence.
 """
 
 import logging
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ class CepEvaluationBlock(PipelineBlock):
     Evaluates CEP (Conscious Echo Proof) for safety and coherence.
     """
 
-    def __init__(self, evaluator: Optional[CEPEvaluatorProtocol] = None):
+    def __init__(self, evaluator: CEPEvaluatorProtocol | None = None):
         """
         Initialize block.
 
@@ -44,7 +44,7 @@ class CepEvaluationBlock(PipelineBlock):
         super().__init__("cep_evaluation")
         self.evaluator = evaluator
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no evaluator available."""
         if self.evaluator is None:
             return "cep_evaluator_not_available"

--- a/phionyx_core/pipeline/blocks/cognitive_layer.py
+++ b/phionyx_core/pipeline/blocks/cognitive_layer.py
@@ -7,9 +7,9 @@ Processes cognitive layer (memory, intuition, physics).
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class CognitiveLayerProcessorProtocol(Protocol):
         card_type: str,
         card_result: str,
         scene_context: str,
-        physics_params: Dict[str, Any],
+        physics_params: dict[str, Any],
         **kwargs
     ) -> Any:  # Returns updated frame
         """Process cognitive layer."""
@@ -42,7 +42,7 @@ class CognitiveLayerBlock(PipelineBlock):
 
     determinism = "noisy_sensor"  # delegates to injected processor; LLM-backed in default wiring
 
-    def __init__(self, processor: Optional[CognitiveLayerProcessorProtocol] = None):
+    def __init__(self, processor: CognitiveLayerProcessorProtocol | None = None):
         """
         Initialize block.
 
@@ -52,7 +52,7 @@ class CognitiveLayerBlock(PipelineBlock):
         super().__init__("cognitive_layer")
         self.processor = processor
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if processor not available."""
         if self.processor is None:
             return "processor_not_available"

--- a/phionyx_core/pipeline/blocks/confidence_fusion.py
+++ b/phionyx_core/pipeline/blocks/confidence_fusion.py
@@ -10,9 +10,8 @@ Fuses confidence estimates from multiple modules using W_final.
 """
 
 import logging
-from typing import Optional
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +27,7 @@ class ConfidenceFusionBlock(PipelineBlock):
     def __init__(self):
         super().__init__("confidence_fusion")
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         # No skip — v2.5 uses inline fallback, v3.0+ uses full v4 path
         return None
 

--- a/phionyx_core/pipeline/blocks/context_retrieval_rag.py
+++ b/phionyx_core/pipeline/blocks/context_retrieval_rag.py
@@ -14,10 +14,11 @@ This block:
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
-from ..base import PipelineBlock, BlockContext, BlockResult
 from phionyx_core.services.rag_service import RAGService
+
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +32,8 @@ class ContextRetrievalRagBlock(PipelineBlock):
 
     def __init__(
         self,
-        rag_service: Optional[RAGService] = None,
-        vector_store: Optional[Any] = None,
+        rag_service: RAGService | None = None,
+        vector_store: Any | None = None,
         max_context_tokens: int = 2000,
         relevance_threshold: float = 0.7
     ):

--- a/phionyx_core/pipeline/blocks/counterfactual_analysis.py
+++ b/phionyx_core/pipeline/blocks/counterfactual_analysis.py
@@ -10,7 +10,7 @@ Position in pipeline: After causal_intervention, optional enrichment.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/create_scenario_frame.py
+++ b/phionyx_core/pipeline/blocks/create_scenario_frame.py
@@ -7,9 +7,9 @@ Creates the ScenarioFrame immutable state object for the pipeline.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class ScenarioFrameCreatorProtocol(Protocol):
         card_title: str,
         scene_context: str,
         card_result: str,
-        physics_params: Dict[str, Any]
+        physics_params: dict[str, Any]
     ) -> Any:  # Returns ScenarioFrame
         """Create scenario frame."""
         ...
@@ -36,7 +36,7 @@ class CreateScenarioFrameBlock(PipelineBlock):
     Creates the ScenarioFrame immutable state object that flows through the pipeline.
     """
 
-    def __init__(self, frame_creator: Optional[ScenarioFrameCreatorProtocol] = None):
+    def __init__(self, frame_creator: ScenarioFrameCreatorProtocol | None = None):
         """
         Initialize block.
 
@@ -46,7 +46,7 @@ class CreateScenarioFrameBlock(PipelineBlock):
         super().__init__("create_scenario_frame")
         self.frame_creator = frame_creator
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if frame_creator not available."""
         if self.frame_creator is None:
             return "frame_creator_not_available"

--- a/phionyx_core/pipeline/blocks/deliberative_ethics_gate.py
+++ b/phionyx_core/pipeline/blocks/deliberative_ethics_gate.py
@@ -11,7 +11,7 @@ Position in pipeline: After ethics_pre_response, before narrative_layer.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/emotion_estimation.py
+++ b/phionyx_core/pipeline/blocks/emotion_estimation.py
@@ -7,17 +7,17 @@ Estimates emotion (valence, arousal) from user input using EmotionEstimator.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
 from ...memory.emotion_cache import EmotionCache
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
 
 class EmotionEstimatorProtocol(Protocol):
     """Protocol for emotion estimation."""
-    async def estimate(self, text: str) -> Dict[str, Any]:
+    async def estimate(self, text: str) -> dict[str, Any]:
         """Estimate emotion from text."""
         ...
 
@@ -33,8 +33,8 @@ class EmotionEstimationBlock(PipelineBlock):
 
     def __init__(
         self,
-        emotion_estimator: Optional[EmotionEstimatorProtocol] = None,
-        emotion_cache: Optional[EmotionCache] = None
+        emotion_estimator: EmotionEstimatorProtocol | None = None,
+        emotion_cache: EmotionCache | None = None
     ):
         """
         Initialize emotion estimation block.
@@ -49,7 +49,7 @@ class EmotionEstimationBlock(PipelineBlock):
         # This is essential for parallel execution consistency
         self.emotion_cache = emotion_cache or EmotionCache(max_size=10000, enable_metrics=True)
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no estimator available."""
         if self.emotion_estimator is None:
             return "emotion_estimator_not_available"

--- a/phionyx_core/pipeline/blocks/entropy_amplitude_post_gate.py
+++ b/phionyx_core/pipeline/blocks/entropy_amplitude_post_gate.py
@@ -7,9 +7,9 @@ Gate that checks entropy/amplitude after narrative generation.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +18,8 @@ class EntropyAmplitudeGateProtocol(Protocol):
     """Protocol for entropy/amplitude gating."""
     def apply_gate(
         self,
-        physics_state: Dict[str, Any]
-    ) -> Dict[str, Any]:  # Returns gated physics_state
+        physics_state: dict[str, Any]
+    ) -> dict[str, Any]:  # Returns gated physics_state
         """Apply entropy/amplitude gate."""
         ...
 
@@ -31,7 +31,7 @@ class EntropyAmplitudePostGateBlock(PipelineBlock):
     Applies entropy/amplitude gate after narrative generation.
     """
 
-    def __init__(self, gate: Optional[EntropyAmplitudeGateProtocol] = None):
+    def __init__(self, gate: EntropyAmplitudeGateProtocol | None = None):
         """
         Initialize block.
 
@@ -41,7 +41,7 @@ class EntropyAmplitudePostGateBlock(PipelineBlock):
         super().__init__("entropy_amplitude_post_gate")
         self.gate = gate
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Never skip — inline fallback handles missing gate service."""
         return None
 

--- a/phionyx_core/pipeline/blocks/entropy_amplitude_pre_gate.py
+++ b/phionyx_core/pipeline/blocks/entropy_amplitude_pre_gate.py
@@ -7,9 +7,9 @@ Gate that checks entropy/amplitude before CEP evaluation.
 """
 
 import logging
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +19,9 @@ class EntropyAmplitudeGateProtocol(Protocol):
     def apply_gate(
         self,
         cognitive_state: Any,
-        unified_state: Optional[Any],
+        unified_state: Any | None,
         enhanced_context_string: str
-    ) -> tuple[str, Optional[Any]]:  # Returns (enhanced_context_string, gated_state)
+    ) -> tuple[str, Any | None]:  # Returns (enhanced_context_string, gated_state)
         """Apply entropy/amplitude gate."""
         ...
 
@@ -33,7 +33,7 @@ class EntropyAmplitudePreGateBlock(PipelineBlock):
     Applies entropy/amplitude gate before CEP evaluation.
     """
 
-    def __init__(self, gate: Optional[EntropyAmplitudeGateProtocol] = None):
+    def __init__(self, gate: EntropyAmplitudeGateProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class EntropyAmplitudePreGateBlock(PipelineBlock):
         super().__init__("entropy_amplitude_pre_gate")
         self.gate = gate
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Never skip — inline fallback handles missing gate service."""
         return None
 

--- a/phionyx_core/pipeline/blocks/entropy_computation.py
+++ b/phionyx_core/pipeline/blocks/entropy_computation.py
@@ -7,9 +7,9 @@ Computes entropy value from user input and response.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +19,9 @@ class EntropyComputationProtocol(Protocol):
     def compute_entropy(
         self,
         user_input: str,
-        response_text: Optional[str] = None,
-        previous_entropy: Optional[float] = None
-    ) -> Dict[str, Any]:
+        response_text: str | None = None,
+        previous_entropy: float | None = None
+    ) -> dict[str, Any]:
         """Compute entropy value."""
         ...
 
@@ -34,7 +34,7 @@ class EntropyComputationBlock(PipelineBlock):
     This is an always-on block.
     """
 
-    def __init__(self, entropy_computer: Optional[EntropyComputationProtocol] = None):
+    def __init__(self, entropy_computer: EntropyComputationProtocol | None = None):
         """
         Initialize block.
 

--- a/phionyx_core/pipeline/blocks/ethics_post_response.py
+++ b/phionyx_core/pipeline/blocks/ethics_post_response.py
@@ -7,9 +7,9 @@ Ethics check after narrative generation.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class EthicsProcessorProtocol(Protocol):
         frame: Any,
         narrative_response: str,
         cognitive_state: Any
-    ) -> Dict[str, Any]:  # Returns ethics_result
+    ) -> dict[str, Any]:  # Returns ethics_result
         """Check ethics after response."""
         ...
 
@@ -33,7 +33,7 @@ class EthicsPostResponseBlock(PipelineBlock):
     Performs ethics check after narrative generation.
     """
 
-    def __init__(self, processor: Optional[EthicsProcessorProtocol] = None):
+    def __init__(self, processor: EthicsProcessorProtocol | None = None):
         """
         Initialize block.
 

--- a/phionyx_core/pipeline/blocks/ethics_pre_response.py
+++ b/phionyx_core/pipeline/blocks/ethics_pre_response.py
@@ -7,9 +7,9 @@ Ethics check before narrative generation.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class EthicsProcessorProtocol(Protocol):
         frame: Any,
         user_input: str,
         cognitive_state: Any
-    ) -> Dict[str, Any]:  # Returns ethics_result
+    ) -> dict[str, Any]:  # Returns ethics_result
         """Check ethics before response."""
         ...
 
@@ -33,7 +33,7 @@ class EthicsPreResponseBlock(PipelineBlock):
     Performs ethics check before narrative generation.
     """
 
-    def __init__(self, processor: Optional[EthicsProcessorProtocol] = None):
+    def __init__(self, processor: EthicsProcessorProtocol | None = None):
         """
         Initialize block.
 

--- a/phionyx_core/pipeline/blocks/goal_decomposition.py
+++ b/phionyx_core/pipeline/blocks/goal_decomposition.py
@@ -11,7 +11,7 @@ Position in pipeline: After intent_classification, before narrative_layer.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/goal_evaluation.py
+++ b/phionyx_core/pipeline/blocks/goal_evaluation.py
@@ -10,17 +10,17 @@ Evaluates active goals, computes legitimacy and utility scores.
 """
 
 import logging
-from typing import Optional, Protocol, List, Any
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
 
 class GoalRegistryProtocol(Protocol):
     """Protocol for goal registry service."""
-    async def get_active_goals(self) -> List[Any]: ...
-    async def evaluate_goals(self, context: Any) -> List[Any]: ...
+    async def get_active_goals(self) -> list[Any]: ...
+    async def evaluate_goals(self, context: Any) -> list[Any]: ...
 
 
 class GoalEvaluationBlock(PipelineBlock):
@@ -31,11 +31,11 @@ class GoalEvaluationBlock(PipelineBlock):
     Updates goal priorities and detects goal drift.
     """
 
-    def __init__(self, goal_registry: Optional[GoalRegistryProtocol] = None):
+    def __init__(self, goal_registry: GoalRegistryProtocol | None = None):
         super().__init__("goal_evaluation")
         self.goal_registry = goal_registry
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         # goal_registry=None → inline fallback in execute() (goals_evaluated: 0)

--- a/phionyx_core/pipeline/blocks/initialize_unified_state.py
+++ b/phionyx_core/pipeline/blocks/initialize_unified_state.py
@@ -7,9 +7,9 @@ Initializes the unified state (EchoState2) for the pipeline.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class UnifiedStateInitializerProtocol(Protocol):
         self,
         frame: Any,
         time_delta: float,
-        physics_params: Dict[str, Any]
+        physics_params: dict[str, Any]
     ) -> Any:  # Returns UnifiedEchoState
         """Initialize unified state."""
         ...
@@ -33,7 +33,7 @@ class InitializeUnifiedStateBlock(PipelineBlock):
     Initializes the unified state (EchoState2) from frame and physics parameters.
     """
 
-    def __init__(self, initializer: Optional[UnifiedStateInitializerProtocol] = None):
+    def __init__(self, initializer: UnifiedStateInitializerProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class InitializeUnifiedStateBlock(PipelineBlock):
         super().__init__("initialize_unified_state")
         self.initializer = initializer
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if initializer not available."""
         if self.initializer is None:
             return "initializer_not_available"

--- a/phionyx_core/pipeline/blocks/input_safety_gate.py
+++ b/phionyx_core/pipeline/blocks/input_safety_gate.py
@@ -13,9 +13,9 @@ Both blocks serve the same purpose: early rejection of problematic inputs.
 """
 
 import logging
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -29,8 +29,8 @@ class SafetyLayerProcessorProtocol(Protocol):
         narrative_response: str,
         cognitive_state: Any,
         context_string: str,
-        cep_flags: Optional[Any] = None,
-        cep_config: Optional[Any] = None
+        cep_flags: Any | None = None,
+        cep_config: Any | None = None
     ) -> tuple[Any, Any]:  # Returns (frame, safety_result)
         """Process safety layer."""
         ...
@@ -49,7 +49,7 @@ class InputSafetyGateBlock(PipelineBlock):
 
     def __init__(
         self,
-        processor: Optional[SafetyLayerProcessorProtocol] = None,
+        processor: SafetyLayerProcessorProtocol | None = None,
         min_input_length: int = 3
     ):
         """

--- a/phionyx_core/pipeline/blocks/intent_classification.py
+++ b/phionyx_core/pipeline/blocks/intent_classification.py
@@ -12,10 +12,11 @@ This block:
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
-from ..base import PipelineBlock, BlockContext, BlockResult
 from phionyx_core.services.intent_classifier import IntentClassifier, IntentType
+
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -32,9 +33,9 @@ class IntentClassificationBlock(PipelineBlock):
 
     def __init__(
         self,
-        intent_classifier: Optional[IntentClassifier] = None,
-        embedding_cache: Optional[Any] = None,
-        llm_provider: Optional[Any] = None
+        intent_classifier: IntentClassifier | None = None,
+        embedding_cache: Any | None = None,
+        llm_provider: Any | None = None
     ):
         """
         Initialize block.

--- a/phionyx_core/pipeline/blocks/kill_switch_gate.py
+++ b/phionyx_core/pipeline/blocks/kill_switch_gate.py
@@ -10,9 +10,9 @@ Position in pipeline: After confidence_fusion, before narrative_layer.
 """
 
 import logging
-from typing import Dict, Any
+from typing import Any
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -126,7 +126,7 @@ class KillSwitchGateBlock(PipelineBlock):
                 data={"error": str(e)}
             )
 
-    def _extract_ethics_risk(self, metadata: Dict[str, Any]) -> float:
+    def _extract_ethics_risk(self, metadata: dict[str, Any]) -> float:
         """Extract max ethics risk from pipeline context."""
         # From ethics_pre_response block result
         ethics_result = metadata.get("ethics_result")
@@ -146,7 +146,7 @@ class KillSwitchGateBlock(PipelineBlock):
 
         return 0.0
 
-    def _extract_t_meta(self, metadata: Dict[str, Any]) -> float:
+    def _extract_t_meta(self, metadata: dict[str, Any]) -> float:
         """Extract T_meta from confidence fusion."""
         # From confidence_fusion block result
         confidence = metadata.get("confidence_result")
@@ -166,7 +166,7 @@ class KillSwitchGateBlock(PipelineBlock):
 
         return 1.0  # Default: fully trusted
 
-    def _extract_drift(self, metadata: Dict[str, Any]) -> bool:
+    def _extract_drift(self, metadata: dict[str, Any]) -> bool:
         """Extract drift detection status."""
         drift_result = metadata.get("drift_result")
         if drift_result:

--- a/phionyx_core/pipeline/blocks/knowledge_boundary_check.py
+++ b/phionyx_core/pipeline/blocks/knowledge_boundary_check.py
@@ -10,7 +10,7 @@ Position in pipeline: After self_model_assessment, before narrative_layer.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/learning_gate.py
+++ b/phionyx_core/pipeline/blocks/learning_gate.py
@@ -10,17 +10,17 @@ Gates learning updates through boundary zone checks.
 """
 
 import logging
-from typing import Optional, Protocol, List, Any
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
 
 class LearningGateServiceProtocol(Protocol):
     """Protocol for learning gate service."""
-    async def evaluate_updates(self, updates: List[Any]) -> List[Any]: ...
-    async def apply_approved(self, updates: List[Any]) -> int: ...
+    async def evaluate_updates(self, updates: list[Any]) -> list[Any]: ...
+    async def apply_approved(self, updates: list[Any]) -> int: ...
 
 
 class LearningGateBlock(PipelineBlock):
@@ -32,11 +32,11 @@ class LearningGateBlock(PipelineBlock):
     Adaptive zone: auto-approved within bounds.
     """
 
-    def __init__(self, gate_service: Optional[LearningGateServiceProtocol] = None):
+    def __init__(self, gate_service: LearningGateServiceProtocol | None = None):
         super().__init__("learning_gate")
         self.gate_service = gate_service
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         return None
@@ -63,7 +63,7 @@ class LearningGateBlock(PipelineBlock):
                 rejected_count = len(evaluated) - len(approved)
             else:
                 # Default: approve adaptive, reject immutable, defer gated
-                from ...contracts.v4.learning_update import LearningUpdate, LearningGateDecision
+                from ...contracts.v4.learning_update import LearningGateDecision, LearningUpdate
 
                 for update in pending_updates:
                     if isinstance(update, LearningUpdate):

--- a/phionyx_core/pipeline/blocks/memory_consolidation_block.py
+++ b/phionyx_core/pipeline/blocks/memory_consolidation_block.py
@@ -10,7 +10,7 @@ Position in pipeline: After audit_layer (post-response), end of pipeline.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/narrative_layer.py
+++ b/phionyx_core/pipeline/blocks/narrative_layer.py
@@ -7,11 +7,12 @@ Generates narrative response using LLM.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
 from phionyx_core.templates import get_template_manager
 from phionyx_core.templates.response_templates import IntentType
+
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +27,9 @@ class NarrativeLayerProcessorProtocol(Protocol):
         card_result: str,
         scene_context: str,
         enhanced_context_string: str,
-        system_prompt: Optional[str] = None,
-        physics_state: Optional[Dict[str, Any]] = None,
-        selected_intent: Optional[Dict[str, Any]] = None
+        system_prompt: str | None = None,
+        physics_state: dict[str, Any] | None = None,
+        selected_intent: dict[str, Any] | None = None
     ) -> tuple[Any, str, Any]:  # Returns (frame, narrative_text, narrative_result)
         """Process narrative layer."""
         ...
@@ -45,7 +46,7 @@ class NarrativeLayerBlock(PipelineBlock):
 
     CLAIM_REFS = ("SF1:C4", "SF1:C14", "SF1:C15")
 
-    def __init__(self, processor: Optional[NarrativeLayerProcessorProtocol] = None, enable_templates: bool = True):
+    def __init__(self, processor: NarrativeLayerProcessorProtocol | None = None, enable_templates: bool = True):
         """
         Initialize block.
 
@@ -61,7 +62,7 @@ class NarrativeLayerBlock(PipelineBlock):
         else:
             self.template_manager = None
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if processor not available."""
         if self.processor is None:
             return "processor_not_available"

--- a/phionyx_core/pipeline/blocks/neurotransmitter_memory_growth.py
+++ b/phionyx_core/pipeline/blocks/neurotransmitter_memory_growth.py
@@ -7,9 +7,9 @@ Updates neurotransmitter and memory growth metrics.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -20,8 +20,8 @@ class NeurotransmitterMemoryGrowthProtocol(Protocol):
         self,
         user_input: str,
         narrative_response: str,
-        physics_state: Dict[str, Any]
-    ) -> Dict[str, Any]:  # Returns growth metrics
+        physics_state: dict[str, Any]
+    ) -> dict[str, Any]:  # Returns growth metrics
         """Update neurotransmitter and memory growth."""
         ...
 
@@ -33,7 +33,7 @@ class NeurotransmitterMemoryGrowthBlock(PipelineBlock):
     Updates neurotransmitter and memory growth metrics.
     """
 
-    def __init__(self, growth_updater: Optional[NeurotransmitterMemoryGrowthProtocol] = None):
+    def __init__(self, growth_updater: NeurotransmitterMemoryGrowthProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class NeurotransmitterMemoryGrowthBlock(PipelineBlock):
         super().__init__("neurotransmitter_memory_growth")
         self.growth_updater = growth_updater
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no updater available."""
         if self.growth_updater is None:
             return "growth_updater_not_available"

--- a/phionyx_core/pipeline/blocks/outcome_feedback.py
+++ b/phionyx_core/pipeline/blocks/outcome_feedback.py
@@ -13,9 +13,9 @@ Cognitive vs. automation: Cognitive — first closed feedback loop in pipeline
 """
 
 import logging
-from typing import Dict, Any, List
+from typing import Any
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ class OutcomeFeedbackBlock(PipelineBlock):
 
         try:
             metadata = context.metadata or {}
-            result_data: Dict[str, Any] = {
+            result_data: dict[str, Any] = {
                 "outcomes_recorded": [],
                 "confidence_updates": {},
                 "revisions_proposed": [],
@@ -129,7 +129,7 @@ class OutcomeFeedbackBlock(PipelineBlock):
             )
 
     def _determine_turn_success(
-        self, audit_result: Dict[str, Any], metadata: Dict[str, Any]
+        self, audit_result: dict[str, Any], metadata: dict[str, Any]
     ) -> bool:
         """Determine turn success from audit result and pipeline metadata."""
         # Explicit audit status
@@ -152,7 +152,7 @@ class OutcomeFeedbackBlock(PipelineBlock):
         # Default: success
         return True
 
-    def _infer_capabilities(self, metadata: Dict[str, Any]) -> List[str]:
+    def _infer_capabilities(self, metadata: dict[str, Any]) -> list[str]:
         """Infer which capabilities were exercised this turn."""
         capabilities = ["respond"]  # Always present — pipeline produced a response
 

--- a/phionyx_core/pipeline/blocks/perceptual_frame_emit.py
+++ b/phionyx_core/pipeline/blocks/perceptual_frame_emit.py
@@ -10,9 +10,8 @@ Emits a PerceptualFrame from measurement data and context.
 """
 
 import logging
-from typing import Optional
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -28,14 +27,14 @@ class PerceptualFrameEmitBlock(PipelineBlock):
     def __init__(self):
         super().__init__("perceptual_frame_emit")
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         return None
 
     async def execute(self, context: BlockContext) -> BlockResult:
         try:
-            from ...contracts.v4.perceptual_frame import PerceptualFrame, Modality
+            from ...contracts.v4.perceptual_frame import Modality, PerceptualFrame
 
             metadata = context.metadata or {}
             measurement = metadata.get("measurement_vector", {})

--- a/phionyx_core/pipeline/blocks/phi_computation.py
+++ b/phionyx_core/pipeline/blocks/phi_computation.py
@@ -7,9 +7,9 @@ Computes phi (integrated information) value from physics state.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +18,9 @@ class PhiComputationProtocol(Protocol):
     """Protocol for phi computation."""
     def compute_phi(
         self,
-        physics_state: Dict[str, Any],
-        previous_phi: Optional[float] = None
-    ) -> Dict[str, Any]:
+        physics_state: dict[str, Any],
+        previous_phi: float | None = None
+    ) -> dict[str, Any]:
         """Compute phi value from physics state."""
         ...
 
@@ -33,7 +33,7 @@ class PhiComputationBlock(PipelineBlock):
     This is an always-on block.
     """
 
-    def __init__(self, phi_computer: Optional[PhiComputationProtocol] = None):
+    def __init__(self, phi_computer: PhiComputationProtocol | None = None):
         """
         Initialize block.
 

--- a/phionyx_core/pipeline/blocks/phi_publish.py
+++ b/phionyx_core/pipeline/blocks/phi_publish.py
@@ -7,9 +7,9 @@ Publishes phi value to unified state.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class PhiPublisherProtocol(Protocol):
         self,
         unified_state: Any,
         phi_value: float,
-        phi_components: Optional[Dict[str, Any]] = None
+        phi_components: dict[str, Any] | None = None
     ) -> Any:  # Returns updated unified_state
         """Publish phi to unified state."""
         ...
@@ -33,7 +33,7 @@ class PhiPublishBlock(PipelineBlock):
     Publishes phi value to unified state.
     """
 
-    def __init__(self, publisher: Optional[PhiPublisherProtocol] = None):
+    def __init__(self, publisher: PhiPublisherProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class PhiPublishBlock(PipelineBlock):
         super().__init__("phi_publish")
         self.publisher = publisher
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no unified_state — output is not consumed downstream."""
         metadata = context.metadata or {}
         if not metadata.get("unified_state"):

--- a/phionyx_core/pipeline/blocks/response_build.py
+++ b/phionyx_core/pipeline/blocks/response_build.py
@@ -7,9 +7,9 @@ Builds final response payload (always-on block).
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -20,21 +20,21 @@ class ResponseBuilderProtocol(Protocol):
         self,
         frame: Any,
         narrative_response: str,
-        physics_state: Dict[str, Any],
-        emotional_state: Optional[Dict[str, Any]] = None,
-        memory_result: Optional[Any] = None,
-        growth_metrics: Optional[Dict[str, Any]] = None,
-        confidence_result: Optional[Any] = None,
-        cep_metrics: Optional[Dict[str, Any]] = None,
-        cep_flags: Optional[Dict[str, Any]] = None,
-        entropy_modulated_amplitude: Optional[float] = None,
-        behavior_modulation: Optional[Dict[str, Any]] = None,
-        current_unified_state: Optional[Any] = None,
+        physics_state: dict[str, Any],
+        emotional_state: dict[str, Any] | None = None,
+        memory_result: Any | None = None,
+        growth_metrics: dict[str, Any] | None = None,
+        confidence_result: Any | None = None,
+        cep_metrics: dict[str, Any] | None = None,
+        cep_flags: dict[str, Any] | None = None,
+        entropy_modulated_amplitude: float | None = None,
+        behavior_modulation: dict[str, Any] | None = None,
+        current_unified_state: Any | None = None,
         esc_available: bool = False,
-        mode: Optional[str] = None,
-        strategy: Optional[str] = None,
-        prompt_context: Optional[str] = None
-    ) -> Dict[str, Any]:  # Returns response payload
+        mode: str | None = None,
+        strategy: str | None = None,
+        prompt_context: str | None = None
+    ) -> dict[str, Any]:  # Returns response payload
         """Build response payload."""
         ...
 

--- a/phionyx_core/pipeline/blocks/response_revision_gate.py
+++ b/phionyx_core/pipeline/blocks/response_revision_gate.py
@@ -28,8 +28,9 @@ exercised directly by behavioural tests today.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, Mapping, Optional
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from typing import Any
 
 from ..base import BlockContext, BlockResult, PipelineBlock
 
@@ -91,7 +92,7 @@ class RevisionThresholds:
     # Drift
     drift_rewrite: float = 0.60
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> dict[str, float]:
         return asdict(self)
 
 
@@ -101,12 +102,12 @@ class RevisionDirective:
 
     directive: str = DIRECTIVE_PASS
     reasons: list = field(default_factory=list)
-    damp_factor: Optional[float] = None   # only set for DAMP
-    entropy_floor: Optional[float] = None  # SF2 C1 entropy floor when damping
-    state_snapshot: Dict[str, Any] = field(default_factory=dict)
+    damp_factor: float | None = None   # only set for DAMP
+    entropy_floor: float | None = None  # SF2 C1 entropy floor when damping
+    state_snapshot: dict[str, Any] = field(default_factory=dict)
     claim_refs: tuple = field(default_factory=tuple)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
         d["claim_refs"] = list(self.claim_refs)
         return d
@@ -164,17 +165,17 @@ class ResponseRevisionGateBlock(PipelineBlock):
         "SF2:C1", "SF2:C11",
     )
 
-    def __init__(self, thresholds: Optional[RevisionThresholds] = None):
+    def __init__(self, thresholds: RevisionThresholds | None = None):
         super().__init__("response_revision_gate", claim_refs=self.CLAIM_REFS)
         self.thresholds = thresholds or RevisionThresholds()
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Never skip — missing signals are handled by the decision logic."""
         return None
 
     # ----- decision helpers -------------------------------------------------
 
-    def _extract_state(self, context: BlockContext) -> Dict[str, Any]:
+    def _extract_state(self, context: BlockContext) -> dict[str, Any]:
         """Collect the state signals this gate cares about."""
         metadata = context.metadata or {}
         physics_state = metadata.get("physics_state") or {}
@@ -319,8 +320,8 @@ class ResponseRevisionGateBlock(PipelineBlock):
         if s["cep_flagged"]:
             escalate(DIRECTIVE_REWRITE, "cep_flagged")
 
-        damp_factor: Optional[float] = None
-        entropy_floor: Optional[float] = None
+        damp_factor: float | None = None
+        entropy_floor: float | None = None
         if current == DIRECTIVE_DAMP:
             damp_factor = _compute_damp_factor(s["entropy"], t)
             # SF2 C9: entropy floor = max(current_entropy, min_threshold)

--- a/phionyx_core/pipeline/blocks/root_cause_analysis.py
+++ b/phionyx_core/pipeline/blocks/root_cause_analysis.py
@@ -10,7 +10,7 @@ Position in pipeline: After counterfactual_analysis, when anomalies detected.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/self_model_assessment.py
+++ b/phionyx_core/pipeline/blocks/self_model_assessment.py
@@ -11,7 +11,7 @@ Position in pipeline: After confidence_fusion, before narrative_layer.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/state_update_physics.py
+++ b/phionyx_core/pipeline/blocks/state_update_physics.py
@@ -7,9 +7,9 @@ Final physics state update (always-on block).
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +18,9 @@ class PhysicsStateUpdaterProtocol(Protocol):
     """Protocol for physics state update."""
     def update_physics_state(
         self,
-        physics_state: Dict[str, Any],
-        unified_state: Optional[Any]
-    ) -> Dict[str, Any]:  # Returns updated physics_state
+        physics_state: dict[str, Any],
+        unified_state: Any | None
+    ) -> dict[str, Any]:  # Returns updated physics_state
         """Update physics state from unified state."""
         ...
 
@@ -33,7 +33,7 @@ class StateUpdatePhysicsBlock(PipelineBlock):
     This block MUST ALWAYS run, even on early exit.
     """
 
-    def __init__(self, updater: Optional[PhysicsStateUpdaterProtocol] = None):
+    def __init__(self, updater: PhysicsStateUpdaterProtocol | None = None):
         """
         Initialize block.
 
@@ -43,7 +43,7 @@ class StateUpdatePhysicsBlock(PipelineBlock):
         super().__init__("state_update_physics")
         self.updater = updater
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip only if there is no physics_state at all — nothing to update."""
         metadata = context.metadata or {}
         # Run if physics_state exists (even without unified_state):

--- a/phionyx_core/pipeline/blocks/time_update_sot.py
+++ b/phionyx_core/pipeline/blocks/time_update_sot.py
@@ -7,9 +7,9 @@ Updates time semantics using TimeManager (single source of truth per Echoism Cor
 """
 
 import logging
-from typing import Optional, Protocol
+from typing import Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class TimeUpdateSotBlock(PipelineBlock):
         self.time_manager = time_manager
         self.participant_id = participant_id
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if time_manager not available."""
         if self.time_manager is None:
             return "time_manager_not_available"

--- a/phionyx_core/pipeline/blocks/trust_evaluation.py
+++ b/phionyx_core/pipeline/blocks/trust_evaluation.py
@@ -11,7 +11,7 @@ Position in pipeline: After cognitive_layer, before narrative_layer.
 
 import logging
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/pipeline/blocks/ukf_predict.py
+++ b/phionyx_core/pipeline/blocks/ukf_predict.py
@@ -7,9 +7,9 @@ Performs UKF (Unscented Kalman Filter) prediction for state estimation.
 """
 
 import logging
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ class UkfPredictBlock(PipelineBlock):
     Performs UKF prediction to estimate next state.
     """
 
-    def __init__(self, predictor: Optional[UKFPredictorProtocol] = None):
+    def __init__(self, predictor: UKFPredictorProtocol | None = None):
         """
         Initialize block.
 
@@ -42,7 +42,7 @@ class UkfPredictBlock(PipelineBlock):
         super().__init__("ukf_predict")
         self.predictor = predictor
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no predictor available."""
         if self.predictor is None:
             return "ukf_predictor_not_available"

--- a/phionyx_core/pipeline/blocks/unified_state_update_esc.py
+++ b/phionyx_core/pipeline/blocks/unified_state_update_esc.py
@@ -7,9 +7,9 @@ Updates unified state (EchoState2) from physics state.
 """
 
 import logging
-from typing import Dict, Any, Optional, Protocol
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +19,7 @@ class UnifiedStateUpdaterProtocol(Protocol):
     def update_from_physics_state(
         self,
         unified_state: Any,
-        physics_state: Dict[str, Any]
+        physics_state: dict[str, Any]
     ) -> Any:  # Returns updated unified_state
         """Update unified state from physics state."""
         ...
@@ -32,7 +32,7 @@ class UnifiedStateUpdateEscBlock(PipelineBlock):
     Updates unified state (EchoState2) from physics state.
     """
 
-    def __init__(self, updater: Optional[UnifiedStateUpdaterProtocol] = None):
+    def __init__(self, updater: UnifiedStateUpdaterProtocol | None = None):
         """
         Initialize block.
 
@@ -42,7 +42,7 @@ class UnifiedStateUpdateEscBlock(PipelineBlock):
         super().__init__("unified_state_update_esc")
         self.updater = updater
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         """Skip if no updater or unified_state available."""
         metadata = context.metadata or {}
         if not self.updater or not metadata.get("unified_state"):

--- a/phionyx_core/pipeline/blocks/workspace_broadcast.py
+++ b/phionyx_core/pipeline/blocks/workspace_broadcast.py
@@ -11,9 +11,9 @@ High-salience events are broadcast to all subscribed modules.
 """
 
 import logging
-from typing import Optional, Protocol, List, Any
+from typing import Any, Protocol
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 class GlobalWorkspaceProtocol(Protocol):
     """Protocol for global workspace service."""
     async def broadcast(self, event: Any) -> None: ...
-    async def get_pending_events(self) -> List[Any]: ...
+    async def get_pending_events(self) -> list[Any]: ...
 
 
 class WorkspaceBroadcastBlock(PipelineBlock):
@@ -32,18 +32,18 @@ class WorkspaceBroadcastBlock(PipelineBlock):
     and broadcasts them to subscribed modules.
     """
 
-    def __init__(self, workspace: Optional[GlobalWorkspaceProtocol] = None):
+    def __init__(self, workspace: GlobalWorkspaceProtocol | None = None):
         super().__init__("workspace_broadcast")
         self.workspace = workspace
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         return None
 
     async def execute(self, context: BlockContext) -> BlockResult:
         try:
-            from ...contracts.v4.workspace_event import WorkspaceEvent, SalienceLevel
+            from ...contracts.v4.workspace_event import SalienceLevel, WorkspaceEvent
 
             metadata = context.metadata or {}
             events_broadcast = 0

--- a/phionyx_core/pipeline/blocks/world_state_snapshot.py
+++ b/phionyx_core/pipeline/blocks/world_state_snapshot.py
@@ -10,9 +10,8 @@ Captures full world state snapshot after physics update.
 """
 
 import logging
-from typing import Optional
 
-from ..base import PipelineBlock, BlockContext, BlockResult
+from ..base import BlockContext, BlockResult, PipelineBlock
 
 logger = logging.getLogger(__name__)
 
@@ -28,14 +27,14 @@ class WorldStateSnapshotBlock(PipelineBlock):
     def __init__(self):
         super().__init__("world_state_snapshot")
 
-    def should_skip(self, context: BlockContext) -> Optional[str]:
+    def should_skip(self, context: BlockContext) -> str | None:
         if context.pipeline_version < "3.0.0":
             return "v4_block_requires_pipeline_v3"
         return None
 
     async def execute(self, context: BlockContext) -> BlockResult:
         try:
-            from ...contracts.v4.world_state_snapshot import WorldStateSnapshot, ArbitrationStatus
+            from ...contracts.v4.world_state_snapshot import ArbitrationStatus, WorldStateSnapshot
 
             metadata = context.metadata or {}
             unified_state = metadata.get("unified_state")

--- a/phionyx_core/planning/__init__.py
+++ b/phionyx_core/planning/__init__.py
@@ -8,7 +8,7 @@ Components:
 - GoalDecomposer: Breaks high-level goals into sub-goals
 """
 
-from .goal_decomposer import GoalDecomposer, SubGoal, DecompositionPlan
+from .goal_decomposer import DecompositionPlan, GoalDecomposer, SubGoal
 
 __all__ = [
     "GoalDecomposer",

--- a/phionyx_core/planning/goal_decomposer.py
+++ b/phionyx_core/planning/goal_decomposer.py
@@ -18,9 +18,9 @@ Integrates with:
 """
 
 import logging
-from typing import List, Dict, Optional, Any, Set
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +47,10 @@ class SubGoal:
     parent_goal_id: str = ""
     status: str = SubGoalStatus.PENDING.value
     priority: int = 0                  # Lower = higher priority (execution order)
-    prerequisites: List[str] = field(default_factory=list)  # Sub-goal IDs this depends on
+    prerequisites: list[str] = field(default_factory=list)  # Sub-goal IDs this depends on
     action_type: str = "respond"       # ActionType from action_intent
     estimated_complexity: float = 0.5  # 0.0-1.0
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     @property
     def is_ready(self) -> bool:
@@ -66,12 +66,12 @@ class DecompositionPlan:
     """Full decomposition of a goal into sub-goals."""
     goal_id: str
     goal_name: str
-    sub_goals: List[SubGoal]
-    execution_order: List[str]  # Sub-goal IDs in execution order
+    sub_goals: list[SubGoal]
+    execution_order: list[str]  # Sub-goal IDs in execution order
     total_complexity: float
     estimated_steps: int
 
-    def get_ready_goals(self, completed: Optional[Set[str]] = None) -> List[SubGoal]:
+    def get_ready_goals(self, completed: set[str] | None = None) -> list[SubGoal]:
         """Get sub-goals whose prerequisites are all completed."""
         completed = completed or set()
         ready = []
@@ -97,7 +97,7 @@ class DecompositionPlan:
         completed = sum(1 for sg in self.sub_goals if sg.is_complete)
         return completed / len(self.sub_goals)
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "goal_id": self.goal_id,
             "goal_name": self.goal_name,
@@ -147,10 +147,10 @@ class GoalDecomposer:
         self,
         goal_id: str,
         goal_name: str,
-        requirements: List[str],
-        dependencies: Optional[Dict[str, List[str]]] = None,
-        action_types: Optional[Dict[str, str]] = None,
-        complexities: Optional[Dict[str, float]] = None,
+        requirements: list[str],
+        dependencies: dict[str, list[str]] | None = None,
+        action_types: dict[str, str] | None = None,
+        complexities: dict[str, float] | None = None,
     ) -> DecompositionPlan:
         """
         Decompose a goal into sub-goals.
@@ -174,8 +174,8 @@ class GoalDecomposer:
         reqs = requirements[:self.max_sub_goals]
 
         # Create sub-goals
-        name_to_id: Dict[str, str] = {}
-        sub_goals: List[SubGoal] = []
+        name_to_id: dict[str, str] = {}
+        sub_goals: list[SubGoal] = []
 
         for i, req in enumerate(reqs):
             sg_id = f"sg_{goal_id}_{i}"
@@ -218,8 +218,8 @@ class GoalDecomposer:
         self,
         goal_id: str,
         goal_name: str,
-        requirements: List[str],
-        causal_dependencies: List[tuple],
+        requirements: list[str],
+        causal_dependencies: list[tuple],
     ) -> DecompositionPlan:
         """
         Decompose using causal graph hints for dependency ordering.
@@ -227,7 +227,7 @@ class GoalDecomposer:
         Args:
             causal_dependencies: List of (cause_req, effect_req) tuples
         """
-        deps: Dict[str, List[str]] = {}
+        deps: dict[str, list[str]] = {}
         for cause, effect in causal_dependencies:
             if effect not in deps:
                 deps[effect] = []
@@ -240,10 +240,10 @@ class GoalDecomposer:
             dependencies=deps,
         )
 
-    def _topological_sort(self, sub_goals: List[SubGoal]) -> List[str]:
+    def _topological_sort(self, sub_goals: list[SubGoal]) -> list[str]:
         """Sort sub-goals by dependency order."""
         id_to_sg = {sg.sub_goal_id: sg for sg in sub_goals}
-        in_degree: Dict[str, int] = {sg.sub_goal_id: 0 for sg in sub_goals}
+        in_degree: dict[str, int] = {sg.sub_goal_id: 0 for sg in sub_goals}
 
         for sg in sub_goals:
             for prereq in sg.prerequisites:

--- a/phionyx_core/planning/goal_persistence.py
+++ b/phionyx_core/planning/goal_persistence.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -43,15 +43,15 @@ class PersistentGoal:
     status: GoalStatus = GoalStatus.PENDING
     priority: GoalPriority = GoalPriority.MEDIUM
     created_at: str = ""
-    activated_at: Optional[str] = None
-    completed_at: Optional[str] = None
+    activated_at: str | None = None
+    completed_at: str | None = None
     session_created: str = ""
     session_last_active: str = ""
     progress: float = 0.0  # 0.0-1.0
-    sub_goal_ids: List[str] = field(default_factory=list)
-    parent_goal_id: Optional[str] = None
-    conflicts_with: List[str] = field(default_factory=list)
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    sub_goal_ids: list[str] = field(default_factory=list)
+    parent_goal_id: str | None = None
+    conflicts_with: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         if not self.created_at:
@@ -77,7 +77,7 @@ class GoalPersistenceReport:
     pending_goals: int
     blocked_goals: int
     abandoned_goals: int
-    conflicts: List[ConflictReport]
+    conflicts: list[ConflictReport]
     cross_session_goals: int  # Goals spanning multiple sessions
 
 
@@ -94,9 +94,9 @@ class GoalPersistence:
     """
 
     def __init__(self):
-        self._goals: Dict[str, PersistentGoal] = {}
+        self._goals: dict[str, PersistentGoal] = {}
         self._session_id: str = ""
-        self._conflicts: List[ConflictReport] = []
+        self._conflicts: list[ConflictReport] = []
         self._auto_save_enabled: bool = False
         self._auto_save_path: str = "data/goals"
 
@@ -124,7 +124,7 @@ class GoalPersistence:
         name: str,
         description: str = "",
         priority: GoalPriority = GoalPriority.MEDIUM,
-        parent_goal_id: Optional[str] = None,
+        parent_goal_id: str | None = None,
     ) -> PersistentGoal:
         """Add a new goal."""
         if goal_id in self._goals:
@@ -203,11 +203,11 @@ class GoalPersistence:
         self._trigger_auto_save()
         return True
 
-    def get_goal(self, goal_id: str) -> Optional[PersistentGoal]:
+    def get_goal(self, goal_id: str) -> PersistentGoal | None:
         """Get a goal by ID."""
         return self._goals.get(goal_id)
 
-    def get_active_goals(self) -> List[PersistentGoal]:
+    def get_active_goals(self) -> list[PersistentGoal]:
         """Get all active goals, sorted by priority."""
         priority_order = {
             GoalPriority.CRITICAL: 0,
@@ -218,11 +218,11 @@ class GoalPersistence:
         active = [g for g in self._goals.values() if g.status == GoalStatus.ACTIVE]
         return sorted(active, key=lambda g: priority_order.get(g.priority, 99))
 
-    def get_goals_by_status(self, status: GoalStatus) -> List[PersistentGoal]:
+    def get_goals_by_status(self, status: GoalStatus) -> list[PersistentGoal]:
         """Get goals filtered by status."""
         return [g for g in self._goals.values() if g.status == status]
 
-    def detect_conflicts(self) -> List[ConflictReport]:
+    def detect_conflicts(self) -> list[ConflictReport]:
         """
         Detect conflicts between active goals.
 
@@ -268,7 +268,7 @@ class GoalPersistence:
         self._conflicts = conflicts
         return conflicts
 
-    def get_cross_session_goals(self) -> List[PersistentGoal]:
+    def get_cross_session_goals(self) -> list[PersistentGoal]:
         """Get goals that span multiple sessions."""
         return [
             g for g in self._goals.values()
@@ -300,7 +300,7 @@ class GoalPersistence:
         goal_id: str,
         reason: str,
         evidence: str = "",
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Propose a revision to an existing goal (Reflect → Plan feedback).
 
@@ -316,7 +316,7 @@ class GoalPersistence:
             Revision proposal dict, or None if goal not found or already proposed
         """
         if not hasattr(self, '_pending_revisions'):
-            self._pending_revisions: List[Dict[str, Any]] = []
+            self._pending_revisions: list[dict[str, Any]] = []
 
         if goal_id not in self._goals:
             return None
@@ -341,7 +341,7 @@ class GoalPersistence:
         self._trigger_auto_save()
         return revision
 
-    def get_pending_revisions(self) -> List[Dict[str, Any]]:
+    def get_pending_revisions(self) -> list[dict[str, Any]]:
         """Get all pending (unapplied) revision proposals."""
         if not hasattr(self, '_pending_revisions'):
             return []
@@ -364,7 +364,7 @@ class GoalPersistence:
                 return True
         return False
 
-    def auto_save(self, base_path: str = "data/goals") -> Optional[str]:
+    def auto_save(self, base_path: str = "data/goals") -> str | None:
         """Auto-save goals to JSON file for cross-session persistence.
 
         Saves to {base_path}/{session_id}.json on every state change.
@@ -401,7 +401,7 @@ class GoalPersistence:
             return None
 
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 data = json.load(f)
             instance = cls.from_dict(data)
             logger.info("Goals auto-loaded from %s (%d goals)", file_path, len(instance._goals))
@@ -410,7 +410,7 @@ class GoalPersistence:
             logger.error("Auto-load failed for %s: %s", file_path, e)
             return None
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize for persistence."""
         result = {
             "session_id": self._session_id,
@@ -440,7 +440,7 @@ class GoalPersistence:
         return result
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "GoalPersistence":
+    def from_dict(cls, data: dict[str, Any]) -> "GoalPersistence":
         """Restore from serialized data."""
         instance = cls()
         instance._session_id = data.get("session_id", "")

--- a/phionyx_core/policy/__init__.py
+++ b/phionyx_core/policy/__init__.py
@@ -2,8 +2,8 @@
 Phionyx Policy SDK Package
 """
 
-from .policies import Policy, PolicyPresets
 from .engine import PolicyEngine
+from .policies import Policy, PolicyPresets
 
 __all__ = [
     "Policy",

--- a/phionyx_core/policy/engine.py
+++ b/phionyx_core/policy/engine.py
@@ -6,7 +6,7 @@ Selects appropriate behavioral policy based on context, risk level, and user rol
 """
 
 import logging
-from typing import Optional, Dict, Any
+from typing import Any
 
 from .policies import Policy, PolicyPresets
 
@@ -23,7 +23,7 @@ class PolicyEngine:
     - User role (teacher, student, etc.)
     """
 
-    def __init__(self, mode: Optional[str] = None, **kwargs):
+    def __init__(self, mode: str | None = None, **kwargs):
         """
         Initialize policy engine.
 
@@ -37,10 +37,10 @@ class PolicyEngine:
 
     def select_policy(
         self,
-        context_mode: Optional[str] = None,
+        context_mode: str | None = None,
         risk_level: int = 0,
-        user_role: Optional[str] = None,
-        additional_context: Optional[Dict[str, Any]] = None
+        user_role: str | None = None,
+        additional_context: dict[str, Any] | None = None
     ) -> Policy:
         """
         Select appropriate policy based on context.
@@ -140,7 +140,7 @@ class PolicyEngine:
         )
         return self.presets.DEFAULT_POLICY
 
-    def get_policy_config(self, policy: Policy) -> Dict[str, Any]:
+    def get_policy_config(self, policy: Policy) -> dict[str, Any]:
         """
         Convert policy to configuration dictionary for LLM calls.
 

--- a/phionyx_core/policy/policies.py
+++ b/phionyx_core/policy/policies.py
@@ -6,9 +6,8 @@ Defines behavioral policies for different contexts (School vs Game).
 Each policy controls temperature, tone, safety strictness, and interaction style.
 """
 
-from dataclasses import dataclass
-from typing import Optional
 import logging
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +30,8 @@ class Policy:
     tone: str
     safety_strictness: int
     interaction_style: str
-    max_tokens: Optional[int] = None
-    system_prompt_modifier: Optional[str] = None
+    max_tokens: int | None = None
+    system_prompt_modifier: str | None = None
 
     def __post_init__(self):
         """Validate policy parameters."""
@@ -118,7 +117,7 @@ class PolicyPresets:
     )
 
     @classmethod
-    def get_preset(cls, preset_name: str) -> Optional[Policy]:
+    def get_preset(cls, preset_name: str) -> Policy | None:
         """
         Get a preset policy by name.
 

--- a/phionyx_core/ports/__init__.py
+++ b/phionyx_core/ports/__init__.py
@@ -12,13 +12,13 @@ Port-Adapter Pattern:
 - Product profiles select which ports to use
 """
 
-from .physics_port import PhysicsPort
-from .memory_port import MemoryPort
 from .intuition_port import IntuitionPort
-from .pedagogy_port import PedagogyPort
-from .policy_port import PolicyPort
-from .narrative_port import NarrativePort
+from .memory_port import MemoryPort
 from .meta_port import MetaPort
+from .narrative_port import NarrativePort
+from .pedagogy_port import PedagogyPort
+from .physics_port import PhysicsPort
+from .policy_port import PolicyPort
 
 # NOTE: OfstedPort moved to apps/school_ingest/ports/ofsted_port.py
 # Per Echoism Core v1.0: Ofsted is product-specific, not part of core SDK

--- a/phionyx_core/ports/goal_port.py
+++ b/phionyx_core/ports/goal_port.py
@@ -6,7 +6,7 @@ Port interface for goal management (AD-2: port-adapter pattern).
 """
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Any
+from typing import Any
 
 
 class GoalPort(ABC):
@@ -18,17 +18,17 @@ class GoalPort(ABC):
         ...
 
     @abstractmethod
-    async def get_active_goals(self) -> List[Any]:
+    async def get_active_goals(self) -> list[Any]:
         """Get active goals."""
         ...
 
     @abstractmethod
-    async def evaluate_goals(self, context: Any) -> List[Any]:
+    async def evaluate_goals(self, context: Any) -> list[Any]:
         """Evaluate goals against context."""
         ...
 
     @abstractmethod
-    async def complete_goal(self, goal_id: str) -> Optional[Any]:
+    async def complete_goal(self, goal_id: str) -> Any | None:
         """Mark goal as completed."""
         ...
 
@@ -39,11 +39,11 @@ class NullGoalPort(GoalPort):
     async def register_goal(self, goal: Any) -> Any:
         return goal
 
-    async def get_active_goals(self) -> List[Any]:
+    async def get_active_goals(self) -> list[Any]:
         return []
 
-    async def evaluate_goals(self, context: Any) -> List[Any]:
+    async def evaluate_goals(self, context: Any) -> list[Any]:
         return []
 
-    async def complete_goal(self, goal_id: str) -> Optional[Any]:
+    async def complete_goal(self, goal_id: str) -> Any | None:
         return None

--- a/phionyx_core/ports/intuition_port.py
+++ b/phionyx_core/ports/intuition_port.py
@@ -7,7 +7,7 @@ Enables swapping GraphRAG with Null implementation.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
+from typing import Any
 
 
 class IntuitionPort(ABC):
@@ -17,7 +17,7 @@ class IntuitionPort(ABC):
     async def extract_concepts(
         self,
         text: str
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Extract concepts from text.
 
@@ -30,8 +30,8 @@ class IntuitionPort(ABC):
     async def discover_hidden_context(
         self,
         user_text: str,  # SPRINT 5: Accept user_text (will extract concepts internally)
-        actor_ref: Optional[str] = None  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
-    ) -> Optional[Dict[str, Any]]:
+        actor_ref: str | None = None  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
+    ) -> dict[str, Any] | None:
         """
         Discover hidden context from user text using GraphRAG.
 
@@ -47,9 +47,9 @@ class IntuitionPort(ABC):
     @abstractmethod
     async def infer_hidden_context(
         self,
-        concepts: List[str],
-        actor_ref: Optional[str] = None  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
-    ) -> Optional[Dict[str, Any]]:
+        concepts: list[str],
+        actor_ref: str | None = None  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
+    ) -> dict[str, Any] | None:
         """
         Infer hidden context from concepts using GraphRAG.
 
@@ -65,9 +65,9 @@ class IntuitionPort(ABC):
     @abstractmethod
     async def build_concept_graph(
         self,
-        concepts: List[str],
-        relationships: Optional[List[Dict[str, Any]]] = None
-    ) -> Optional[Dict[str, Any]]:
+        concepts: list[str],
+        relationships: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any] | None:
         """Build concept graph."""
         pass
 

--- a/phionyx_core/ports/memory_port.py
+++ b/phionyx_core/ports/memory_port.py
@@ -7,7 +7,7 @@ Enables swapping Memory with Null implementation.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, List, Optional
+from typing import Any
 
 
 class MemoryPort(ABC):
@@ -19,8 +19,8 @@ class MemoryPort(ABC):
         content: str,
         actor_ref: str,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
         importance: float,
-        metadata: Optional[Dict[str, Any]] = None
-    ) -> Optional[str]:
+        metadata: dict[str, Any] | None = None
+    ) -> str | None:
         """
         Add memory to vector store.
 
@@ -41,7 +41,7 @@ class MemoryPort(ABC):
         query: str,
         actor_ref: str,  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
         limit: int = 5
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Search memories by semantic similarity.
 
@@ -60,7 +60,7 @@ class MemoryPort(ABC):
         self,
         memory_id: str,
         actor_ref: str  # SPRINT 5: Replaced user_id with actor_ref (core-neutral)
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Get memory by ID.
 

--- a/phionyx_core/ports/meta_port.py
+++ b/phionyx_core/ports/meta_port.py
@@ -7,7 +7,7 @@ Enables swapping Meta with Null implementation.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional, List
+from typing import Any
 
 
 class MetaPort(ABC):
@@ -17,9 +17,9 @@ class MetaPort(ABC):
     async def estimate_confidence(
         self,
         user_input: str,
-        context: Optional[str] = None,
-        memory_matches: Optional[List[Dict[str, Any]]] = None
-    ) -> Dict[str, Any]:
+        context: str | None = None,
+        memory_matches: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any]:
         """
         Estimate confidence in response.
 

--- a/phionyx_core/ports/narrative_port.py
+++ b/phionyx_core/ports/narrative_port.py
@@ -7,7 +7,6 @@ Enables swapping between SIMPLE, RICH, and THERAPEUTIC modes.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional, List
 
 
 class NarrativePort(ABC):
@@ -18,10 +17,10 @@ class NarrativePort(ABC):
         self,
         user_input: str,
         context: str,
-        physics_state: Dict[str, float],
+        physics_state: dict[str, float],
         model_id: str,
         system_prompt: str,
-        temperature: Optional[float] = None
+        temperature: float | None = None
     ) -> str:
         """
         Generate narrative response.
@@ -45,7 +44,7 @@ class NarrativePort(ABC):
     async def apply_filters(
         self,
         narrative: str,
-        filters: List[str]
+        filters: list[str]
     ) -> str:
         """Apply safety/content filters to narrative."""
         pass

--- a/phionyx_core/ports/null_implementations.py
+++ b/phionyx_core/ports/null_implementations.py
@@ -11,15 +11,15 @@ Key Principle:
 - No errors, just "module not available" behavior
 """
 
-from typing import Dict, Any, List, Optional
+from typing import Any
 
-from .physics_port import PhysicsPort
-from .memory_port import MemoryPort
 from .intuition_port import IntuitionPort
-from .pedagogy_port import PedagogyPort
-from .policy_port import PolicyPort
-from .narrative_port import NarrativePort
+from .memory_port import MemoryPort
 from .meta_port import MetaPort
+from .narrative_port import NarrativePort
+from .pedagogy_port import PedagogyPort
+from .physics_port import PhysicsPort
+from .policy_port import PolicyPort
 
 
 class NullPhysicsEngine(PhysicsPort):
@@ -38,7 +38,7 @@ class NullPhysicsEngine(PhysicsPort):
         w_p: float = 0.5,
         context_mode: str = "DEFAULT",
         entropy_penalty_k: float = 0.5
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """Calculate phi using direct SDK if available, otherwise return safe defaults."""
         try:
             # Try to use real physics calculation
@@ -90,8 +90,8 @@ class NullMemoryEngine(MemoryPort):
         content: str,
         user_id: str,
         importance: float,
-        metadata: Optional[Dict[str, Any]] = None
-    ) -> Optional[str]:
+        metadata: dict[str, Any] | None = None
+    ) -> str | None:
         """Memory not available - return None."""
         return None
 
@@ -99,8 +99,8 @@ class NullMemoryEngine(MemoryPort):
         self,
         query: str,
         limit: int = 5,
-        user_id: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
+        user_id: str | None = None
+    ) -> list[dict[str, Any]]:
         """Search memories - Null implementation returns empty list."""
         return []
 
@@ -109,7 +109,7 @@ class NullMemoryEngine(MemoryPort):
         query: str,
         user_id: str,
         limit: int = 5
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """No memories available - return empty list."""
         return []
 
@@ -117,7 +117,7 @@ class NullMemoryEngine(MemoryPort):
         self,
         memory_id: str,
         user_id: str
-    ) -> Optional[Dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         return None
 
     def is_connected(self) -> bool:
@@ -132,15 +132,15 @@ class NullIntuitionEngine(IntuitionPort):
         """Null implementation is always "available" (degraded mode)."""
         return True  # Return True so engine can use it (degraded)
 
-    async def extract_concepts(self, text: str) -> List[str]:
+    async def extract_concepts(self, text: str) -> list[str]:
         """No concept extraction - return empty list."""
         return []
 
     async def discover_hidden_context(
         self,
         user_text: str,
-        user_id: Optional[str] = None
-    ) -> Dict[str, Any]:
+        user_id: str | None = None
+    ) -> dict[str, Any]:
         """Null implementation returns empty context."""
         return {
             "intuitive_context": None,
@@ -150,17 +150,17 @@ class NullIntuitionEngine(IntuitionPort):
 
     async def infer_hidden_context(
         self,
-        concepts: List[str],
-        user_id: Optional[str] = None
-    ) -> Optional[Dict[str, Any]]:
+        concepts: list[str],
+        user_id: str | None = None
+    ) -> dict[str, Any] | None:
         """No hidden context inference - return None."""
         return None
 
     async def build_concept_graph(
         self,
-        concepts: List[str],
-        relationships: Optional[List[Dict[str, Any]]] = None
-    ) -> Optional[Dict[str, Any]]:
+        concepts: list[str],
+        relationships: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any] | None:
         return None
 
 
@@ -170,10 +170,10 @@ class NullPedagogyEngine(PedagogyPort):
     async def assess_risk(
         self,
         user_input: str,
-        physics_state: Dict[str, float],
-        actor_ref: Optional[str] = None,
-        tenant_ref: Optional[str] = None
-    ) -> Dict[str, Any]:
+        physics_state: dict[str, float],
+        actor_ref: str | None = None,
+        tenant_ref: str | None = None
+    ) -> dict[str, Any]:
         """Return safe default risk assessment."""
         return {
             "risk_level": 0,  # No risk
@@ -192,8 +192,8 @@ class NullPedagogyEngine(PedagogyPort):
         self,
         risk_type: str,
         language: str = "tr",
-        physics_state: Optional[Dict[str, float]] = None
-    ) -> Optional[str]:
+        physics_state: dict[str, float] | None = None
+    ) -> str | None:
         return None
 
     def get_strictness_level(self) -> str:
@@ -205,18 +205,18 @@ class NullPolicyEngine(PolicyPort):
 
     async def select_policy(
         self,
-        context_mode: Optional[str] = None,
+        context_mode: str | None = None,
         risk_level: int = 0,
-        user_role: Optional[str] = None
-    ) -> Optional[Any]:
+        user_role: str | None = None
+    ) -> Any | None:
         return None
 
     async def evaluate_content(
         self,
         content: str,
         policy: Any,
-        physics_state: Optional[Dict[str, float]] = None
-    ) -> Dict[str, Any]:
+        physics_state: dict[str, float] | None = None
+    ) -> dict[str, Any]:
         return {
             "decision": "allow",
             "blocking_reason": None
@@ -233,10 +233,10 @@ class NullNarrativeEngine(NarrativePort):
         self,
         user_input: str,
         context: str,
-        physics_state: Dict[str, float],
+        physics_state: dict[str, float],
         model_id: str,
         system_prompt: str,
-        temperature: Optional[float] = None
+        temperature: float | None = None
     ) -> str:
         """Return safe default response."""
         return "I'm here to help. Could you tell me more about what you're thinking?"
@@ -244,7 +244,7 @@ class NullNarrativeEngine(NarrativePort):
     def get_mode(self) -> str:
         return "simple"
 
-    async def apply_filters(self, narrative: str, filters: List[str]) -> str:
+    async def apply_filters(self, narrative: str, filters: list[str]) -> str:
         return narrative  # No filtering
 
 
@@ -254,9 +254,9 @@ class NullMetaEngine(MetaPort):
     async def estimate_confidence(
         self,
         user_input: str,
-        context: Optional[str] = None,
-        memory_matches: Optional[List[Dict[str, Any]]] = None
-    ) -> Dict[str, Any]:
+        context: str | None = None,
+        memory_matches: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any]:
         """Return safe default confidence."""
         return {
             "confidence_score": 0.7,  # Moderate confidence

--- a/phionyx_core/ports/pedagogy_port.py
+++ b/phionyx_core/ports/pedagogy_port.py
@@ -7,7 +7,7 @@ Enables swapping Pedagogy with different strictness levels.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
+from typing import Any
 
 
 class PedagogyPort(ABC):
@@ -17,10 +17,10 @@ class PedagogyPort(ABC):
     async def assess_risk(
         self,
         user_input: str,
-        physics_state: Dict[str, float],
-        actor_ref: Optional[str] = None,
-        tenant_ref: Optional[str] = None
-    ) -> Dict[str, Any]:
+        physics_state: dict[str, float],
+        actor_ref: str | None = None,
+        tenant_ref: str | None = None
+    ) -> dict[str, Any]:
         """
         Assess risk level for user input.
 
@@ -58,8 +58,8 @@ class PedagogyPort(ABC):
         self,
         risk_type: str,
         language: str = "tr",
-        physics_state: Optional[Dict[str, float]] = None
-    ) -> Optional[str]:
+        physics_state: dict[str, float] | None = None
+    ) -> str | None:
         """
         Get safe template for risk type.
 

--- a/phionyx_core/ports/physics_port.py
+++ b/phionyx_core/ports/physics_port.py
@@ -7,7 +7,6 @@ Enables swapping Physics v2.1 with Null implementation.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict
 
 
 class PhysicsPort(ABC):
@@ -27,7 +26,7 @@ class PhysicsPort(ABC):
         w_p: float = 0.5,
         context_mode: str = "DEFAULT",
         entropy_penalty_k: float = 1.0  # ⚠️ NEW: Entropy penalty coefficient (default 1.0, range [0, 2])
-    ) -> Dict[str, float]:
+    ) -> dict[str, float]:
         """
         Calculate Phi (Echo Quality) using Physics v2.1.
 

--- a/phionyx_core/ports/policy_port.py
+++ b/phionyx_core/ports/policy_port.py
@@ -7,7 +7,7 @@ Enables swapping Policy with different implementations.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
+from typing import Any
 
 
 class PolicyPort(ABC):
@@ -16,10 +16,10 @@ class PolicyPort(ABC):
     @abstractmethod
     async def select_policy(
         self,
-        context_mode: Optional[str] = None,
+        context_mode: str | None = None,
         risk_level: int = 0,
-        user_role: Optional[str] = None
-    ) -> Optional[Any]:
+        user_role: str | None = None
+    ) -> Any | None:
         """
         Select appropriate policy based on context.
 
@@ -33,8 +33,8 @@ class PolicyPort(ABC):
         self,
         content: str,
         policy: Any,
-        physics_state: Optional[Dict[str, float]] = None
-    ) -> Dict[str, Any]:
+        physics_state: dict[str, float] | None = None
+    ) -> dict[str, Any]:
         """
         Evaluate content against policy.
 

--- a/phionyx_core/profiles/__init__.py
+++ b/phionyx_core/profiles/__init__.py
@@ -6,28 +6,26 @@ Central configuration system that maps high-level personas (Teacher, Gamer)
 to low-level technical parameters across all SDK modules.
 """
 
-from .schema import (
-    Profile,
-    PhysicsConfig,
-    PedagogyConfig,
-    GovernanceConfig,
-    RoutingConfig,
-    BaseMode,
-    PIIMode,
-    AuditLevel,
-    LLMTierStrategy,
-)
-
 from .loader import ProfileLoader
-
 from .manager import (
-    ProfileManager,
-    PhysicsParams,
-    PedagogyParams,
     GovernanceParams,
-    get_global_manager,
+    PedagogyParams,
+    PhysicsParams,
+    ProfileManager,
     get_active_profile,
+    get_global_manager,
     set_active_profile,
+)
+from .schema import (
+    AuditLevel,
+    BaseMode,
+    GovernanceConfig,
+    LLMTierStrategy,
+    PedagogyConfig,
+    PhysicsConfig,
+    PIIMode,
+    Profile,
+    RoutingConfig,
 )
 
 __all__ = [

--- a/phionyx_core/profiles/compiler.py
+++ b/phionyx_core/profiles/compiler.py
@@ -8,8 +8,9 @@ Reduces runtime latency by pre-calculating parameter mappings.
 
 import json
 import logging
-from typing import Dict, Any, Optional, List
 from pathlib import Path
+from typing import Any
+
 from .schema import Profile
 from .tuner import ProfileTuner
 
@@ -26,7 +27,7 @@ class ProfileCompiler:
     - Caches results for fast runtime lookup
     """
 
-    def __init__(self, cache_dir: Optional[Path] = None):
+    def __init__(self, cache_dir: Path | None = None):
         """
         Initialize profile compiler.
 
@@ -37,7 +38,7 @@ class ProfileCompiler:
         self.cache_dir.mkdir(parents=True, exist_ok=True)
         self.tuner = ProfileTuner()
 
-    def compile_profile(self, profile: Profile) -> Dict[str, Any]:
+    def compile_profile(self, profile: Profile) -> dict[str, Any]:
         """
         Compile a profile to cached parameters.
 
@@ -106,7 +107,7 @@ class ProfileCompiler:
 
         return compiled
 
-    def save_compiled_profile(self, compiled: Dict[str, Any], profile_name: str):
+    def save_compiled_profile(self, compiled: dict[str, Any], profile_name: str):
         """
         Save compiled profile to cache.
 
@@ -128,7 +129,7 @@ class ProfileCompiler:
         except Exception as e:
             logger.error(f"Failed to save compiled profile: {e}")
 
-    def load_compiled_profile(self, profile_name: str) -> Optional[Dict[str, Any]]:
+    def load_compiled_profile(self, profile_name: str) -> dict[str, Any] | None:
         """
         Load compiled profile from cache.
 
@@ -144,7 +145,7 @@ class ProfileCompiler:
             return None
 
         try:
-            with open(cache_file, "r", encoding="utf-8") as f:
+            with open(cache_file, encoding="utf-8") as f:
                 compiled = json.load(f)
 
             logger.debug(f"Loaded compiled profile: {cache_file}")
@@ -154,7 +155,7 @@ class ProfileCompiler:
             logger.error(f"Failed to load compiled profile: {e}")
             return None
 
-    def compile_all_profiles(self, profiles: List[Profile]):
+    def compile_all_profiles(self, profiles: list[Profile]):
         """
         Compile all profiles and save to cache.
 
@@ -171,7 +172,7 @@ class ProfileCompiler:
                 logger.error(f"Failed to compile profile {profile.name}: {e}")
 
 
-def compile_profiles(profile_dir: Optional[Path] = None):
+def compile_profiles(profile_dir: Path | None = None):
     """
     Convenience function to compile all profiles from YAML.
 

--- a/phionyx_core/profiles/loader.py
+++ b/phionyx_core/profiles/loader.py
@@ -5,12 +5,13 @@ Profile Loader - YAML Loading and Merging Logic
 Loads profiles from YAML files and merges high-level personas with low-level defaults.
 """
 
-from typing import Dict, Any, Optional
-from pathlib import Path
-import yaml
 import logging
+from pathlib import Path
+from typing import Any
 
-from .schema import Profile, PhysicsConfig, PedagogyConfig, GovernanceConfig, RoutingConfig
+import yaml
+
+from .schema import GovernanceConfig, PedagogyConfig, PhysicsConfig, Profile, RoutingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,7 @@ class ProfileLoader:
     3. Merge persona overrides into defaults
     """
 
-    def __init__(self, config_dir: Optional[Path] = None):
+    def __init__(self, config_dir: Path | None = None):
         """
         Initialize profile loader.
 
@@ -41,10 +42,10 @@ class ProfileLoader:
         self.defaults_dir = self.config_dir / "defaults"
 
         # Cache loaded defaults
-        self._defaults_cache: Dict[str, Dict[str, Any]] = {}
-        self._profiles_cache: Dict[str, Profile] = {}
+        self._defaults_cache: dict[str, dict[str, Any]] = {}
+        self._profiles_cache: dict[str, Profile] = {}
 
-    def _load_defaults(self) -> Dict[str, Dict[str, Any]]:
+    def _load_defaults(self) -> dict[str, dict[str, Any]]:
         """
         Load all default YAML files from defaults/ directory.
 
@@ -59,7 +60,7 @@ class ProfileLoader:
         # Load physics defaults
         physics_file = self.defaults_dir / "physics.yaml"
         if physics_file.exists():
-            with open(physics_file, 'r', encoding='utf-8') as f:
+            with open(physics_file, encoding='utf-8') as f:
                 defaults['physics'] = yaml.safe_load(f) or {}
         else:
             logger.warning(f"Physics defaults not found: {physics_file}")
@@ -68,7 +69,7 @@ class ProfileLoader:
         # Load pedagogy defaults
         pedagogy_file = self.defaults_dir / "pedagogy.yaml"
         if pedagogy_file.exists():
-            with open(pedagogy_file, 'r', encoding='utf-8') as f:
+            with open(pedagogy_file, encoding='utf-8') as f:
                 defaults['pedagogy'] = yaml.safe_load(f) or {}
         else:
             logger.warning(f"Pedagogy defaults not found: {pedagogy_file}")
@@ -77,7 +78,7 @@ class ProfileLoader:
         # Load governance defaults
         governance_file = self.defaults_dir / "governance.yaml"
         if governance_file.exists():
-            with open(governance_file, 'r', encoding='utf-8') as f:
+            with open(governance_file, encoding='utf-8') as f:
                 defaults['governance'] = yaml.safe_load(f) or {}
         else:
             logger.warning(f"Governance defaults not found: {governance_file}")
@@ -86,7 +87,7 @@ class ProfileLoader:
         self._defaults_cache = defaults
         return defaults
 
-    def _merge_config(self, base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    def _merge_config(self, base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
         """
         Deep merge override into base.
 
@@ -107,7 +108,7 @@ class ProfileLoader:
 
         return result
 
-    def _load_profiles(self) -> Dict[str, Dict[str, Any]]:
+    def _load_profiles(self) -> dict[str, dict[str, Any]]:
         """
         Load profiles.yaml file.
 
@@ -120,7 +121,7 @@ class ProfileLoader:
                 f"Please create profiles.yaml with profile definitions."
             )
 
-        with open(self.profiles_file, 'r', encoding='utf-8') as f:
+        with open(self.profiles_file, encoding='utf-8') as f:
             data = yaml.safe_load(f)
 
         if not isinstance(data, dict) or 'profiles' not in data:

--- a/phionyx_core/profiles/manager.py
+++ b/phionyx_core/profiles/manager.py
@@ -6,12 +6,12 @@ Maps high-level profile knobs to low-level technical parameters across all SDK m
 This is the "brain" that distributes settings to all modules.
 """
 
-from typing import Dict, Any, Optional
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
+from typing import Any
 
-from .schema import Profile, RoutingConfig
 from .loader import ProfileLoader
+from .schema import Profile, RoutingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class ProfileManager:
     3. Returns structured params for each module
     """
 
-    def __init__(self, config_dir: Optional[str] = None):
+    def __init__(self, config_dir: str | None = None):
         """
         Initialize profile manager.
 
@@ -71,7 +71,7 @@ class ProfileManager:
             config_dir: Optional path to config directory
         """
         self.loader = ProfileLoader(config_dir)
-        self._active_profile: Optional[Profile] = None
+        self._active_profile: Profile | None = None
 
     def load_profile(self, profile_name: str) -> Profile:
         """
@@ -88,7 +88,7 @@ class ProfileManager:
         logger.info(f"Loaded profile: {profile_name}")
         return profile
 
-    def get_active_profile(self) -> Optional[Profile]:
+    def get_active_profile(self) -> Profile | None:
         """Get the currently active profile."""
         return self._active_profile
 
@@ -96,7 +96,7 @@ class ProfileManager:
     # Fan-Out Logic: High-Level → Low-Level Mapping
     # ========================================================================
 
-    def get_physics_params(self, profile: Optional[Profile] = None) -> PhysicsParams:
+    def get_physics_params(self, profile: Profile | None = None) -> PhysicsParams:
         """
         Map PhysicsConfig to low-level physics parameters.
 
@@ -147,7 +147,7 @@ class ProfileManager:
             safety_strictness=safety_strictness
         )
 
-    def get_pedagogy_params(self, profile: Optional[Profile] = None) -> PedagogyParams:
+    def get_pedagogy_params(self, profile: Profile | None = None) -> PedagogyParams:
         """
         Map PedagogyConfig to low-level pedagogy parameters.
 
@@ -171,7 +171,7 @@ class ProfileManager:
             vygotsky_zone=pedagogy.vygotsky_level
         )
 
-    def get_governance_params(self, profile: Optional[Profile] = None) -> GovernanceParams:
+    def get_governance_params(self, profile: Profile | None = None) -> GovernanceParams:
         """
         Map GovernanceConfig to low-level governance parameters.
 
@@ -196,7 +196,7 @@ class ProfileManager:
             regex_patterns=governance.custom_regex_patterns or []
         )
 
-    def get_routing_config(self, profile: Optional[Profile] = None) -> RoutingConfig:
+    def get_routing_config(self, profile: Profile | None = None) -> RoutingConfig:
         """
         Get routing configuration.
 
@@ -214,7 +214,7 @@ class ProfileManager:
 
         return profile.routing
 
-    def explain_mapping(self, profile: Optional[Profile] = None) -> Dict[str, Any]:
+    def explain_mapping(self, profile: Profile | None = None) -> dict[str, Any]:
         """
         Explain how a profile maps to low-level parameters (for debugging/UI).
 
@@ -288,7 +288,7 @@ class ProfileManager:
 # Singleton Helper Function
 # ============================================================================
 
-_global_manager: Optional[ProfileManager] = None
+_global_manager: ProfileManager | None = None
 
 
 def get_global_manager() -> ProfileManager:
@@ -306,7 +306,7 @@ def get_global_manager() -> ProfileManager:
     return _global_manager
 
 
-def get_active_profile() -> Optional[Profile]:
+def get_active_profile() -> Profile | None:
     """
     Get the globally active profile.
 

--- a/phionyx_core/profiles/profile_configs.py
+++ b/phionyx_core/profiles/profile_configs.py
@@ -5,13 +5,13 @@ Product Profile Configurations
 Predefined product profiles for different use cases.
 """
 
-from typing import Dict, Any
+from typing import Any
 
 # ============================================================================
 # EDU PROFILE (Kooth / Smoothwall)
 # ============================================================================
 
-EDU_PROFILE: Dict[str, Any] = {
+EDU_PROFILE: dict[str, Any] = {
     "profile": "edu",
     "description": "Educational profile for schools and mental health platforms",
     "modules": {
@@ -45,7 +45,7 @@ EDU_PROFILE: Dict[str, Any] = {
 # GAME PROFILE (Inkle / Failbetter)
 # ============================================================================
 
-GAME_PROFILE: Dict[str, Any] = {
+GAME_PROFILE: dict[str, Any] = {
     "profile": "game",
     "description": "Game profile for interactive fiction studios",
     "modules": {
@@ -79,7 +79,7 @@ GAME_PROFILE: Dict[str, Any] = {
 # CLINICAL PROFILE (Kooth clinical triage)
 # ============================================================================
 
-CLINICAL_PROFILE: Dict[str, Any] = {
+CLINICAL_PROFILE: dict[str, Any] = {
     "profile": "clinical",
     "description": "Clinical profile for mental health triage",
     "modules": {
@@ -114,7 +114,7 @@ CLINICAL_PROFILE: Dict[str, Any] = {
 # HELPER FUNCTIONS
 # ============================================================================
 
-def get_profile_config(profile_name: str) -> Dict[str, Any]:
+def get_profile_config(profile_name: str) -> dict[str, Any]:
     """
     Get profile configuration by name.
 

--- a/phionyx_core/profiles/profile_manager.py
+++ b/phionyx_core/profiles/profile_manager.py
@@ -6,28 +6,28 @@ Manages product profiles and port instantiation.
 Creates appropriate port implementations based on profile configuration.
 """
 
-import logging
-from typing import Dict, Any, Optional
-from pathlib import Path
 import json
+import logging
+from pathlib import Path
+from typing import Any
 
 from ..ports import (
-    PhysicsPort,
-    MemoryPort,
     IntuitionPort,
-    PedagogyPort,
-    PolicyPort,
+    MemoryPort,
+    MetaPort,
     NarrativePort,
-    MetaPort
+    PedagogyPort,
+    PhysicsPort,
+    PolicyPort,
 )
 from ..ports.null_implementations import (
-    NullPhysicsEngine,
-    NullMemoryEngine,
     NullIntuitionEngine,
-    NullPedagogyEngine,
-    NullPolicyEngine,
+    NullMemoryEngine,
+    NullMetaEngine,
     NullNarrativeEngine,
-    NullMetaEngine
+    NullPedagogyEngine,
+    NullPhysicsEngine,
+    NullPolicyEngine,
 )
 from .profile_configs import get_profile_config
 
@@ -47,7 +47,7 @@ class ProductProfile:
         narrative: NarrativePort,
         meta: MetaPort,
         profile_name: str,
-        config: Dict[str, Any]
+        config: dict[str, Any]
     ):
         self.physics = physics
         self.memory = memory
@@ -59,7 +59,7 @@ class ProductProfile:
         self.profile_name = profile_name
         self.config = config
 
-    def get_module_status(self) -> Dict[str, bool]:
+    def get_module_status(self) -> dict[str, bool]:
         """Get status of each module (enabled/disabled)."""
         return {
             "physics": not isinstance(self.physics, NullPhysicsEngine),
@@ -84,6 +84,7 @@ class ProfileManager:
         # Try to import real Physics implementation
         try:
             from phionyx_core.physics.formulas import calculate_phi_v2_1  # noqa: F401
+
             # Create real Physics port implementation
             # This would be a wrapper around the real SDK
             from ..implementations.physics_impl import RealPhysicsEngine
@@ -100,6 +101,7 @@ class ProfileManager:
 
         try:
             from phionyx_core.memory.vector_store import VectorStore  # noqa: F401
+
             from ..implementations.memory_impl import RealMemoryEngine
             return RealMemoryEngine()
         except ImportError:
@@ -114,6 +116,7 @@ class ProfileManager:
 
         try:
             from phionyx_intuition import GraphEngine  # noqa: F401
+
             from ..implementations.intuition_impl import RealIntuitionEngine
             return RealIntuitionEngine()
         except ImportError:
@@ -128,6 +131,7 @@ class ProfileManager:
 
         try:
             from phionyx_core.pedagogy.risk_assessment import RiskAssessor  # noqa: F401
+
             from ..implementations.pedagogy_impl import RealPedagogyEngine
             return RealPedagogyEngine(strictness=module_config)
         except ImportError:
@@ -177,7 +181,7 @@ class ProfileManager:
     def create_profile(
         cls,
         profile_name: str,
-        config: Optional[Dict[str, Any]] = None
+        config: dict[str, Any] | None = None
     ) -> ProductProfile:
         """
         Create product profile from configuration.
@@ -218,7 +222,7 @@ class ProfileManager:
         )
 
     @staticmethod
-    def _get_module_status(modules: Dict[str, str]) -> str:
+    def _get_module_status(modules: dict[str, str]) -> str:
         """Get human-readable module status."""
         status = []
         for module, config in modules.items():
@@ -240,7 +244,7 @@ class ProfileManager:
         if not path.exists():
             raise FileNotFoundError(f"Profile config not found: {config_path}")
 
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             config = json.load(f)
 
         profile_name = config.get("profile", "edu")

--- a/phionyx_core/profiles/schema.py
+++ b/phionyx_core/profiles/schema.py
@@ -6,7 +6,7 @@ Defines the nested structure for high-level personas and low-level technical par
 """
 
 from enum import Enum
-from typing import Optional, Dict, List
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
@@ -57,15 +57,15 @@ class PhysicsConfig(BaseModel):
     safety_bias: float = Field(0.5, ge=0.0, le=1.0, description="Safety strictness (0=permissive, 1=strict)")
     base_mode: BaseMode = Field(BaseMode.DEFAULT, description="Base context mode")
     # Physics v2.1 Parameters (Circumplex Model) - optional for backward compatibility
-    valence: Optional[float] = Field(None, ge=-1.0, le=1.0, description="Emotional valence from Circumplex (-1 to +1)")
-    arousal: Optional[float] = Field(None, ge=0.0, le=1.0, description="Arousal from Circumplex (0 to 1)")
-    amplitude: Optional[float] = Field(None, ge=0.0, le=10.0, description="Emotional intensity slider (0-10)")
-    entropy: Optional[float] = Field(None, ge=0.0, le=1.0, description="Chaos level (0-1)")
-    stability: Optional[float] = Field(None, ge=0.0, le=1.0, description="Internal resilience (0-1)")
-    gamma: Optional[float] = Field(None, ge=0.0, le=1.0, description="Decay rate (0-1)")
-    w_c: Optional[float] = Field(None, ge=0.0, le=1.0, description="Cognitive weight (0-1)")
-    w_p: Optional[float] = Field(None, ge=0.0, le=1.0, description="Physical weight (0-1)")
-    entropy_penalty_k: Optional[float] = Field(1.0, ge=0.0, le=2.0, description="Entropy penalty coefficient (0-2, default 1.0)")
+    valence: float | None = Field(None, ge=-1.0, le=1.0, description="Emotional valence from Circumplex (-1 to +1)")
+    arousal: float | None = Field(None, ge=0.0, le=1.0, description="Arousal from Circumplex (0 to 1)")
+    amplitude: float | None = Field(None, ge=0.0, le=10.0, description="Emotional intensity slider (0-10)")
+    entropy: float | None = Field(None, ge=0.0, le=1.0, description="Chaos level (0-1)")
+    stability: float | None = Field(None, ge=0.0, le=1.0, description="Internal resilience (0-1)")
+    gamma: float | None = Field(None, ge=0.0, le=1.0, description="Decay rate (0-1)")
+    w_c: float | None = Field(None, ge=0.0, le=1.0, description="Cognitive weight (0-1)")
+    w_p: float | None = Field(None, ge=0.0, le=1.0, description="Physical weight (0-1)")
+    entropy_penalty_k: float | None = Field(1.0, ge=0.0, le=2.0, description="Entropy penalty coefficient (0-2, default 1.0)")
 
     @field_validator('reactivity', 'resilience', 'safety_bias')
     @classmethod
@@ -100,7 +100,7 @@ class GovernanceConfig(BaseModel):
     policy_id: str = Field("default", description="Policy identifier")
     pii_mode: PIIMode = Field(PIIMode.PARTIAL, description="PII scrubbing mode")
     audit_level: AuditLevel = Field(AuditLevel.STANDARD, description="Audit logging level")
-    custom_regex_patterns: Optional[List[str]] = Field(None, description="Custom PII regex patterns")
+    custom_regex_patterns: list[str] | None = Field(None, description="Custom PII regex patterns")
 
     model_config = ConfigDict(use_enum_values=True)
 class RoutingConfig(BaseModel):
@@ -110,8 +110,8 @@ class RoutingConfig(BaseModel):
     Determines which LLM tier to use for different scenarios.
     """
     llm_tier_strategy: LLMTierStrategy = Field(LLMTierStrategy.BALANCED, description="LLM selection strategy")
-    fallback_model: Optional[str] = Field(None, description="Fallback model if primary fails")
-    max_tokens_per_tier: Optional[Dict[str, int]] = Field(None, description="Max tokens per tier")
+    fallback_model: str | None = Field(None, description="Fallback model if primary fails")
+    max_tokens_per_tier: dict[str, int] | None = Field(None, description="Max tokens per tier")
     enable_graph_rag: bool = Field(False, description="Enable GraphRAG for hidden context discovery (default: OFF, only for Academic/Enterprise/Deep-analysis modes)")
 
     model_config = ConfigDict(use_enum_values=True)
@@ -157,21 +157,21 @@ class Profile(BaseModel):
     This is the high-level "Persona" that maps to low-level technical parameters.
     """
     name: str = Field(..., description="Profile identifier (e.g., 'SCHOOL_DEFAULT')")
-    description: Optional[str] = Field(None, description="Human-readable description")
+    description: str | None = Field(None, description="Human-readable description")
 
     # Module configurations
     physics: PhysicsConfig = Field(default_factory=PhysicsConfig, description="Physics module config")
     pedagogy: PedagogyConfig = Field(default_factory=PedagogyConfig, description="Pedagogy module config")
     governance: GovernanceConfig = Field(default_factory=GovernanceConfig, description="Governance module config")
     routing: RoutingConfig = Field(default_factory=RoutingConfig, description="Routing module config")
-    execution_guard: Optional[ExecutionGuardConfig] = Field(
+    execution_guard: ExecutionGuardConfig | None = Field(
         None,
         description="Optional per-profile ExecutionGuard limits. None = hard-coded defaults.",
     )
 
     # Metadata
-    version: Optional[str] = Field("1.0.0", description="Profile version")
-    tags: Optional[List[str]] = Field(None, description="Tags for filtering/searching")
+    version: str | None = Field("1.0.0", description="Profile version")
+    tags: list[str] | None = Field(None, description="Tags for filtering/searching")
 
     model_config = ConfigDict(
         use_enum_values=True,

--- a/phionyx_core/reference/echoism_core_minimal/state.py
+++ b/phionyx_core/reference/echoism_core_minimal/state.py
@@ -8,7 +8,6 @@ Per Echoism Core v1.1:
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional
 from datetime import datetime
 
 
@@ -37,13 +36,13 @@ class EchoState2Plus:
     dV: float = 0.0
     t_local: float = 0.0
     t_global: float = 0.0
-    E_tags: List[EventReference] = field(default_factory=list)
+    E_tags: list[EventReference] = field(default_factory=list)
 
     # v1.1 Extended
     I: float = 0.6  # Inertia  # noqa: E741
     R: float = 0.05  # ResonanceScore
     C: float = 0.5  # Coherence
-    D: Optional[float] = None  # Dominance (optional)
+    D: float | None = None  # Dominance (optional)
 
     # Time semantics
     t_now: datetime = field(default_factory=datetime.now)
@@ -57,7 +56,7 @@ class EchoState2Plus:
         valence_norm = (self.V + 1.0) / 2.0
         return min(1.0, stability * (valence_norm * 0.6 + self.A * 0.4))
 
-    def update_time(self, current_time: Optional[datetime] = None) -> float:
+    def update_time(self, current_time: datetime | None = None) -> float:
         """Update time fields."""
         if current_time is None:
             current_time = datetime.now()

--- a/phionyx_core/research_engine/analysis/pre_agi_impact.py
+++ b/phionyx_core/research_engine/analysis/pre_agi_impact.py
@@ -15,7 +15,6 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -81,8 +80,8 @@ class PREAGIImpactAnalyzer:
 
     def __init__(
         self,
-        experiments_path: Optional[Path] = None,
-        surfaces_path: Optional[Path] = None,
+        experiments_path: Path | None = None,
+        surfaces_path: Path | None = None,
     ):
         self._experiments_path = experiments_path or DEFAULT_EXPERIMENTS_PATH
         self._surfaces_path = surfaces_path or DEFAULT_SURFACES_PATH
@@ -225,7 +224,7 @@ class PREAGIImpactAnalyzer:
 
         return report
 
-    def save_report(self, output_path: Optional[Path] = None) -> Path:
+    def save_report(self, output_path: Path | None = None) -> Path:
         """Generate and save report as JSON."""
         report = self.generate_campaign_report()
         if output_path is None:

--- a/phionyx_core/research_engine/campaign/selector.py
+++ b/phionyx_core/research_engine/campaign/selector.py
@@ -15,7 +15,6 @@ Cognitive vs. automation: Automation (experiment selection heuristic)
 
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +45,7 @@ class SelectionPolicy:
     w_stages: float = 0.10    # Mind-loop stage coverage importance
 
 
-def load_campaigns(surfaces_data: dict) -> List[dict]:
+def load_campaigns(surfaces_data: dict) -> list[dict]:
     """Extract campaign definitions from surfaces.yaml data.
 
     Args:
@@ -146,9 +145,9 @@ def score_campaign(campaign: dict, policy: SelectionPolicy) -> CampaignScore:
 
 
 def select_campaign(
-    campaigns: List[dict],
-    policy: Optional[SelectionPolicy] = None,
-) -> Optional[CampaignScore]:
+    campaigns: list[dict],
+    policy: SelectionPolicy | None = None,
+) -> CampaignScore | None:
     """Select the highest-scored campaign.
 
     Args:
@@ -167,9 +166,9 @@ def select_campaign(
 
 
 def rank_campaigns(
-    campaigns: List[dict],
-    policy: Optional[SelectionPolicy] = None,
-) -> List[CampaignScore]:
+    campaigns: list[dict],
+    policy: SelectionPolicy | None = None,
+) -> list[CampaignScore]:
     """Rank all campaigns by selection score (descending).
 
     Args:

--- a/phionyx_core/research_engine/cli/run_session.py
+++ b/phionyx_core/research_engine/cli/run_session.py
@@ -14,8 +14,9 @@ Options:
 import argparse
 import re
 import sys
-import yaml
 from pathlib import Path
+
+import yaml
 
 
 def load_surfaces(surfaces_file: str | None = None) -> list[dict]:

--- a/phionyx_core/research_engine/cli/verify_tracker.py
+++ b/phionyx_core/research_engine/cli/verify_tracker.py
@@ -18,10 +18,11 @@ Options:
 import json
 import re
 import sys
-import yaml
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
-from collections import Counter
+
+import yaml
 
 # ── Paths ──
 

--- a/phionyx_core/research_engine/config.py
+++ b/phionyx_core/research_engine/config.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
 
 
 @dataclass
@@ -32,7 +31,7 @@ class AcceptanceThresholds:
     min_cqs_delta: float = 0.005
     max_latency_increase_pct: float = 20.0
     max_cost_increase_pct: float = 15.0
-    complexity_tax: Dict[str, float] = field(
+    complexity_tax: dict[str, float] = field(
         default_factory=lambda: {
             "1-10": 0.000,   # trivial one-liner — no extra bar
             "11-30": 0.002,  # small refactor

--- a/phionyx_core/research_engine/decision.py
+++ b/phionyx_core/research_engine/decision.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import List
 
 from .evaluation.scoring import compute_complexity_tax, compute_decision_score
 
@@ -73,7 +72,7 @@ class Decision:
     action: str
     status: str
     rationale: str
-    guardrail_violations: List[str]
+    guardrail_violations: list[str]
     cqs_delta: float
     decision_score: float
 
@@ -98,7 +97,7 @@ class Decision:
 def decide(
     baseline_cqs: float,
     experiment_cqs: float,
-    guardrail_violations: List[str],
+    guardrail_violations: list[str],
     diff_lines: int,
     tier: str,
     latency_regression_pct: float = 0.0,

--- a/phionyx_core/research_engine/evaluation/quality_probe.py
+++ b/phionyx_core/research_engine/evaluation/quality_probe.py
@@ -11,8 +11,8 @@ Tier B (review required for modifications).
 v2.1.0 — 11 probe domains, 31 metrics, 18 source files.
 """
 
-import re
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -302,9 +302,9 @@ class QualityProbe:
             "phionyx_core/physics/formulas.py", "recovery_gain", 0.05
         )
 
-        _kw = dict(entropy=0.6, stability=0.8, valence=0.0)
-        _rec_kw = dict(entropy=0.4, stability=0.8, valence=0.3,
-                       previous_entropy=0.8, previous_valence=-0.5)
+        _kw = {"entropy": 0.6, "stability": 0.8, "valence": 0.0}
+        _rec_kw = {"entropy": 0.4, "stability": 0.8, "valence": 0.3,
+                       "previous_entropy": 0.8, "previous_valence": -0.5}
 
         phi_curr = calculate_phi_cognitive(**_kw, entropy_penalty_k=epk, base_resonance=br, recovery_gain=rg)
         phi_best = calculate_phi_cognitive(**_kw, entropy_penalty_k=0.0, base_resonance=br, recovery_gain=rg)
@@ -312,7 +312,7 @@ class QualityProbe:
         span1 = phi_best - phi_worst
         norm_epk = (phi_curr - phi_worst) / span1 if span1 > 0 else 0.5
 
-        _kw2 = dict(entropy=0.1, stability=0.9, valence=0.0)
+        _kw2 = {"entropy": 0.1, "stability": 0.9, "valence": 0.0}
         phi_curr2 = calculate_phi_cognitive(**_kw2, entropy_penalty_k=epk, base_resonance=br, recovery_gain=rg)
         phi_best2 = calculate_phi_cognitive(**_kw2, entropy_penalty_k=epk, base_resonance=0.2, recovery_gain=rg)
         phi_worst2 = calculate_phi_cognitive(**_kw2, entropy_penalty_k=epk, base_resonance=0.05, recovery_gain=rg)
@@ -487,8 +487,8 @@ class QualityProbe:
 
     def _probe_world(self) -> dict[str, float]:
         """Probe temporal tracker and goal decomposer."""
-        from phionyx_core.world.temporal_tracker import TemporalTracker
         from phionyx_core.planning.goal_decomposer import GoalDecomposer
+        from phionyx_core.world.temporal_tracker import TemporalTracker
 
         dr = self._read_param(
             "phionyx_core/world/temporal_tracker.py", "temporal_decay_rate", 0.02
@@ -629,8 +629,8 @@ class QualityProbe:
         Tests that entropy/phi computations actually vary with input,
         and that feedback blocks skip gracefully with None DI.
         """
-        from phionyx_core.physics.text_physics import calculate_text_entropy_zlib
         from phionyx_core.physics.formulas import calculate_phi_cognitive
+        from phionyx_core.physics.text_physics import calculate_text_entropy_zlib
 
         # Metric 1: pipeline_entropy_sensitivity — 3 texts → entropy spread
         texts = [
@@ -673,7 +673,9 @@ class QualityProbe:
             pass
 
         try:
-            from phionyx_core.pipeline.blocks.memory_consolidation_block import MemoryConsolidationBlock
+            from phionyx_core.pipeline.blocks.memory_consolidation_block import (
+                MemoryConsolidationBlock,
+            )
             _blk = MemoryConsolidationBlock()
             skip_count += 1
         except Exception:

--- a/phionyx_core/research_engine/evaluation/scoring.py
+++ b/phionyx_core/research_engine/evaluation/scoring.py
@@ -13,7 +13,6 @@ decisions are auditable and deterministic.
 from __future__ import annotations
 
 import math
-from typing import Dict, List
 
 # ---------------------------------------------------------------------------
 # Primary metric components
@@ -21,7 +20,7 @@ from typing import Dict, List
 
 #: The six required components for the Composite Quality Score.
 #: Order is significant for audit-log readability but not for computation.
-_CQS_REQUIRED_COMPONENTS: List[str] = [
+_CQS_REQUIRED_COMPONENTS: list[str] = [
     "task_completion_accuracy",
     "determinism_consistency",
     "reasoning_chain_validity",
@@ -35,7 +34,7 @@ _CQS_REQUIRED_COMPONENTS: List[str] = [
 # ---------------------------------------------------------------------------
 
 
-def compute_cqs(components: Dict[str, float]) -> float:
+def compute_cqs(components: dict[str, float]) -> float:
     """Compute Composite Quality Score using geometric mean.
 
     Parameters
@@ -72,7 +71,7 @@ def compute_cqs(components: Dict[str, float]) -> float:
     For example, an agent cannot compensate for poor determinism by
     inflating trace completeness.
     """
-    values: List[float] = []
+    values: list[float] = []
     for key in _CQS_REQUIRED_COMPONENTS:
         v = components.get(key, 0.0)
         if not (0.0 <= v <= 1.0):
@@ -93,7 +92,7 @@ def compute_cqs(components: Dict[str, float]) -> float:
 # ---------------------------------------------------------------------------
 
 
-def check_guardrails(metrics: Dict[str, float]) -> List[str]:
+def check_guardrails(metrics: dict[str, float]) -> list[str]:
     """Check guardrail metrics and return a list of violation descriptions.
 
     Guardrails carry **veto power**: a non-empty violation list blocks
@@ -129,7 +128,7 @@ def check_guardrails(metrics: Dict[str, float]) -> List[str]:
     | gold_task_regressions     | >        | 0    (zero regressions on gold tasks)         |
     +---------------------------+----------+-----------------------------------------------+
     """
-    violations: List[str] = []
+    violations: list[str] = []
 
     # --- Governance: zero tolerance -------------------------------------------
     gvr = metrics.get("governance_violation_rate", 0.0)

--- a/phionyx_core/research_engine/evaluation/shadow_evaluator.py
+++ b/phionyx_core/research_engine/evaluation/shadow_evaluator.py
@@ -22,7 +22,6 @@ from phionyx_core.research_engine.evaluation.runner import (
 )
 from phionyx_core.research_engine.evaluation.scoring import compute_cqs
 
-
 # Holdout suites — tests NOT in the main composite benchmark
 HOLDOUT_SUITES: dict[str, str] = {
     "adversarial": "tests/behavioral_eval/test_adversarial_scenarios.py",

--- a/phionyx_core/research_engine/exploration_window.py
+++ b/phionyx_core/research_engine/exploration_window.py
@@ -34,7 +34,7 @@ Cognitive vs. automation: Infrastructure (seeded parameter search)
 
 import logging
 import random
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -67,7 +67,7 @@ class ExplorationOutcome:
     score_after: float
     score_delta: float
     guardrails_passed: bool
-    violations: List[str] = field(default_factory=list)
+    violations: list[str] = field(default_factory=list)
 
     @property
     def improved(self) -> bool:
@@ -81,8 +81,8 @@ class ExplorationWindowResult:
     total_steps: int
     improvements_found: int
     violations_count: int
-    outcomes: List[ExplorationOutcome]
-    best_outcome: Optional[ExplorationOutcome]
+    outcomes: list[ExplorationOutcome]
+    best_outcome: ExplorationOutcome | None
     opened_at: str
     closed_at: str
     budget_remaining: int
@@ -111,8 +111,8 @@ class ExplorationWindow:
     def __init__(
         self,
         seed: int,
-        allowed_parameters: Optional[Set[str]] = None,
-        parameter_ranges: Optional[Dict[str, Tuple[float, float]]] = None,
+        allowed_parameters: set[str] | None = None,
+        parameter_ranges: dict[str, tuple[float, float]] | None = None,
         max_perturbations: int = DEFAULT_MAX_PERTURBATIONS,
         max_delta_fraction: float = DEFAULT_MAX_DELTA_FRACTION,
         budget: int = DEFAULT_WINDOW_BUDGET,
@@ -135,13 +135,13 @@ class ExplorationWindow:
         self.budget = budget
         self._rng = random.Random(seed)
         self._step_count = 0
-        self._outcomes: List[ExplorationOutcome] = []
+        self._outcomes: list[ExplorationOutcome] = []
 
     def run(
         self,
-        current_values: Dict[str, float],
-        evaluate_fn: Callable[[Dict[str, float]], float],
-        guardrail_fn: Optional[Callable[[Dict[str, float], float], Tuple[bool, List[str]]]] = None,
+        current_values: dict[str, float],
+        evaluate_fn: Callable[[dict[str, float]], float],
+        guardrail_fn: Callable[[dict[str, float], float], tuple[bool, list[str]]] | None = None,
     ) -> ExplorationWindowResult:
         """
         Execute the exploration window.
@@ -240,9 +240,9 @@ class ExplorationWindow:
 
     def generate_perturbations(
         self,
-        current_values: Dict[str, float],
+        current_values: dict[str, float],
         count: int = 1,
-    ) -> List[Perturbation]:
+    ) -> list[Perturbation]:
         """
         Generate perturbations without executing evaluation.
 
@@ -265,7 +265,7 @@ class ExplorationWindow:
 
         return perturbations
 
-    def _filter_allowed(self, values: Dict[str, float]) -> Dict[str, float]:
+    def _filter_allowed(self, values: dict[str, float]) -> dict[str, float]:
         """Filter parameter values to only allowed ones."""
         if self.allowed_parameters is None:
             return dict(values)
@@ -279,7 +279,7 @@ class ExplorationWindow:
         param_name: str,
         current_value: float,
         step_index: int,
-    ) -> Optional[Perturbation]:
+    ) -> Perturbation | None:
         """Generate a single bounded perturbation."""
         if current_value == 0:
             # Can't compute fraction of zero; use small absolute delta

--- a/phionyx_core/research_engine/loop.py
+++ b/phionyx_core/research_engine/loop.py
@@ -10,19 +10,19 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from .audit.logger import AuditLogger
 from .config import EngineConfig
 from .decision import decide
 from .evaluation.runner import BenchmarkRunner
 from .evaluation.scoring import check_guardrails, compute_cqs
 from .governance.budget_monitor import BudgetMonitor
-from .audit.logger import AuditLogger
-from .store.experiment_store import ExperimentStore
-from .store.baseline_store import BaselineStore
-from .rollback.git_manager import GitManager
-from .rollback.config_snapshot import ConfigSnapshot
 from .mutation.planner import create_plan
-from .mutation.scope_validator import validate_scope
 from .mutation.range_validator import validate_range
+from .mutation.scope_validator import validate_scope
+from .rollback.config_snapshot import ConfigSnapshot
+from .rollback.git_manager import GitManager
+from .store.baseline_store import BaselineStore
+from .store.experiment_store import ExperimentStore
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/research_engine/mutation/planner.py
+++ b/phionyx_core/research_engine/mutation/planner.py
@@ -8,7 +8,6 @@ The LLM role in v1 is limited to interpreting results, not generating hypotheses
 """
 import random
 from dataclasses import dataclass, field
-from typing import List, Set
 
 
 @dataclass
@@ -22,7 +21,7 @@ class HypothesisPlan:
     reasoning: str
 
 
-def _frange(start: float, stop: float, step: float) -> List[float]:
+def _frange(start: float, stop: float, step: float) -> list[float]:
     """Generate float range, avoiding floating point issues."""
     result = []
     current = start
@@ -40,8 +39,8 @@ def generate_grid_hypotheses(
     range_min: float,
     range_max: float,
     step: float,
-    already_tried: Set[float] | None = None,
-) -> List[HypothesisPlan]:
+    already_tried: set[float] | None = None,
+) -> list[HypothesisPlan]:
     """Generate hypotheses by systematic grid search.
 
     Tries every value in [range_min, range_max] with given step,
@@ -86,7 +85,7 @@ def generate_random_hypotheses(
     range_max: float,
     count: int = 5,
     seed: int | None = None,
-) -> List[HypothesisPlan]:
+) -> list[HypothesisPlan]:
     """Generate hypotheses by random sampling within range."""
     rng = random.Random(seed)
 
@@ -112,7 +111,7 @@ def generate_boundary_hypotheses(
     range_min: float,
     range_max: float,
     step: float,
-) -> List[HypothesisPlan]:
+) -> list[HypothesisPlan]:
     """Generate hypotheses at boundary values and extremes.
 
     Tests: min, max, min+step, max-step, midpoint.
@@ -127,7 +126,7 @@ def generate_boundary_hypotheses(
         range_max,
     ]
     # Remove current and duplicates
-    seen: Set[float] = set()
+    seen: set[float] = set()
     unique = []
     for v in candidates:
         v = round(v, 10)
@@ -153,7 +152,7 @@ def generate_boundary_hypotheses(
 class MutationPlan:
     """Complete mutation plan for an experiment session."""
     surface_file: str
-    hypotheses: List[HypothesisPlan] = field(default_factory=list)
+    hypotheses: list[HypothesisPlan] = field(default_factory=list)
 
     @property
     def remaining(self) -> int:
@@ -165,13 +164,13 @@ class MutationPlan:
         return None
 
 
-def _interleave(per_param: List[List[HypothesisPlan]]) -> List[HypothesisPlan]:
+def _interleave(per_param: list[list[HypothesisPlan]]) -> list[HypothesisPlan]:
     """Round-robin interleave hypothesis lists from different parameters.
 
     Ensures all parameters get explored even with small experiment budgets.
     Example: [A1,A2,A3], [B1,B2] -> [A1,B1,A2,B2,A3]
     """
-    result: List[HypothesisPlan] = []
+    result: list[HypothesisPlan] = []
     max_len = max((len(h) for h in per_param), default=0)
     for i in range(max_len):
         for param_hyps in per_param:
@@ -183,8 +182,8 @@ def _interleave(per_param: List[List[HypothesisPlan]]) -> List[HypothesisPlan]:
 def create_plan(
     surface_file: str,
     tier: str,
-    parameters: List[dict],
-    already_tried: dict[str, Set[float]] | None = None,
+    parameters: list[dict],
+    already_tried: dict[str, set[float]] | None = None,
     strategy: str = "grid",  # "grid", "random", "boundary", "all"
     seed: int | None = None,
 ) -> MutationPlan:
@@ -198,11 +197,11 @@ def create_plan(
     if already_tried is None:
         already_tried = {}
 
-    per_param: List[List[HypothesisPlan]] = []
+    per_param: list[list[HypothesisPlan]] = []
 
     for param in parameters:
         param_tried = already_tried.get(param["name"], set())
-        param_hyps: List[HypothesisPlan] = []
+        param_hyps: list[HypothesisPlan] = []
 
         if strategy in ("grid", "all"):
             param_hyps.extend(generate_grid_hypotheses(

--- a/phionyx_core/research_engine/mutation/range_validator.py
+++ b/phionyx_core/research_engine/mutation/range_validator.py
@@ -1,18 +1,18 @@
 """Range validator — enforces parameter safe ranges."""
 from dataclasses import dataclass
-from typing import Any, List
+from typing import Any
 
 
 @dataclass(frozen=True)
 class RangeValidationResult:
     valid: bool
-    violations: List[str]
+    violations: list[str]
 
 
 def validate_range(
     param_name: str,
     value: Any,
-    surface_params: List[dict],  # List of parameter defs from surfaces.yaml
+    surface_params: list[dict],  # List of parameter defs from surfaces.yaml
 ) -> RangeValidationResult:
     """Validate that a parameter value is within its declared safe range.
 
@@ -75,7 +75,7 @@ def validate_constraint(
     param_name: str,
     value: Any,
     related_params: dict[str, Any],
-    constraints: List[dict],
+    constraints: list[dict],
 ) -> RangeValidationResult:
     """Validate cross-parameter constraints (e.g., weights must sum to 1.0)."""
     violations = []

--- a/phionyx_core/research_engine/mutation/scope_validator.py
+++ b/phionyx_core/research_engine/mutation/scope_validator.py
@@ -1,19 +1,18 @@
 """Scope validator — enforces Tier A/B/C/D edit permissions."""
 from dataclasses import dataclass
-from typing import List
 
 
 @dataclass(frozen=True)
 class ValidationResult:
     valid: bool
-    violations: List[str]
+    violations: list[str]
 
 
 def validate_scope(
     file_path: str,
     diff_lines: int,
     tier: str,
-    surfaces: List[dict],  # Parsed from surfaces.yaml
+    surfaces: list[dict],  # Parsed from surfaces.yaml
 ) -> ValidationResult:
     """Validate that the proposed edit is within scope.
 

--- a/phionyx_core/research_engine/outcome_observer.py
+++ b/phionyx_core/research_engine/outcome_observer.py
@@ -25,7 +25,6 @@ Cognitive vs. automation: Infrastructure (threshold-based proposal generation)
 """
 
 import logging
-from typing import Dict, List, Optional
 from dataclasses import dataclass, field
 
 from phionyx_core.contracts.v4.learning_update import (
@@ -49,7 +48,7 @@ class ParameterEvidence:
     parameter_name: str
     surface_file: str
     tier: str
-    experiments: List[Dict] = field(default_factory=list)
+    experiments: list[dict] = field(default_factory=list)
 
     @property
     def keep_count(self) -> int:
@@ -72,7 +71,7 @@ class ParameterEvidence:
         return sum(e["cqs_delta"] for e in kept) / len(kept)
 
     @property
-    def best_value(self) -> Optional[float]:
+    def best_value(self) -> float | None:
         """Best proposed value from kept experiments (highest CQS delta)."""
         kept = [e for e in self.experiments if e["decision"] == "keep"]
         if not kept:
@@ -81,7 +80,7 @@ class ParameterEvidence:
         return best["proposed_value"]
 
     @property
-    def current_value(self) -> Optional[float]:
+    def current_value(self) -> float | None:
         """Current value from the most recent experiment."""
         if not self.experiments:
             return None
@@ -94,7 +93,7 @@ class OutcomeObserverResult:
     total_observed: int
     parameters_tracked: int
     updates_proposed: int
-    proposed_updates: List[LearningUpdate]
+    proposed_updates: list[LearningUpdate]
 
 
 class OutcomeObserver:
@@ -119,7 +118,7 @@ class OutcomeObserver:
         min_experiments: int = MIN_CONSISTENT_EXPERIMENTS,
         cqs_delta_threshold: float = CQS_DELTA_THRESHOLD,
         max_delta_fraction: float = MAX_DELTA_FRACTION,
-        tier_zone_map: Optional[Dict[str, str]] = None,
+        tier_zone_map: dict[str, str] | None = None,
     ):
         """
         Args:
@@ -137,7 +136,7 @@ class OutcomeObserver:
             "C": "gated",
             "D": "immutable",
         }
-        self._evidence: Dict[str, ParameterEvidence] = {}
+        self._evidence: dict[str, ParameterEvidence] = {}
         self._proposed_params: set = set()
 
     def observe(self, record: ExperimentRecord) -> None:
@@ -167,7 +166,7 @@ class OutcomeObserver:
             "timestamp": record.timestamp,
         })
 
-    def observe_batch(self, records: List[ExperimentRecord]) -> None:
+    def observe_batch(self, records: list[ExperimentRecord]) -> None:
         """Observe multiple experiment records."""
         for record in records:
             self.observe(record)
@@ -186,7 +185,7 @@ class OutcomeObserver:
         Returns:
             OutcomeObserverResult with proposed LearningUpdates.
         """
-        proposals: List[LearningUpdate] = []
+        proposals: list[LearningUpdate] = []
 
         for param_name, evidence in sorted(self._evidence.items()):
             if param_name in self._proposed_params:
@@ -209,11 +208,11 @@ class OutcomeObserver:
             proposed_updates=proposals,
         )
 
-    def get_evidence(self, parameter_name: str) -> Optional[ParameterEvidence]:
+    def get_evidence(self, parameter_name: str) -> ParameterEvidence | None:
         """Get accumulated evidence for a parameter."""
         return self._evidence.get(parameter_name)
 
-    def get_all_evidence(self) -> Dict[str, ParameterEvidence]:
+    def get_all_evidence(self) -> dict[str, ParameterEvidence]:
         """Get all accumulated evidence."""
         return dict(self._evidence)
 
@@ -250,7 +249,7 @@ class OutcomeObserver:
 
         return True
 
-    def _create_update(self, evidence: ParameterEvidence) -> Optional[LearningUpdate]:
+    def _create_update(self, evidence: ParameterEvidence) -> LearningUpdate | None:
         """Create a LearningUpdate from accumulated evidence."""
         current = evidence.current_value
         proposed = evidence.best_value

--- a/phionyx_core/research_engine/schemas.py
+++ b/phionyx_core/research_engine/schemas.py
@@ -7,10 +7,9 @@ hashed, and passed across async boundaries without defensive copying.
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, List, Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
-
 
 # ---------------------------------------------------------------------------
 # MetricVector
@@ -142,7 +141,7 @@ class ExperimentRecord(BaseModel):
     diff_lines_changed: int
     benchmark_suite: str
     benchmark_duration_seconds: float
-    guardrail_violations: List[str]
+    guardrail_violations: list[str]
     status: Literal["rejected", "archived", "candidate", "promoted", "gold"]
 
 
@@ -162,7 +161,7 @@ class BaselineSnapshot(BaseModel):
     timestamp: str          # ISO 8601
     git_commit: str
     metrics: MetricVector
-    surface_values: Dict[str, Any]
+    surface_values: dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +187,7 @@ class SessionReport(BaseModel):
     crashed: int
     best_cqs_delta: float
     stop_reason: str
-    experiments: List[str]  # experiment IDs
+    experiments: list[str]  # experiment IDs
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +227,6 @@ class Surface(BaseModel):
 
     file: str
     tier: Literal["A", "B", "C", "D"]
-    parameters: List[SurfaceParameter]
+    parameters: list[SurfaceParameter]
     max_lines_changed: int
     review_required: bool = False

--- a/phionyx_core/research_engine/store/experiment_store.py
+++ b/phionyx_core/research_engine/store/experiment_store.py
@@ -1,7 +1,6 @@
 """Experiment store — append-only JSONL storage for experiment records."""
 import json
 from pathlib import Path
-from typing import List
 
 
 class ExperimentStore:
@@ -22,7 +21,7 @@ class ExperimentStore:
         with open(self._file, "a") as f:
             f.write(json.dumps(record, default=str) + "\n")
 
-    def get_all(self) -> List[dict]:
+    def get_all(self) -> list[dict]:
         """Get all experiment records."""
         if not self._file.exists():
             return []
@@ -34,15 +33,15 @@ class ExperimentStore:
                     records.append(json.loads(line))
         return records
 
-    def get_by_session(self, session_id: str) -> List[dict]:
+    def get_by_session(self, session_id: str) -> list[dict]:
         """Get experiments for a specific session."""
         return [r for r in self.get_all() if r.get("session_id") == session_id]
 
-    def get_by_surface(self, surface_file: str) -> List[dict]:
+    def get_by_surface(self, surface_file: str) -> list[dict]:
         """Get experiments for a specific surface."""
         return [r for r in self.get_all() if r.get("surface_file") == surface_file]
 
-    def get_by_status(self, status: str) -> List[dict]:
+    def get_by_status(self, status: str) -> list[dict]:
         """Get experiments with a specific status."""
         return [r for r in self.get_all() if r.get("status") == status]
 

--- a/phionyx_core/schemas/__init__.py
+++ b/phionyx_core/schemas/__init__.py
@@ -5,8 +5,8 @@ Phionyx SDK Schemas
 Pydantic models for Phionyx SDK components.
 """
 
-from .npc_echo_profile import NPCEchoProfile
 from . import npc_echo_profile_integration
+from .npc_echo_profile import NPCEchoProfile
 
 __all__ = [
     "NPCEchoProfile",

--- a/phionyx_core/schemas/npc_echo_profile.py
+++ b/phionyx_core/schemas/npc_echo_profile.py
@@ -8,7 +8,6 @@ Integrates Plutchik → Circumplex → Φ Physics pipeline.
 
 from __future__ import annotations
 
-from typing import Dict
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -63,7 +62,7 @@ class NPCEchoProfile(BaseModel):
     )
 
     # 7 echo domains (weights 0.0 to 1.0)
-    domain_weights: Dict[str, float] = Field(
+    domain_weights: dict[str, float] = Field(
         default_factory=lambda: {
             "physical": 0.3,
             "biological": 0.2,

--- a/phionyx_core/schemas/npc_echo_profile_integration.py
+++ b/phionyx_core/schemas/npc_echo_profile_integration.py
@@ -10,7 +10,7 @@ Helper functions to integrate NPC echo profile criteria into various systems:
 - Policy Engine (feedback_sensitivity)
 """
 
-from typing import Dict
+
 from .npc_echo_profile import NPCEchoProfile
 
 
@@ -135,7 +135,7 @@ def apply_feedback_sensitivity(
 def get_npc_physics_params(
     npc_profile: NPCEchoProfile,
     time_delta: float = 0.0
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """
     Get physics parameters for NPC from echo profile.
 

--- a/phionyx_core/services/assumption_challenge_module.py
+++ b/phionyx_core/services/assumption_challenge_module.py
@@ -7,9 +7,9 @@ Faz 3.1: Kalan Özellikler
 AI varsayımlarını kabul etmek yerine challenge eder.
 """
 
-from typing import List, Dict, Any
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 from phionyx_core.services.assumption_types import Assumption
 
@@ -29,7 +29,7 @@ class AssumptionChallenge:
     assumption: Assumption
     challenge_type: ChallengeType
     challenge_reason: str
-    required_evidence: List[str]
+    required_evidence: list[str]
     severity: str = "medium"  # "low", "medium", "high", "critical"
 
 
@@ -46,12 +46,12 @@ class AssumptionChallengeModule:
 
     def __init__(self):
         """Initialize assumption challenge module."""
-        self.challenge_history: List[AssumptionChallenge] = []
+        self.challenge_history: list[AssumptionChallenge] = []
 
     def challenge_assumptions(
         self,
-        assumptions: List[Assumption]
-    ) -> List[AssumptionChallenge]:
+        assumptions: list[Assumption]
+    ) -> list[AssumptionChallenge]:
         """
         Challenge assumptions that lack evidence or have low confidence.
 
@@ -101,7 +101,7 @@ class AssumptionChallengeModule:
         self.challenge_history.extend(challenges)
         return challenges
 
-    def _get_required_evidence(self, assumption: Assumption) -> List[str]:
+    def _get_required_evidence(self, assumption: Assumption) -> list[str]:
         """Get required evidence for assumption type."""
         evidence_map = {
             "input_type": ["Type annotation", "Usage examples", "Documentation"],
@@ -115,7 +115,7 @@ class AssumptionChallengeModule:
     def _check_contradictory(
         self,
         assumption: Assumption,
-        all_assumptions: List[Assumption]
+        all_assumptions: list[Assumption]
     ) -> bool:
         """Check if assumption contradicts others."""
         # Simple heuristic: check for opposite descriptions
@@ -142,8 +142,8 @@ class AssumptionChallengeModule:
     def process_challenge_response(
         self,
         challenge_id: str,
-        response: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        response: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Process response to assumption challenge.
 

--- a/phionyx_core/services/assumption_engine.py
+++ b/phionyx_core/services/assumption_engine.py
@@ -7,11 +7,11 @@ Faz 2.1: Assumption Surfacing Engine - Tam Fonksiyonel
 Gelişmiş assumption extraction ve validation servisi.
 """
 
-from typing import List, Dict, Any, Optional, Tuple
-from dataclasses import dataclass
-import re
 import ast
 import hashlib
+import re
+from dataclasses import dataclass
+from typing import Any
 
 from phionyx_core.services.assumption_types import Assumption
 
@@ -29,8 +29,8 @@ class AssumptionEvidence:
 class ValidationResult:
     """Result of assumption validation."""
     is_valid: bool
-    violations: List[Assumption]
-    warnings: List[Assumption]
+    violations: list[Assumption]
+    warnings: list[Assumption]
     validated_count: int
     total_count: int
 
@@ -46,7 +46,7 @@ class AssumptionSurfacingEngine:
     - Assumption challenge mechanism
     """
 
-    def __init__(self, profile: Optional[Any] = None):
+    def __init__(self, profile: Any | None = None):
         """
         Initialize assumption engine.
 
@@ -54,15 +54,15 @@ class AssumptionSurfacingEngine:
             profile: Profile instance for validation (optional)
         """
         self.profile = profile
-        self.assumption_cache: Dict[str, List[Assumption]] = {}
-        self.evidence_map: Dict[str, List[AssumptionEvidence]] = {}
+        self.assumption_cache: dict[str, list[Assumption]] = {}
+        self.evidence_map: dict[str, list[AssumptionEvidence]] = {}
 
     def extract_assumptions(
         self,
         code: str,
         context: Any,
-        state: Optional[Any] = None
-    ) -> List[Assumption]:
+        state: Any | None = None
+    ) -> list[Assumption]:
         """
         Extract assumptions from code and context.
 
@@ -107,7 +107,7 @@ class AssumptionSurfacingEngine:
         self,
         code: str,
         context: Any
-    ) -> List[Assumption]:
+    ) -> list[Assumption]:
         """Enhanced type assumption extraction."""
         assumptions = []
 
@@ -175,7 +175,7 @@ class AssumptionSurfacingEngine:
 
         return assumptions
 
-    def _infer_type_from_usage(self, func_node: ast.FunctionDef, param_name: str) -> Optional[str]:
+    def _infer_type_from_usage(self, func_node: ast.FunctionDef, param_name: str) -> str | None:
         """Infer parameter type from function body usage."""
         # Look for operations on parameter
         for node in ast.walk(func_node):
@@ -201,7 +201,7 @@ class AssumptionSurfacingEngine:
 
         return None
 
-    def _infer_return_type(self, func_node: ast.FunctionDef) -> Optional[str]:
+    def _infer_return_type(self, func_node: ast.FunctionDef) -> str | None:
         """Infer return type from function body."""
         # Look for return statements
         for node in ast.walk(func_node):
@@ -210,7 +210,7 @@ class AssumptionSurfacingEngine:
                     return self._infer_type_from_value(node.value)
         return None
 
-    def _infer_type_from_value(self, value_node: ast.AST) -> Optional[str]:
+    def _infer_type_from_value(self, value_node: ast.AST) -> str | None:
         """Infer type from AST value node."""
         if isinstance(value_node, ast.Str):
             return "str"
@@ -230,7 +230,7 @@ class AssumptionSurfacingEngine:
                     return func_name
         return None
 
-    def _extract_type_assumptions_pattern(self, code: str) -> List[Assumption]:
+    def _extract_type_assumptions_pattern(self, code: str) -> list[Assumption]:
         """Pattern-based type assumption extraction (fallback)."""
         assumptions = []
 
@@ -258,7 +258,7 @@ class AssumptionSurfacingEngine:
         self,
         state: Any,
         context: Any
-    ) -> List[Assumption]:
+    ) -> list[Assumption]:
         """Enhanced state assumption extraction."""
         assumptions = []
 
@@ -302,7 +302,7 @@ class AssumptionSurfacingEngine:
 
         return assumptions
 
-    def _extract_state_assumptions_from_context(self, context: Any) -> List[Assumption]:
+    def _extract_state_assumptions_from_context(self, context: Any) -> list[Assumption]:
         """Extract state assumptions from context (when state not available)."""
         assumptions = []
 
@@ -330,7 +330,7 @@ class AssumptionSurfacingEngine:
         self,
         code: str,
         context: Any
-    ) -> List[Assumption]:
+    ) -> list[Assumption]:
         """Enhanced dependency assumption extraction."""
         assumptions = []
 
@@ -377,7 +377,7 @@ class AssumptionSurfacingEngine:
         self,
         code: str,
         context: Any
-    ) -> List[Assumption]:
+    ) -> list[Assumption]:
         """Extract performance assumptions."""
         assumptions = []
 
@@ -416,7 +416,7 @@ class AssumptionSurfacingEngine:
         assumption: Assumption,
         code: str,
         context: Any,
-        state: Optional[Any] = None
+        state: Any | None = None
     ) -> None:
         """Link evidence to assumption."""
         if not assumption.evidence:
@@ -442,9 +442,9 @@ class AssumptionSurfacingEngine:
 
     def validate_assumptions(
         self,
-        assumptions: List[Assumption],
-        profile: Optional[Any] = None,
-        state: Optional[Any] = None
+        assumptions: list[Assumption],
+        profile: Any | None = None,
+        state: Any | None = None
     ) -> ValidationResult:
         """
         Validate assumptions against profile and state.
@@ -503,7 +503,7 @@ class AssumptionSurfacingEngine:
         self,
         assumption: Assumption,
         challenge_reason: str
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> tuple[bool, str | None]:
         """
         Challenge an assumption.
 

--- a/phionyx_core/services/assumption_types.py
+++ b/phionyx_core/services/assumption_types.py
@@ -5,7 +5,6 @@ Assumption Types
 Shared types for assumption-related modules.
 """
 
-from typing import List, Optional
 from dataclasses import dataclass
 
 
@@ -14,9 +13,9 @@ class Assumption:
     """Assumption data structure."""
     type: str  # "input_type", "state", "dependency", "performance"
     description: str
-    code_reference: Optional[str] = None  # File:line reference
+    code_reference: str | None = None  # File:line reference
     confidence: float = 1.0  # 0.0-1.0
-    evidence: Optional[List[str]] = None
+    evidence: list[str] | None = None
 
 
 __all__ = ['Assumption']

--- a/phionyx_core/services/clarification_engine.py
+++ b/phionyx_core/services/clarification_engine.py
@@ -7,9 +7,9 @@ Faz 3.1: Kalan Özellikler
 Confusion yönetimi için clarification request prompting.
 """
 
-from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class ConfusionType(Enum):
@@ -29,7 +29,7 @@ class ClarificationRequest:
     question: str
     context: str
     priority: str = "medium"  # "low", "medium", "high", "critical"
-    suggested_options: List[str] = None
+    suggested_options: list[str] = None
 
     def __post_init__(self):
         if self.suggested_options is None:
@@ -48,13 +48,13 @@ class ClarificationRequestEngine:
 
     def __init__(self):
         """Initialize clarification engine."""
-        self.request_history: List[ClarificationRequest] = []
+        self.request_history: list[ClarificationRequest] = []
 
     def detect_confusion(
         self,
         user_input: str,
-        context: Optional[Dict[str, Any]] = None
-    ) -> List[ClarificationRequest]:
+        context: dict[str, Any] | None = None
+    ) -> list[ClarificationRequest]:
         """
         Detect confusion points and generate clarification requests.
 
@@ -119,8 +119,8 @@ class ClarificationRequestEngine:
     def _detect_missing_information(
         self,
         user_input: str,
-        context: Optional[Dict[str, Any]] = None
-    ) -> Optional[str]:
+        context: dict[str, Any] | None = None
+    ) -> str | None:
         """Detect missing information."""
         # Check for common missing information patterns
         missing_patterns = [
@@ -147,7 +147,7 @@ class ClarificationRequestEngine:
         text_lower = text.lower()
         return any(indicator in text_lower for indicator in conflict_indicators)
 
-    def _generate_clarification_options(self, text: str) -> List[str]:
+    def _generate_clarification_options(self, text: str) -> list[str]:
         """Generate clarification options."""
         options = [
             "Could you provide more details?",
@@ -160,7 +160,7 @@ class ClarificationRequestEngine:
         self,
         request_id: str,
         response: str
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Process user clarification response.
 

--- a/phionyx_core/services/complexity_engine.py
+++ b/phionyx_core/services/complexity_engine.py
@@ -7,13 +7,12 @@ Faz 2.3: Complexity Budget Enforcement - Tam Fonksiyonel
 Gelişmiş complexity measurement ve enforcement servisi.
 """
 
-from typing import List, Optional, Tuple
-from dataclasses import dataclass
-import re
 import ast
 import math
+import re
+from dataclasses import dataclass
 
-from phionyx_core.pipeline.blocks.complexity_budget import ComplexityMetrics, ComplexityBudget
+from phionyx_core.pipeline.blocks.complexity_budget import ComplexityBudget, ComplexityMetrics
 
 
 @dataclass
@@ -40,7 +39,7 @@ class ComplexityBudgetEngine:
     - Entropy integration
     """
 
-    def __init__(self, budget: Optional[ComplexityBudget] = None):
+    def __init__(self, budget: ComplexityBudget | None = None):
         """
         Initialize complexity engine.
 
@@ -48,7 +47,7 @@ class ComplexityBudgetEngine:
             budget: ComplexityBudget configuration (optional)
         """
         self.budget = budget or ComplexityBudget()
-        self.metrics_history: List[ComplexityMetrics] = []
+        self.metrics_history: list[ComplexityMetrics] = []
 
     def measure_complexity_enhanced(self, code: str) -> ComplexityMetrics:
         """
@@ -264,8 +263,8 @@ class ComplexityBudgetEngine:
     def check_budget_enhanced(
         self,
         metrics: ComplexityMetrics,
-        budget: Optional[ComplexityBudget] = None
-    ) -> Tuple[bool, List[str], List[SimplificationSuggestion]]:
+        budget: ComplexityBudget | None = None
+    ) -> tuple[bool, list[str], list[SimplificationSuggestion]]:
         """
         Enhanced budget checking with suggestions.
 
@@ -374,8 +373,8 @@ class ComplexityBudgetEngine:
         self,
         code: str,
         metrics: ComplexityMetrics,
-        budget: Optional[ComplexityBudget] = None
-    ) -> List[SimplificationSuggestion]:
+        budget: ComplexityBudget | None = None
+    ) -> list[SimplificationSuggestion]:
         """
         Generate simplification suggestions based on complexity metrics.
 

--- a/phionyx_core/services/crypto/ed25519_signer.py
+++ b/phionyx_core/services/crypto/ed25519_signer.py
@@ -13,18 +13,17 @@ import hashlib
 import hmac
 import logging
 import os
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 # Try to import Ed25519 from cryptography or nacl
 _ED25519_AVAILABLE = False
 try:
+    from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric.ed25519 import (
         Ed25519PrivateKey,
         Ed25519PublicKey,  # noqa: F401
     )
-    from cryptography.hazmat.primitives import serialization
     _ED25519_AVAILABLE = True
 except ImportError:
     logger.info("cryptography package not available — falling back to HMAC-SHA256")
@@ -38,7 +37,7 @@ class Ed25519Signer:
     Falls back to HMAC-SHA256 if Ed25519 library is not installed.
     """
 
-    def __init__(self, private_key_hex: Optional[str] = None):
+    def __init__(self, private_key_hex: str | None = None):
         """
         Initialize signer.
 

--- a/phionyx_core/services/dead_code_pruner.py
+++ b/phionyx_core/services/dead_code_pruner.py
@@ -7,10 +7,10 @@ Faz 3.1: Kalan Özellikler
 Dead code detection and removal suggestions.
 """
 
-from typing import List, Dict, Any, Optional, Set
-from dataclasses import dataclass
-import re
 import ast
+import re
+from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -37,13 +37,13 @@ class DeadCodePruner:
 
     def __init__(self):
         """Initialize dead code pruner."""
-        self.detected_items: List[DeadCodeItem] = []
+        self.detected_items: list[DeadCodeItem] = []
 
     def detect_dead_code(
         self,
         code: str,
-        entry_points: Optional[List[str]] = None
-    ) -> List[DeadCodeItem]:
+        entry_points: list[str] | None = None
+    ) -> list[DeadCodeItem]:
         """
         Detect dead code in codebase.
 
@@ -114,7 +114,7 @@ class DeadCodePruner:
         self.detected_items.extend(dead_items)
         return dead_items
 
-    def _extract_functions(self, tree: ast.AST) -> List[Dict[str, Any]]:
+    def _extract_functions(self, tree: ast.AST) -> list[dict[str, Any]]:
         """Extract function definitions."""
         functions = []
         for node in ast.walk(tree):
@@ -125,7 +125,7 @@ class DeadCodePruner:
                 })
         return functions
 
-    def _extract_classes(self, tree: ast.AST) -> List[Dict[str, Any]]:
+    def _extract_classes(self, tree: ast.AST) -> list[dict[str, Any]]:
         """Extract class definitions."""
         classes = []
         for node in ast.walk(tree):
@@ -136,7 +136,7 @@ class DeadCodePruner:
                 })
         return classes
 
-    def _extract_variables(self, tree: ast.AST) -> List[Dict[str, Any]]:
+    def _extract_variables(self, tree: ast.AST) -> list[dict[str, Any]]:
         """Extract variable definitions."""
         variables = []
         for node in ast.walk(tree):
@@ -149,7 +149,7 @@ class DeadCodePruner:
                         })
         return variables
 
-    def _extract_imports(self, tree: ast.AST) -> List[Dict[str, Any]]:
+    def _extract_imports(self, tree: ast.AST) -> list[dict[str, Any]]:
         """Extract import statements."""
         imports = []
         for node in ast.walk(tree):
@@ -167,7 +167,7 @@ class DeadCodePruner:
                     })
         return imports
 
-    def _extract_function_calls(self, tree: ast.AST) -> Set[str]:
+    def _extract_function_calls(self, tree: ast.AST) -> set[str]:
         """Extract function calls."""
         calls = set()
         for node in ast.walk(tree):
@@ -178,7 +178,7 @@ class DeadCodePruner:
                     calls.add(node.func.attr)
         return calls
 
-    def _extract_class_instantiations(self, tree: ast.AST) -> Set[str]:
+    def _extract_class_instantiations(self, tree: ast.AST) -> set[str]:
         """Extract class instantiations."""
         instantiations = set()
         for node in ast.walk(tree):
@@ -187,7 +187,7 @@ class DeadCodePruner:
                     instantiations.add(node.func.id)
         return instantiations
 
-    def _extract_variable_usages(self, tree: ast.AST) -> Set[str]:
+    def _extract_variable_usages(self, tree: ast.AST) -> set[str]:
         """Extract variable usages."""
         usages = set()
         for node in ast.walk(tree):
@@ -195,7 +195,7 @@ class DeadCodePruner:
                 usages.add(node.id)
         return usages
 
-    def _detect_dead_code_pattern(self, code: str) -> List[DeadCodeItem]:
+    def _detect_dead_code_pattern(self, code: str) -> list[DeadCodeItem]:
         """Pattern-based dead code detection (fallback)."""
         dead_items = []
 

--- a/phionyx_core/services/global_workspace.py
+++ b/phionyx_core/services/global_workspace.py
@@ -8,10 +8,9 @@ Port-adapter pattern (AD-2).
 """
 
 import logging
-from typing import List, Dict, Set, Optional
 from collections import defaultdict
 
-from ..contracts.v4.workspace_event import WorkspaceEvent, SalienceLevel
+from ..contracts.v4.workspace_event import SalienceLevel, WorkspaceEvent
 
 logger = logging.getLogger(__name__)
 
@@ -24,17 +23,17 @@ class GlobalWorkspace:
     """
 
     def __init__(self, salience_threshold: float = 0.3):
-        self._subscribers: Dict[str, Set[str]] = defaultdict(set)
-        self._event_log: List[WorkspaceEvent] = []
+        self._subscribers: dict[str, set[str]] = defaultdict(set)
+        self._event_log: list[WorkspaceEvent] = []
         self._salience_threshold = salience_threshold
         self._max_log_size = 1000
 
-    def subscribe(self, module_id: str, event_types: List[str]) -> None:
+    def subscribe(self, module_id: str, event_types: list[str]) -> None:
         """Subscribe a module to specific event types."""
         for event_type in event_types:
             self._subscribers[event_type].add(module_id)
 
-    def unsubscribe(self, module_id: str, event_types: Optional[List[str]] = None) -> None:
+    def unsubscribe(self, module_id: str, event_types: list[str] | None = None) -> None:
         """Unsubscribe a module from event types."""
         if event_types is None:
             for subs in self._subscribers.values():
@@ -69,7 +68,7 @@ class GlobalWorkspace:
             f"(salience={event.salience.value}, targets={len(targets)})"
         )
 
-    async def get_pending_events(self) -> List[WorkspaceEvent]:
+    async def get_pending_events(self) -> list[WorkspaceEvent]:
         """Get recent events from the workspace."""
         return list(self._event_log[-50:])
 

--- a/phionyx_core/services/goal_registry.py
+++ b/phionyx_core/services/goal_registry.py
@@ -8,8 +8,8 @@ Port-adapter pattern (AD-2): implements GoalRegistryProtocol.
 """
 
 import logging
-from typing import List, Optional, Dict, Any
 from datetime import datetime, timezone
+from typing import Any
 
 from ..contracts.v4.goal_object import GoalObject, GoalPriority, GoalStatus
 from ..meta.arbitration_math import compute_goal_utility
@@ -25,7 +25,7 @@ class GoalRegistry:
     """
 
     def __init__(self):
-        self._goals: Dict[str, GoalObject] = {}
+        self._goals: dict[str, GoalObject] = {}
 
     async def register_goal(self, goal: GoalObject) -> GoalObject:
         """Register a new goal."""
@@ -41,7 +41,7 @@ class GoalRegistry:
         self._goals[goal.goal_id] = goal
         return goal
 
-    async def activate_goal(self, goal_id: str) -> Optional[GoalObject]:
+    async def activate_goal(self, goal_id: str) -> GoalObject | None:
         """Activate a proposed goal."""
         goal = self._goals.get(goal_id)
         if goal and goal.status == GoalStatus.PROPOSED:
@@ -49,7 +49,7 @@ class GoalRegistry:
             goal.activated_at = datetime.now(timezone.utc)
         return goal
 
-    async def get_active_goals(self) -> List[GoalObject]:
+    async def get_active_goals(self) -> list[GoalObject]:
         """Get all active goals sorted by priority."""
         priority_order = {
             GoalPriority.CRITICAL: 0,
@@ -60,7 +60,7 @@ class GoalRegistry:
         active = [g for g in self._goals.values() if g.status == GoalStatus.ACTIVE]
         return sorted(active, key=lambda g: priority_order.get(g.priority, 99))
 
-    async def evaluate_goals(self, context: Any) -> List[GoalObject]:
+    async def evaluate_goals(self, context: Any) -> list[GoalObject]:
         """Evaluate all active goals against current context."""
         active = await self.get_active_goals()
         for goal in active:
@@ -73,7 +73,7 @@ class GoalRegistry:
             )
         return active
 
-    async def complete_goal(self, goal_id: str) -> Optional[GoalObject]:
+    async def complete_goal(self, goal_id: str) -> GoalObject | None:
         """Mark a goal as completed."""
         goal = self._goals.get(goal_id)
         if goal:
@@ -81,6 +81,6 @@ class GoalRegistry:
             goal.completed_at = datetime.now(timezone.utc)
         return goal
 
-    def get_goal(self, goal_id: str) -> Optional[GoalObject]:
+    def get_goal(self, goal_id: str) -> GoalObject | None:
         """Get a goal by ID."""
         return self._goals.get(goal_id)

--- a/phionyx_core/services/inconsistency_engine.py
+++ b/phionyx_core/services/inconsistency_engine.py
@@ -7,10 +7,10 @@ Faz 2.2: Inconsistency Detection Engine - Tam Fonksiyonel
 Gelişmiş inconsistency detection ve resolution servisi.
 """
 
-from typing import List, Dict, Any, Optional, Tuple
-from dataclasses import dataclass
-import re
 import ast
+import re
+from dataclasses import dataclass
+from typing import Any
 
 from phionyx_core.pipeline.blocks.inconsistency_detection import Inconsistency
 
@@ -49,17 +49,17 @@ class InconsistencyDetectionEngine:
 
     def __init__(self):
         """Initialize inconsistency detection engine."""
-        self.inconsistency_cache: Dict[str, List[Inconsistency]] = {}
-        self.resolution_cache: Dict[str, List[ResolutionSuggestion]] = {}
+        self.inconsistency_cache: dict[str, list[Inconsistency]] = {}
+        self.resolution_cache: dict[str, list[ResolutionSuggestion]] = {}
 
     def detect_inconsistencies(
         self,
         code: str,
-        plan: Optional[str] = None,
-        tests: Optional[List[str]] = None,
-        requirements: Optional[List[str]] = None,
-        state: Optional[Any] = None
-    ) -> Tuple[List[Inconsistency], CoherenceMetrics]:
+        plan: str | None = None,
+        tests: list[str] | None = None,
+        requirements: list[str] | None = None,
+        state: Any | None = None
+    ) -> tuple[list[Inconsistency], CoherenceMetrics]:
         """
         Detect inconsistencies between code, plan, tests, and requirements.
 
@@ -113,7 +113,7 @@ class InconsistencyDetectionEngine:
         self,
         code: str,
         plan: str
-    ) -> List[Inconsistency]:
+    ) -> list[Inconsistency]:
         """Enhanced code-plan mismatch detection."""
         inconsistencies = []
 
@@ -174,8 +174,8 @@ class InconsistencyDetectionEngine:
     def _detect_code_test_mismatch_enhanced(
         self,
         code: str,
-        tests: List[str]
-    ) -> List[Inconsistency]:
+        tests: list[str]
+    ) -> list[Inconsistency]:
         """Enhanced code-test mismatch detection."""
         inconsistencies = []
 
@@ -225,8 +225,8 @@ class InconsistencyDetectionEngine:
     def _detect_plan_requirement_mismatch_enhanced(
         self,
         plan: str,
-        requirements: List[str]
-    ) -> List[Inconsistency]:
+        requirements: list[str]
+    ) -> list[Inconsistency]:
         """Enhanced plan-requirement mismatch detection."""
         inconsistencies = []
 
@@ -258,7 +258,7 @@ class InconsistencyDetectionEngine:
 
         return inconsistencies
 
-    def _detect_state_inconsistency_enhanced(self, state: Any) -> List[Inconsistency]:
+    def _detect_state_inconsistency_enhanced(self, state: Any) -> list[Inconsistency]:
         """Enhanced state inconsistency detection."""
         inconsistencies = []
 
@@ -315,10 +315,10 @@ class InconsistencyDetectionEngine:
     def _calculate_coherence_metrics(
         self,
         code: str,
-        plan: Optional[str],
-        tests: Optional[List[str]],
-        requirements: Optional[List[str]],
-        inconsistencies: List[Inconsistency]
+        plan: str | None,
+        tests: list[str] | None,
+        requirements: list[str] | None,
+        inconsistencies: list[Inconsistency]
     ) -> CoherenceMetrics:
         """Calculate coherence metrics."""
         code_plan_coherence = 1.0
@@ -382,9 +382,9 @@ class InconsistencyDetectionEngine:
         self,
         inconsistency: Inconsistency,
         code: str,
-        plan: Optional[str],
-        tests: Optional[List[str]],
-        requirements: Optional[List[str]]
+        plan: str | None,
+        tests: list[str] | None,
+        requirements: list[str] | None
     ) -> str:
         """Generate resolution suggestion for inconsistency."""
         if inconsistency.type == "code_plan":
@@ -398,7 +398,7 @@ class InconsistencyDetectionEngine:
         else:
             return "Review and resolve inconsistency based on context."
 
-    def _extract_plan_steps_enhanced(self, plan: str) -> List[str]:
+    def _extract_plan_steps_enhanced(self, plan: str) -> list[str]:
         """Enhanced plan step extraction."""
         steps = []
 
@@ -418,7 +418,7 @@ class InconsistencyDetectionEngine:
 
         return steps
 
-    def _extract_code_elements_enhanced(self, code: str) -> List[Dict[str, Any]]:
+    def _extract_code_elements_enhanced(self, code: str) -> list[dict[str, Any]]:
         """Enhanced code element extraction."""
         elements = []
 
@@ -453,7 +453,7 @@ class InconsistencyDetectionEngine:
 
         return elements
 
-    def _extract_functions_enhanced(self, code: str) -> List[Dict[str, Any]]:
+    def _extract_functions_enhanced(self, code: str) -> list[dict[str, Any]]:
         """Enhanced function extraction."""
         functions = []
 
@@ -477,7 +477,7 @@ class InconsistencyDetectionEngine:
 
         return functions
 
-    def _extract_test_cases_enhanced(self, tests: List[str]) -> List[Dict[str, Any]]:
+    def _extract_test_cases_enhanced(self, tests: list[str]) -> list[dict[str, Any]]:
         """Enhanced test case extraction."""
         test_cases = []
 
@@ -493,7 +493,7 @@ class InconsistencyDetectionEngine:
 
         return test_cases
 
-    def _extract_tested_function_enhanced(self, test_case: Dict[str, Any]) -> Optional[str]:
+    def _extract_tested_function_enhanced(self, test_case: dict[str, Any]) -> str | None:
         """Enhanced tested function extraction."""
         test_code = test_case.get("code", "")
 
@@ -509,7 +509,7 @@ class InconsistencyDetectionEngine:
 
         return None
 
-    def _extract_keywords(self, text: str) -> List[str]:
+    def _extract_keywords(self, text: str) -> list[str]:
         """Extract keywords from text."""
         # Remove common words
         stop_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by'}
@@ -517,7 +517,7 @@ class InconsistencyDetectionEngine:
         keywords = [w for w in words if w not in stop_words and len(w) > 2]
         return keywords
 
-    def _calculate_similarity(self, keywords1: List[str], keywords2: List[str]) -> float:
+    def _calculate_similarity(self, keywords1: list[str], keywords2: list[str]) -> float:
         """Calculate similarity between two keyword lists."""
         if not keywords1 or not keywords2:
             return 0.0
@@ -537,7 +537,7 @@ class InconsistencyDetectionEngine:
 
         return len(intersection) / len(union)
 
-    def _validate_state_assumption(self, assumption: Dict[str, Any], state: Any) -> bool:
+    def _validate_state_assumption(self, assumption: dict[str, Any], state: Any) -> bool:
         """Validate state assumption against actual state."""
         # Basic validation - would be enhanced in production
         return True

--- a/phionyx_core/services/inline_plan_engine.py
+++ b/phionyx_core/services/inline_plan_engine.py
@@ -7,8 +7,8 @@ Faz 3.1: Kalan Özellikler
 Kod üretiminden önce plan üretir ve adım ayrıştırması yapar.
 """
 
-from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -17,8 +17,8 @@ class PlanStep:
     id: str
     order: int
     description: str
-    dependencies: List[str] = None  # IDs of steps that must complete before this
-    estimated_time: Optional[float] = None  # In minutes
+    dependencies: list[str] = None  # IDs of steps that must complete before this
+    estimated_time: float | None = None  # In minutes
     status: str = "pending"  # "pending", "in_progress", "completed", "failed"
 
     def __post_init__(self):
@@ -32,8 +32,8 @@ class Plan:
     id: str
     title: str
     description: str
-    steps: List[PlanStep]
-    total_estimated_time: Optional[float] = None
+    steps: list[PlanStep]
+    total_estimated_time: float | None = None
     status: str = "draft"  # "draft", "approved", "executing", "completed"
 
 
@@ -50,12 +50,12 @@ class InlinePlanEngine:
 
     def __init__(self):
         """Initialize inline plan engine."""
-        self.plan_cache: Dict[str, Plan] = {}
+        self.plan_cache: dict[str, Plan] = {}
 
     def generate_plan(
         self,
         requirement: str,
-        context: Optional[Dict[str, Any]] = None
+        context: dict[str, Any] | None = None
     ) -> Plan:
         """
         Generate plan from requirement.
@@ -89,8 +89,8 @@ class InlinePlanEngine:
     def _decompose_requirement(
         self,
         requirement: str,
-        context: Optional[Dict[str, Any]] = None
-    ) -> List[PlanStep]:
+        context: dict[str, Any] | None = None
+    ) -> list[PlanStep]:
         """Decompose requirement into steps."""
         steps = []
 
@@ -108,7 +108,7 @@ class InlinePlanEngine:
         requirement_length = len(requirement)
         num_steps = min(6, max(3, requirement_length // 50))
 
-        for i, (step_type, step_desc, estimated_time) in enumerate(step_patterns[:num_steps]):
+        for i, (_step_type, step_desc, estimated_time) in enumerate(step_patterns[:num_steps]):
             step = PlanStep(
                 id=f"step_{i+1}",
                 order=i+1,
@@ -149,7 +149,7 @@ class InlinePlanEngine:
 
         return False
 
-    def get_execution_order(self, plan: Plan) -> List[PlanStep]:
+    def get_execution_order(self, plan: Plan) -> list[PlanStep]:
         """
         Get execution order considering dependencies.
 

--- a/phionyx_core/services/intent_classifier.py
+++ b/phionyx_core/services/intent_classifier.py
@@ -15,9 +15,9 @@ import logging
 import math
 import re
 import time
-from typing import Any, Dict, List, Optional
-from enum import Enum
 from dataclasses import dataclass
+from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +53,8 @@ class IntentClassifier:
 
     def __init__(
         self,
-        llm_provider: Optional[Any] = None,
-        embedding_cache: Optional[Any] = None
+        llm_provider: Any | None = None,
+        embedding_cache: Any | None = None
     ):
         """
         Initialize intent classifier.
@@ -182,7 +182,7 @@ class IntentClassifier:
             processing_time_ms=elapsed_ms
         )
 
-    def _classify_rule_based(self, normalized_input: str) -> Optional[IntentResult]:
+    def _classify_rule_based(self, normalized_input: str) -> IntentResult | None:
         """
         Rule-based intent classification (fastest).
 
@@ -234,7 +234,7 @@ class IntentClassifier:
 
         return None
 
-    _INTENT_KEYWORDS: Dict[IntentType, List[str]] = {
+    _INTENT_KEYWORDS: dict[IntentType, list[str]] = {
         IntentType.GREETING: [
             "merhaba", "selam", "hey", "hi", "hello", "günaydın",
             "iyi günler", "iyi akşamlar", "how are you", "nasılsın",
@@ -262,7 +262,7 @@ class IntentClassifier:
         ],
     }
 
-    def _classify_embedding_based(self, normalized_input: str) -> Optional[IntentResult]:
+    def _classify_embedding_based(self, normalized_input: str) -> IntentResult | None:
         """
         Embedding-based intent classification (fast path).
 
@@ -289,7 +289,7 @@ class IntentClassifier:
         if not input_tokens:
             return None
 
-        scores: List[float] = []
+        scores: list[float] = []
         for intent_type in self._INTENT_KEYWORDS:
             keywords = self._INTENT_KEYWORDS[intent_type]
             keyword_set = set(keywords)
@@ -322,7 +322,7 @@ class IntentClassifier:
         self,
         normalized_input: str,
         timeout_ms: float
-    ) -> Optional[IntentResult]:
+    ) -> IntentResult | None:
         """
         LLM-based intent classification (fallback, small model only).
 

--- a/phionyx_core/services/learning_gate_service.py
+++ b/phionyx_core/services/learning_gate_service.py
@@ -8,13 +8,12 @@ Port-adapter pattern (AD-2).
 """
 
 import logging
-from pathlib import Path
-from typing import Dict, List, Optional
 from datetime import datetime, timezone
+from pathlib import Path
 
 import yaml
 
-from ..contracts.v4.learning_update import LearningUpdate, LearningGateDecision
+from ..contracts.v4.learning_update import LearningGateDecision, LearningUpdate
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ logger = logging.getLogger(__name__)
 MAX_DELTA_FRACTION = 0.2  # 20% change per update
 
 # Tier-to-zone mapping (Learning Gate Contract v1.0 §3)
-TIER_TO_ZONE: Dict[str, str] = {
+TIER_TO_ZONE: dict[str, str] = {
     "A": "adaptive",
     "B": "gated",
     "C": "gated",
@@ -33,19 +32,19 @@ TIER_TO_ZONE: Dict[str, str] = {
 _SURFACES_YAML = Path(__file__).parent.parent / "research_engine" / "mutation" / "surfaces.yaml"
 
 
-def _load_surface_registry(surfaces_path: Optional[Path] = None) -> Dict[str, str]:
+def _load_surface_registry(surfaces_path: Path | None = None) -> dict[str, str]:
     """Load parameter → boundary zone mapping from surfaces.yaml.
 
     Returns dict mapping 'param_name' -> 'immutable'|'gated'|'adaptive'.
     """
     path = surfaces_path or _SURFACES_YAML
-    registry: Dict[str, str] = {}
+    registry: dict[str, str] = {}
 
     if not path.exists():
         logger.warning("surfaces.yaml not found at %s — using empty registry", path)
         return registry
 
-    with open(path, "r") as f:
+    with open(path) as f:
         data = yaml.safe_load(f)
 
     for surface in data.get("surfaces", []):
@@ -78,12 +77,12 @@ class LearningGateService:
     def __init__(
         self,
         max_delta_fraction: float = MAX_DELTA_FRACTION,
-        surfaces_path: Optional[Path] = None,
+        surfaces_path: Path | None = None,
     ):
         self.max_delta_fraction = max_delta_fraction
-        self._approval_queue: List[LearningUpdate] = []
-        self._applied_updates: Dict[str, LearningUpdate] = {}  # update_id -> update
-        self._zone_registry: Dict[str, str] = _load_surface_registry(surfaces_path)
+        self._approval_queue: list[LearningUpdate] = []
+        self._applied_updates: dict[str, LearningUpdate] = {}  # update_id -> update
+        self._zone_registry: dict[str, str] = _load_surface_registry(surfaces_path)
 
     def get_boundary_zone(self, param_name: str) -> str:
         """Resolve boundary zone for a parameter from surfaces.yaml tier mapping.
@@ -93,7 +92,7 @@ class LearningGateService:
         """
         return self._zone_registry.get(param_name, "gated")
 
-    async def evaluate_updates(self, updates: List[LearningUpdate]) -> List[LearningUpdate]:
+    async def evaluate_updates(self, updates: list[LearningUpdate]) -> list[LearningUpdate]:
         """Evaluate a batch of learning updates."""
         for update in updates:
             # Auto-resolve zone from registry if not explicitly set or still default
@@ -201,7 +200,7 @@ class LearningGateService:
 
         return True
 
-    async def apply_approved(self, updates: List[LearningUpdate]) -> int:
+    async def apply_approved(self, updates: list[LearningUpdate]) -> int:
         """Apply approved updates and track for potential rollback."""
         applied = 0
         for update in updates:
@@ -243,17 +242,17 @@ class LearningGateService:
         )
         return True
 
-    def get_pending_approvals(self) -> List[LearningUpdate]:
+    def get_pending_approvals(self) -> list[LearningUpdate]:
         """Get updates awaiting human approval."""
         return [u for u in self._approval_queue if u.gate_decision == LearningGateDecision.PENDING]
 
-    def get_applied_updates(self) -> Dict[str, LearningUpdate]:
+    def get_applied_updates(self) -> dict[str, LearningUpdate]:
         """Get all currently applied updates (available for rollback)."""
         return dict(self._applied_updates)
 
-    def get_zone_distribution(self) -> Dict[str, int]:
+    def get_zone_distribution(self) -> dict[str, int]:
         """Get count of parameters per boundary zone from registry."""
-        dist: Dict[str, int] = {"immutable": 0, "gated": 0, "adaptive": 0}
+        dist: dict[str, int] = {"immutable": 0, "gated": 0, "adaptive": 0}
         for zone in self._zone_registry.values():
             dist[zone] = dist.get(zone, 0) + 1
         return dist

--- a/phionyx_core/services/orthogonal_change_guard.py
+++ b/phionyx_core/services/orthogonal_change_guard.py
@@ -7,9 +7,9 @@ Faz 3.1: Kalan Özellikler
 Kod dışı etki / değişiklik kontrolü.
 """
 
-from typing import List, Dict, Any, Optional, Set
-from dataclasses import dataclass
 import re
+from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -17,7 +17,7 @@ class OrthogonalChange:
     """Orthogonal change detection."""
     type: str  # "file_modification", "dependency_change", "config_change", "side_effect"
     description: str
-    affected_files: List[str]
+    affected_files: list[str]
     severity: str  # "low", "medium", "high", "critical"
     suggestion: str
 
@@ -35,14 +35,14 @@ class OrthogonalChangeGuard:
 
     def __init__(self):
         """Initialize orthogonal change guard."""
-        self.detected_changes: List[OrthogonalChange] = []
-        self.file_registry: Set[str] = set()
+        self.detected_changes: list[OrthogonalChange] = []
+        self.file_registry: set[str] = set()
 
     def check_orthogonal_changes(
         self,
         code: str,
-        context: Optional[Dict[str, Any]] = None
-    ) -> List[OrthogonalChange]:
+        context: dict[str, Any] | None = None
+    ) -> list[OrthogonalChange]:
         """
         Check for orthogonal changes (side effects).
 
@@ -74,7 +74,7 @@ class OrthogonalChangeGuard:
         self.detected_changes.extend(changes)
         return changes
 
-    def _detect_file_modifications(self, code: str) -> List[OrthogonalChange]:
+    def _detect_file_modifications(self, code: str) -> list[OrthogonalChange]:
         """Detect file modification operations."""
         changes = []
 
@@ -101,7 +101,7 @@ class OrthogonalChangeGuard:
 
         return changes
 
-    def _detect_dependency_changes(self, code: str) -> List[OrthogonalChange]:
+    def _detect_dependency_changes(self, code: str) -> list[OrthogonalChange]:
         """Detect dependency changes."""
         changes = []
 
@@ -120,7 +120,7 @@ class OrthogonalChangeGuard:
 
         return changes
 
-    def _detect_config_changes(self, code: str) -> List[OrthogonalChange]:
+    def _detect_config_changes(self, code: str) -> list[OrthogonalChange]:
         """Detect configuration changes."""
         changes = []
 
@@ -143,7 +143,7 @@ class OrthogonalChangeGuard:
 
         return changes
 
-    def _detect_side_effects(self, code: str) -> List[OrthogonalChange]:
+    def _detect_side_effects(self, code: str) -> list[OrthogonalChange]:
         """Detect side effects."""
         changes = []
 

--- a/phionyx_core/services/pushback_engine.py
+++ b/phionyx_core/services/pushback_engine.py
@@ -7,9 +7,9 @@ Faz 2.4: Push-back Interface - Tam Fonksiyonel
 Push-back mechanism for requirement, constraint, and profile violations.
 """
 
-from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 from phionyx_core.pipeline.base import BlockContext
 
@@ -27,19 +27,19 @@ class PushBackMessage:
     """Push-back message structure."""
     violation_type: ViolationType
     violation_description: str
-    constraint_name: Optional[str] = None
-    requirement_name: Optional[str] = None
-    profile_name: Optional[str] = None
+    constraint_name: str | None = None
+    requirement_name: str | None = None
+    profile_name: str | None = None
     severity: str = "medium"  # "low", "medium", "high", "critical"
-    suggested_action: Optional[str] = None
-    user_feedback_request: Optional[str] = None
+    suggested_action: str | None = None
+    user_feedback_request: str | None = None
 
 
 @dataclass
 class PushBackResult:
     """Result of push-back evaluation."""
     should_push_back: bool
-    messages: List[PushBackMessage]
+    messages: list[PushBackMessage]
     violations_count: int
     can_proceed: bool  # Whether execution can proceed despite violations
 
@@ -57,7 +57,7 @@ class PushBackEngine:
     - User feedback loop
     """
 
-    def __init__(self, governance_node: Optional[Any] = None):
+    def __init__(self, governance_node: Any | None = None):
         """
         Initialize push-back engine.
 
@@ -65,15 +65,15 @@ class PushBackEngine:
             governance_node: GovernanceNode instance (optional)
         """
         self.governance_node = governance_node
-        self.violation_history: List[PushBackMessage] = []
-        self.user_feedback_cache: Dict[str, Any] = {}
+        self.violation_history: list[PushBackMessage] = []
+        self.user_feedback_cache: dict[str, Any] = {}
 
     def evaluate_push_back(
         self,
         context: BlockContext,
-        requirements: Optional[List[Dict[str, Any]]] = None,
-        constraints: Optional[List[Dict[str, Any]]] = None,
-        profile: Optional[Any] = None
+        requirements: list[dict[str, Any]] | None = None,
+        constraints: list[dict[str, Any]] | None = None,
+        profile: Any | None = None
     ) -> PushBackResult:
         """
         Evaluate if push-back is needed.
@@ -129,8 +129,8 @@ class PushBackEngine:
     def _check_requirement_violations(
         self,
         context: BlockContext,
-        requirements: List[Dict[str, Any]]
-    ) -> List[PushBackMessage]:
+        requirements: list[dict[str, Any]]
+    ) -> list[PushBackMessage]:
         """Check requirement violations."""
         violations = []
 
@@ -156,8 +156,8 @@ class PushBackEngine:
     def _check_constraint_violations(
         self,
         context: BlockContext,
-        constraints: List[Dict[str, Any]]
-    ) -> List[PushBackMessage]:
+        constraints: list[dict[str, Any]]
+    ) -> list[PushBackMessage]:
         """Check constraint violations."""
         violations = []
 
@@ -184,7 +184,7 @@ class PushBackEngine:
         self,
         context: BlockContext,
         profile: Any
-    ) -> List[PushBackMessage]:
+    ) -> list[PushBackMessage]:
         """Check profile violations."""
         violations = []
 
@@ -221,7 +221,7 @@ class PushBackEngine:
     def _check_governance_violations(
         self,
         context: BlockContext
-    ) -> List[PushBackMessage]:
+    ) -> list[PushBackMessage]:
         """Check governance violations using Governance Node."""
         violations = []
 
@@ -289,7 +289,7 @@ class PushBackEngine:
     def _check_threshold(
         self,
         value: float,
-        threshold: Dict[str, Any]
+        threshold: dict[str, Any]
     ) -> bool:
         """Check if value is within threshold."""
         min_val = threshold.get("min")
@@ -352,8 +352,8 @@ class PushBackEngine:
     def process_user_feedback(
         self,
         violation_id: str,
-        feedback: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        feedback: dict[str, Any]
+    ) -> dict[str, Any]:
         """
         Process user feedback for a violation.
 

--- a/phionyx_core/services/rag_service.py
+++ b/phionyx_core/services/rag_service.py
@@ -13,10 +13,10 @@ Features:
 """
 
 import logging
-from typing import Dict, Any, Optional, List
 from datetime import datetime
+from typing import Any
 
-from phionyx_core.memory.rag_cache import get_rag_cache, RAGCache
+from phionyx_core.memory.rag_cache import RAGCache, get_rag_cache
 from phionyx_core.physics.semantic_time_decay import SemanticTimeDecayManager
 
 logger = logging.getLogger(__name__)
@@ -35,11 +35,11 @@ class RAGService:
 
     def __init__(
         self,
-        vector_store: Optional[Any] = None,
+        vector_store: Any | None = None,
         max_context_tokens: int = 2000,
         relevance_threshold: float = 0.7,
         semantic_decay_half_life_hours: float = 24.0,
-        rag_cache: Optional[RAGCache] = None,
+        rag_cache: RAGCache | None = None,
         use_semantic_time_decay: bool = True
     ):
         """
@@ -82,12 +82,12 @@ class RAGService:
     async def retrieve_context(
         self,
         query: str,
-        intent: Optional[str] = None,
-        actor_ref: Optional[str] = None,
+        intent: str | None = None,
+        actor_ref: str | None = None,
         limit: int = 5,
-        t_local: Optional[float] = None,
-        t_global: Optional[float] = None
-    ) -> Dict[str, Any]:
+        t_local: float | None = None,
+        t_global: float | None = None
+    ) -> dict[str, Any]:
         """
         Retrieve relevant context using RAG.
 
@@ -194,7 +194,7 @@ class RAGService:
     def _optimize_query_for_intent(
         self,
         query: str,
-        intent: Optional[str] = None
+        intent: str | None = None
     ) -> str:
         """
         Optimize query based on intent.
@@ -222,10 +222,10 @@ class RAGService:
 
     def _apply_semantic_decay(
         self,
-        memories: List[Dict],
-        t_local: Optional[float] = None,
-        t_global: Optional[float] = None
-    ) -> List[Dict]:
+        memories: list[dict],
+        t_local: float | None = None,
+        t_global: float | None = None
+    ) -> list[dict]:
         """
         Apply semantic decay to memories (Patent Aile 4).
 
@@ -252,10 +252,10 @@ class RAGService:
 
     def _apply_semantic_time_decay(
         self,
-        memories: List[Dict],
+        memories: list[dict],
         t_local: float,
-        t_global: Optional[float] = None
-    ) -> List[Dict]:
+        t_global: float | None = None
+    ) -> list[dict]:
         """
         Apply semantic time decay to memories (Patent Aile 4).
 
@@ -311,7 +311,7 @@ class RAGService:
 
         return decayed_memories
 
-    def _apply_wall_clock_decay(self, memories: List[Dict]) -> List[Dict]:
+    def _apply_wall_clock_decay(self, memories: list[dict]) -> list[dict]:
         """
         Apply wall-clock time decay to memories (backward compatibility).
 
@@ -374,7 +374,7 @@ class RAGService:
 
     def _build_context_string(
         self,
-        memories: List[Dict],
+        memories: list[dict],
         max_tokens: int
     ) -> tuple[str, int]:
         """

--- a/phionyx_core/services/secret_manager.py
+++ b/phionyx_core/services/secret_manager.py
@@ -6,9 +6,8 @@ Vault-first secret management with env var fallback.
 Abstracts secret access for all modules.
 """
 
-import os
 import logging
-from typing import Optional, Dict
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -25,8 +24,8 @@ class SecretManager:
 
     def __init__(
         self,
-        vault_url: Optional[str] = None,
-        vault_token: Optional[str] = None,
+        vault_url: str | None = None,
+        vault_token: str | None = None,
         vault_mount: str = "secret",
     ):
         """
@@ -41,7 +40,7 @@ class SecretManager:
         self._vault_token = vault_token or os.environ.get("VAULT_TOKEN")
         self._vault_mount = vault_mount
         self._vault_client = None
-        self._cache: Dict[str, str] = {}
+        self._cache: dict[str, str] = {}
 
         if self._vault_url and self._vault_token:
             self._init_vault()
@@ -67,9 +66,9 @@ class SecretManager:
     def get_secret(
         self,
         key: str,
-        default: Optional[str] = None,
-        vault_path: Optional[str] = None,
-    ) -> Optional[str]:
+        default: str | None = None,
+        vault_path: str | None = None,
+    ) -> str | None:
         """
         Get a secret value.
 

--- a/phionyx_core/services/success_criteria_engine.py
+++ b/phionyx_core/services/success_criteria_engine.py
@@ -7,10 +7,10 @@ Faz 2.5: Success Criteria Workflow - Tam Fonksiyonel
 Test-first workflow implementation with success criteria definition and evaluation.
 """
 
-from typing import List, Dict, Any, Optional, Tuple
+import re
 from dataclasses import dataclass
 from enum import Enum
-import re
+from typing import Any
 
 
 class CriteriaType(Enum):
@@ -32,7 +32,7 @@ class SuccessCriterion:
     test_expression: str  # Test code or expression
     expected_result: Any  # Expected result
     priority: str = "medium"  # "low", "medium", "high", "critical"
-    timeout: Optional[float] = None  # Timeout in seconds
+    timeout: float | None = None  # Timeout in seconds
 
 
 @dataclass
@@ -42,8 +42,8 @@ class TestResult:
     passed: bool
     actual_result: Any
     expected_result: Any
-    error_message: Optional[str] = None
-    execution_time: Optional[float] = None
+    error_message: str | None = None
+    execution_time: float | None = None
 
 
 @dataclass
@@ -53,9 +53,9 @@ class EvaluationResult:
     passed_count: int
     failed_count: int
     total_count: int
-    test_results: List[TestResult]
+    test_results: list[TestResult]
     overall_score: float  # 0.0-1.0
-    critical_failures: List[str]  # IDs of critical criteria that failed
+    critical_failures: list[str]  # IDs of critical criteria that failed
 
 
 class SuccessCriteriaEngine:
@@ -71,7 +71,7 @@ class SuccessCriteriaEngine:
     - Workflow orchestration
     """
 
-    def __init__(self, ai_assurance_kit: Optional[Any] = None):
+    def __init__(self, ai_assurance_kit: Any | None = None):
         """
         Initialize success criteria engine.
 
@@ -79,12 +79,12 @@ class SuccessCriteriaEngine:
             ai_assurance_kit: AI Assurance Kit instance (optional)
         """
         self.ai_assurance_kit = ai_assurance_kit
-        self.criteria_registry: Dict[str, SuccessCriterion] = {}
-        self.test_results_history: List[TestResult] = []
+        self.criteria_registry: dict[str, SuccessCriterion] = {}
+        self.test_results_history: list[TestResult] = []
 
     def define_criteria(
         self,
-        criteria: List[SuccessCriterion]
+        criteria: list[SuccessCriterion]
     ) -> None:
         """
         Define success criteria.
@@ -97,8 +97,8 @@ class SuccessCriteriaEngine:
 
     def generate_tests_from_criteria(
         self,
-        criteria: Optional[List[SuccessCriterion]] = None
-    ) -> List[str]:
+        criteria: list[SuccessCriterion] | None = None
+    ) -> list[str]:
         """
         Generate test code from success criteria.
 
@@ -144,9 +144,9 @@ def {test_name}():
 
     def execute_tests(
         self,
-        test_codes: List[str],
-        context: Optional[Dict[str, Any]] = None
-    ) -> List[TestResult]:
+        test_codes: list[str],
+        context: dict[str, Any] | None = None
+    ) -> list[TestResult]:
         """
         Execute test codes.
 
@@ -201,7 +201,7 @@ def {test_name}():
 
         return results
 
-    def _extract_criterion_id(self, test_code: str) -> Optional[str]:
+    def _extract_criterion_id(self, test_code: str) -> str | None:
         """Extract criterion ID from test code."""
         match = re.search(r'test_(\w+)', test_code)
         if match:
@@ -211,8 +211,8 @@ def {test_name}():
     def _execute_test_code(
         self,
         test_code: str,
-        context: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        context: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """
         Execute test code.
 
@@ -236,8 +236,8 @@ def {test_name}():
 
     def evaluate_criteria(
         self,
-        test_results: List[TestResult],
-        criteria: Optional[List[SuccessCriterion]] = None
+        test_results: list[TestResult],
+        criteria: list[SuccessCriterion] | None = None
     ) -> EvaluationResult:
         """
         Evaluate success criteria based on test results.
@@ -283,8 +283,8 @@ def {test_name}():
 
     def integrate_with_ai_assurance_kit(
         self,
-        criteria: List[SuccessCriterion]
-    ) -> Dict[str, Any]:
+        criteria: list[SuccessCriterion]
+    ) -> dict[str, Any]:
         """
         Integrate with AI Assurance Kit.
 
@@ -316,10 +316,10 @@ def {test_name}():
 
     def orchestrate_workflow(
         self,
-        criteria: List[SuccessCriterion],
-        code: Optional[str] = None,
-        context: Optional[Dict[str, Any]] = None
-    ) -> Tuple[EvaluationResult, List[str]]:
+        criteria: list[SuccessCriterion],
+        code: str | None = None,
+        context: dict[str, Any] | None = None
+    ) -> tuple[EvaluationResult, list[str]]:
         """
         Orchestrate the complete success criteria workflow.
 

--- a/phionyx_core/services/tradeoff_engine.py
+++ b/phionyx_core/services/tradeoff_engine.py
@@ -7,9 +7,9 @@ Faz 3.1: Kalan Özellikler
 Alternatif mimari/fonksiyon seçeneklerini listeler ve maliyet/risk analizi yapar.
 """
 
-from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 
 class AlternativeType(Enum):
@@ -39,8 +39,8 @@ class Alternative:
     risk_score: float = 0.0  # 0.0-1.0, lower is better
     complexity_score: float = 0.0  # 0.0-1.0, lower is better
     maintainability_score: float = 0.0  # 0.0-1.0, higher is better
-    pros: List[str] = None
-    cons: List[str] = None
+    pros: list[str] = None
+    cons: list[str] = None
 
     def __post_init__(self):
         if self.pros is None:
@@ -52,9 +52,9 @@ class Alternative:
 @dataclass
 class TradeOffTable:
     """Trade-off comparison table."""
-    alternatives: List[Alternative]
-    metrics: List[str]  # ["cost", "risk", "complexity", "maintainability"]
-    recommendation: Optional[Alternative] = None
+    alternatives: list[Alternative]
+    metrics: list[str]  # ["cost", "risk", "complexity", "maintainability"]
+    recommendation: Alternative | None = None
 
 
 class TradeOffElicitationEngine:
@@ -70,13 +70,13 @@ class TradeOffElicitationEngine:
 
     def __init__(self):
         """Initialize trade-off engine."""
-        self.alternative_cache: Dict[str, List[Alternative]] = {}
+        self.alternative_cache: dict[str, list[Alternative]] = {}
 
     def generate_alternatives(
         self,
         requirement: str,
-        constraints: Optional[List[Constraint]] = None
-    ) -> List[Alternative]:
+        constraints: list[Constraint] | None = None
+    ) -> list[Alternative]:
         """
         Generate alternative solutions for a requirement.
 
@@ -110,8 +110,8 @@ class TradeOffElicitationEngine:
     def _generate_architectural_alternatives(
         self,
         requirement: str,
-        constraints: Optional[List[Constraint]] = None
-    ) -> List[Alternative]:
+        constraints: list[Constraint] | None = None
+    ) -> list[Alternative]:
         """Generate architectural alternatives."""
         alternatives = []
 
@@ -139,8 +139,8 @@ class TradeOffElicitationEngine:
     def _generate_functional_alternatives(
         self,
         requirement: str,
-        constraints: Optional[List[Constraint]] = None
-    ) -> List[Alternative]:
+        constraints: list[Constraint] | None = None
+    ) -> list[Alternative]:
         """Generate functional alternatives."""
         alternatives = []
 
@@ -168,8 +168,8 @@ class TradeOffElicitationEngine:
     def _generate_implementation_alternatives(
         self,
         requirement: str,
-        constraints: Optional[List[Constraint]] = None
-    ) -> List[Alternative]:
+        constraints: list[Constraint] | None = None
+    ) -> list[Alternative]:
         """Generate implementation alternatives."""
         alternatives = []
 
@@ -197,7 +197,7 @@ class TradeOffElicitationEngine:
     def _calculate_cost(
         self,
         alternative: Alternative,
-        constraints: Optional[List[Constraint]] = None
+        constraints: list[Constraint] | None = None
     ) -> float:
         """Calculate cost score (0.0-1.0, lower is better)."""
         # Base cost based on type
@@ -221,7 +221,7 @@ class TradeOffElicitationEngine:
     def _calculate_risk(
         self,
         alternative: Alternative,
-        constraints: Optional[List[Constraint]] = None
+        constraints: list[Constraint] | None = None
     ) -> float:
         """Calculate risk score (0.0-1.0, lower is better)."""
         # Base risk based on type
@@ -245,7 +245,7 @@ class TradeOffElicitationEngine:
     def _calculate_complexity(
         self,
         alternative: Alternative,
-        constraints: Optional[List[Constraint]] = None
+        constraints: list[Constraint] | None = None
     ) -> float:
         """Calculate complexity score (0.0-1.0, lower is better)."""
         # Base complexity based on type
@@ -267,7 +267,7 @@ class TradeOffElicitationEngine:
     def _calculate_maintainability(
         self,
         alternative: Alternative,
-        constraints: Optional[List[Constraint]] = None
+        constraints: list[Constraint] | None = None
     ) -> float:
         """Calculate maintainability score (0.0-1.0, higher is better)."""
         # Base maintainability (inverse of complexity)
@@ -283,8 +283,8 @@ class TradeOffElicitationEngine:
 
     def generate_tradeoff_table(
         self,
-        alternatives: List[Alternative],
-        metrics: Optional[List[str]] = None
+        alternatives: list[Alternative],
+        metrics: list[str] | None = None
     ) -> TradeOffTable:
         """
         Generate trade-off comparison table.
@@ -322,7 +322,7 @@ class TradeOffElicitationEngine:
             recommendation=best_alternative
         )
 
-    def _get_architectural_pros(self, pattern_id: str) -> List[str]:
+    def _get_architectural_pros(self, pattern_id: str) -> list[str]:
         """Get pros for architectural pattern."""
         pros_map = {
             "monolithic": ["Simple to develop", "Easy to deploy", "Low overhead"],
@@ -332,7 +332,7 @@ class TradeOffElicitationEngine:
         }
         return pros_map.get(pattern_id, [])
 
-    def _get_architectural_cons(self, pattern_id: str) -> List[str]:
+    def _get_architectural_cons(self, pattern_id: str) -> list[str]:
         """Get cons for architectural pattern."""
         cons_map = {
             "monolithic": ["Hard to scale", "Tight coupling", "Single point of failure"],
@@ -342,7 +342,7 @@ class TradeOffElicitationEngine:
         }
         return cons_map.get(pattern_id, [])
 
-    def _get_functional_pros(self, approach_id: str) -> List[str]:
+    def _get_functional_pros(self, approach_id: str) -> list[str]:
         """Get pros for functional approach."""
         pros_map = {
             "simple": ["Easy to understand", "Quick to implement", "Low maintenance"],
@@ -352,7 +352,7 @@ class TradeOffElicitationEngine:
         }
         return pros_map.get(approach_id, [])
 
-    def _get_functional_cons(self, approach_id: str) -> List[str]:
+    def _get_functional_cons(self, approach_id: str) -> list[str]:
         """Get cons for functional approach."""
         cons_map = {
             "simple": ["Limited features", "May need refactoring", "Not optimized"],
@@ -362,7 +362,7 @@ class TradeOffElicitationEngine:
         }
         return cons_map.get(approach_id, [])
 
-    def _get_implementation_pros(self, strategy_id: str) -> List[str]:
+    def _get_implementation_pros(self, strategy_id: str) -> list[str]:
         """Get pros for implementation strategy."""
         pros_map = {
             "iterative": ["Incremental delivery", "Early feedback", "Flexible"],
@@ -372,7 +372,7 @@ class TradeOffElicitationEngine:
         }
         return pros_map.get(strategy_id, [])
 
-    def _get_implementation_cons(self, strategy_id: str) -> List[str]:
+    def _get_implementation_cons(self, strategy_id: str) -> list[str]:
         """Get cons for implementation strategy."""
         cons_map = {
             "iterative": ["Requires discipline", "Integration challenges", "Scope creep risk"],

--- a/phionyx_core/social/__init__.py
+++ b/phionyx_core/social/__init__.py
@@ -8,7 +8,7 @@ Components:
 - TrustPropagation: Transitive trust computation
 """
 
-from .trust_propagation import TrustNetwork, TrustEdge, TrustAssessment
+from .trust_propagation import TrustAssessment, TrustEdge, TrustNetwork
 
 __all__ = [
     "TrustNetwork",

--- a/phionyx_core/social/trust_propagation.py
+++ b/phionyx_core/social/trust_propagation.py
@@ -21,8 +21,8 @@ Integrates with:
 """
 
 import logging
-from typing import Dict, List, Optional, Set, Tuple, Any
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -48,9 +48,9 @@ class TrustAssessment:
     """Result of trust query."""
     source: str
     target: str
-    direct_trust: Optional[float]   # Direct edge (None if no direct)
+    direct_trust: float | None   # Direct edge (None if no direct)
     transitive_trust: float          # Best trust via any path
-    trust_path: List[str]            # Path that produced best trust
+    trust_path: list[str]            # Path that produced best trust
     is_trusted: bool                 # Above threshold?
     reasoning: str
 
@@ -82,8 +82,8 @@ class TrustNetwork:
         self.decay_factor = max(0.0, min(1.0, decay_factor))
         self.trust_threshold = trust_threshold
         self.max_path_length = max_path_length
-        self._edges: Dict[str, Dict[str, TrustEdge]] = {}  # source → {target → edge}
-        self._entities: Set[str] = set()
+        self._edges: dict[str, dict[str, TrustEdge]] = {}  # source → {target → edge}
+        self._entities: set[str] = set()
 
     def add_trust(
         self,
@@ -117,7 +117,7 @@ class TrustNetwork:
         self._edges[source][target] = edge
         return edge
 
-    def get_direct_trust(self, source: str, target: str) -> Optional[float]:
+    def get_direct_trust(self, source: str, target: str) -> float | None:
         """Get direct trust from source to target (None if no direct edge)."""
         if source == target:
             return 1.0
@@ -167,7 +167,7 @@ class TrustNetwork:
             reasoning=reasoning,
         )
 
-    def get_trusted_entities(self, source: str) -> List[Tuple[str, float]]:
+    def get_trusted_entities(self, source: str) -> list[tuple[str, float]]:
         """Get all entities trusted by source (above threshold)."""
         results = []
         for entity in self._entities:
@@ -179,7 +179,7 @@ class TrustNetwork:
         results.sort(key=lambda x: x[1], reverse=True)
         return results
 
-    def get_trust_graph(self) -> Dict[str, Any]:
+    def get_trust_graph(self) -> dict[str, Any]:
         """Serialize trust network."""
         return {
             "entities": sorted(self._entities),
@@ -199,12 +199,12 @@ class TrustNetwork:
 
     def _find_best_trust_path(
         self, source: str, target: str,
-    ) -> Tuple[float, List[str]]:
+    ) -> tuple[float, list[str]]:
         """Find path with highest trust from source to target."""
         best_trust = 0.0
-        best_path: List[str] = []
+        best_path: list[str] = []
 
-        def _dfs(current: str, path: List[str], trust_so_far: float, depth: int):
+        def _dfs(current: str, path: list[str], trust_so_far: float, depth: int):
             nonlocal best_trust, best_path
             if depth > self.max_path_length:
                 return
@@ -229,9 +229,9 @@ class TrustNetwork:
         self,
         source: str,
         target: str,
-        direct: Optional[float],
+        direct: float | None,
         transitive: float,
-        path: List[str],
+        path: list[str],
         is_trusted: bool,
     ) -> str:
         if direct is not None and direct >= transitive:

--- a/phionyx_core/state/__init__.py
+++ b/phionyx_core/state/__init__.py
@@ -11,51 +11,49 @@ Exports:
 - StateSnapshot: Serialize/deserialize utilities
 """
 
-from phionyx_core.state.echo_state_2 import EchoState2, EchoState2Plus
 from phionyx_core.state.aux_state import AuxState
-# StateMigration is not a class, it's a module with functions
-# from phionyx_core.state.state_migration import unified_to_echo_state2, echo_state2_to_unified
-from phionyx_core.state.state_snapshot import StateSnapshot
-from phionyx_core.state.state_adapter import EchoState2Adapter
-from phionyx_core.state.time_manager import TimeManager
-from phionyx_core.state.physics_integration import (
-    get_time_delta_from_state,
-    calculate_phi_v2_with_state,
-    update_physics_params_with_state
-)
 from phionyx_core.state.echo_event import EchoEvent, EventReference
 from phionyx_core.state.echo_ontology import EchoOntology
-from phionyx_core.state.measurement_mapper import MeasurementMapper, MeasurementVector
-from phionyx_core.state.measurement_mapper_v2 import MeasurementPacket, EvidenceSpan
-from phionyx_core.state.ethics import EthicsVector, EthicsRiskAssessor
+from phionyx_core.state.echo_state_2 import EchoState2, EchoState2Plus
+from phionyx_core.state.ethics import EthicsRiskAssessor, EthicsVector
 from phionyx_core.state.ethics_enforcement import (
     EthicsEnforcementConfig,
     EthicsPolicyConfig,
+    apply_ethics_after_response,
     apply_ethics_enforcement,
     apply_forced_damping,
+    check_ethics_before_response,
     generate_safety_message,
     generate_safety_message_policy,
-    check_ethics_before_response,
-    apply_ethics_after_response
 )
-from phionyx_core.state.ukf_measurement_integration import UKFMeasurementIntegration
-from phionyx_core.state.ukf_process_model import (
-    echoism_process_model,
-    create_echoism_process_model
+from phionyx_core.state.measurement_mapper import MeasurementMapper, MeasurementVector
+from phionyx_core.state.measurement_mapper_v2 import EvidenceSpan, MeasurementPacket
+from phionyx_core.state.physics_integration import (
+    calculate_phi_v2_with_state,
+    get_time_delta_from_state,
+    update_physics_params_with_state,
 )
 from phionyx_core.state.resonance import (
     calculate_resonance_score,
-    update_resonance_from_events,
     get_resonance_growth_rate,
+    update_resonance_from_events,
 )
+from phionyx_core.state.state_adapter import EchoState2Adapter
+
+# StateMigration is not a class, it's a module with functions
+# from phionyx_core.state.state_migration import unified_to_echo_state2, echo_state2_to_unified
+from phionyx_core.state.state_snapshot import StateSnapshot
+from phionyx_core.state.time_manager import TimeManager
 from phionyx_core.state.ukf_adaptive_noise import (
     calculate_dynamic_measurement_noise,
-    create_dynamic_measurement_noise_matrix,
-    calculate_emotional_volatility,
     calculate_dynamic_process_noise,
+    calculate_emotional_volatility,
+    create_dynamic_measurement_noise_matrix,
     create_dynamic_process_noise_matrix,
     get_sensor_quality_from_provider,
 )
+from phionyx_core.state.ukf_measurement_integration import UKFMeasurementIntegration
+from phionyx_core.state.ukf_process_model import create_echoism_process_model, echoism_process_model
 
 __all__ = [
     "EchoState2",

--- a/phionyx_core/state/aux_state.py
+++ b/phionyx_core/state/aux_state.py
@@ -12,9 +12,10 @@ Per Echoism Core v1.0:
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
-from typing import Dict, Any, Optional
 from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AuxState(BaseModel):
@@ -92,7 +93,7 @@ class AuxState(BaseModel):
         description="Last update timestamp"
     )
 
-    metadata: Dict[str, Any] = Field(
+    metadata: dict[str, Any] = Field(
         default_factory=dict,
         description="Additional metadata"
     )
@@ -101,7 +102,7 @@ class AuxState(BaseModel):
     # Helper Methods
     # ============================================================
 
-    def update_trust(self, new_trust: float, previous_trust: Optional[float] = None) -> None:
+    def update_trust(self, new_trust: float, previous_trust: float | None = None) -> None:
         """
         Update trust score and compute trend.
 
@@ -116,7 +117,7 @@ class AuxState(BaseModel):
         self.trust_trend = self.trust_score - previous_trust
         self.last_update = datetime.now()
 
-    def update_regulation(self, new_regulation: float, previous_regulation: Optional[float] = None) -> None:
+    def update_regulation(self, new_regulation: float, previous_regulation: float | None = None) -> None:
         """
         Update regulation score and compute trend.
 
@@ -142,7 +143,7 @@ class AuxState(BaseModel):
         self.high_risk_flag = self.risk_score > 0.7
         self.last_update = datetime.now()
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert to dictionary (for serialization).
 
@@ -161,7 +162,7 @@ class AuxState(BaseModel):
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> AuxState:
+    def from_dict(cls, data: dict[str, Any]) -> AuxState:
         """
         Create from dictionary (for deserialization).
 

--- a/phionyx_core/state/echo_event.py
+++ b/phionyx_core/state/echo_event.py
@@ -15,11 +15,12 @@ This module defines:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Any, List
-from datetime import datetime
-from pydantic import BaseModel, Field
 import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class EchoEvent(BaseModel):
@@ -60,17 +61,17 @@ class EchoEvent(BaseModel):
         description="Event intensity (0.0-1.0)"
     )
 
-    tags: List[str] = Field(
+    tags: list[str] = Field(
         default_factory=list,
         description="Semantic tags for categorization"
     )
 
-    payload: Dict[str, Any] = Field(
+    payload: dict[str, Any] = Field(
         default_factory=dict,
         description="Additional event data"
     )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "id": self.id,
@@ -82,7 +83,7 @@ class EchoEvent(BaseModel):
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> EchoEvent:
+    def from_dict(cls, data: dict[str, Any]) -> EchoEvent:
         """Create from dictionary."""
         timestamp = datetime.fromisoformat(data.get("timestamp", datetime.now().isoformat()))
         return cls(
@@ -109,7 +110,7 @@ class EventReference:
     tag: str
     intensity: float
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "id": self.id,
@@ -118,7 +119,7 @@ class EventReference:
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> EventReference:
+    def from_dict(cls, data: dict[str, Any]) -> EventReference:
         """Create from dictionary."""
         return cls(
             id=data["id"],

--- a/phionyx_core/state/echo_ontology.py
+++ b/phionyx_core/state/echo_ontology.py
@@ -15,15 +15,15 @@ This module orchestrates the full chain.
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional, List
 from datetime import datetime
+from typing import Any
 
 from phionyx_core.state.echo_event import EchoEvent
 from phionyx_core.state.echo_state_2 import EchoState2
 
 # Import trace functions if available
 try:
-    from phionyx_core.memory.trace import trace_weight, aggregate_trace
+    from phionyx_core.memory.trace import aggregate_trace, trace_weight
     TRACE_AVAILABLE = True
 except ImportError:
     TRACE_AVAILABLE = False
@@ -52,14 +52,14 @@ class EchoOntology:
         """
         self.state = echo_state2
         self.half_life_seconds = half_life_seconds
-        self.event_history: List[EchoEvent] = []
+        self.event_history: list[EchoEvent] = []
 
     def effect_to_event(
         self,
         effect_type: str,
         intensity: float,
-        tags: List[str],
-        payload: Optional[Dict[str, Any]] = None
+        tags: list[str],
+        payload: dict[str, Any] | None = None
     ) -> EchoEvent:
         """
         Convert effect to event (Step 1: Effect → Event).
@@ -98,9 +98,9 @@ class EchoOntology:
     def event_to_trace(
         self,
         event: EchoEvent,
-        now: Optional[datetime] = None,
-        dt: Optional[float] = None,
-        confidence: Optional[float] = None
+        now: datetime | None = None,
+        dt: float | None = None,
+        confidence: float | None = None
     ) -> float:
         """
         Calculate trace weight from event (Step 2: Event → Trace).
@@ -149,9 +149,9 @@ class EchoOntology:
 
     def trace_to_echo(
         self,
-        events: List[EchoEvent],
-        now: Optional[datetime] = None
-    ) -> Dict[str, Any]:
+        events: list[EchoEvent],
+        now: datetime | None = None
+    ) -> dict[str, Any]:
         """
         Generate echo from trace (Step 3: Trace → Echo).
 
@@ -194,9 +194,9 @@ class EchoOntology:
 
     def echo_to_transformation(
         self,
-        echo: Dict[str, Any],
-        state_update: Optional[Dict[str, float]] = None
-    ) -> Dict[str, float]:
+        echo: dict[str, Any],
+        state_update: dict[str, float] | None = None
+    ) -> dict[str, float]:
         """
         Apply transformation to state (Step 4: Echo → Transformation).
 
@@ -239,10 +239,10 @@ class EchoOntology:
         self,
         effect_type: str,
         intensity: float,
-        tags: List[str],
-        payload: Optional[Dict[str, Any]] = None,
-        state_update: Optional[Dict[str, float]] = None
-    ) -> Dict[str, Any]:
+        tags: list[str],
+        payload: dict[str, Any] | None = None,
+        state_update: dict[str, float] | None = None
+    ) -> dict[str, Any]:
         """
         Process full chain: Effect → Event → Trace → Echo → Transformation.
 

--- a/phionyx_core/state/echo_state_2.py
+++ b/phionyx_core/state/echo_state_2.py
@@ -17,12 +17,13 @@ Key Principles:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import List, Dict, Any, Optional
-from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field
 import math
 import time as time_module  # For monotonic clock
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 # ============================================================
 # Configurable Constants (Patent-Referenced Parameters)
@@ -125,7 +126,7 @@ class EchoState2(BaseModel):
         description="Time since relationship start (seconds)"
     )
 
-    E_tags: List[EventReference] = Field(
+    E_tags: list[EventReference] = Field(
         default_factory=list,
         description="Event references (last N events: id + tag + intensity)"
     )
@@ -253,7 +254,7 @@ class EchoState2(BaseModel):
 
     def update_time(
         self,
-        current_time: Optional[datetime] = None,
+        current_time: datetime | None = None,
         increment_turn: bool = True
     ) -> float:
         """
@@ -342,7 +343,7 @@ class EchoState2(BaseModel):
 
         return self.dt
 
-    def from_physics_state(self, physics_state: Dict[str, Any]) -> None:
+    def from_physics_state(self, physics_state: dict[str, Any]) -> None:
         """
         Update EchoState2 from physics state dictionary.
 
@@ -395,8 +396,8 @@ class EchoState2(BaseModel):
         event_type: str,
         intensity: float,
         semantic_context: str,
-        metadata: Optional[Dict[str, Any]] = None,
-        timestamp: Optional[datetime] = None
+        metadata: dict[str, Any] | None = None,
+        timestamp: datetime | None = None
     ) -> None:
         """
         Add event tag (immutable append-only).
@@ -434,10 +435,10 @@ class EchoState2(BaseModel):
 
     def update_state(
         self,
-        A_new: Optional[float] = None,
-        V_new: Optional[float] = None,
-        H_new: Optional[float] = None,
-        current_time: Optional[datetime] = None,
+        A_new: float | None = None,
+        V_new: float | None = None,
+        H_new: float | None = None,
+        current_time: datetime | None = None,
         increment_turn: bool = True
     ) -> float:
         """
@@ -484,7 +485,7 @@ class EchoState2(BaseModel):
 
         return dt
 
-    def get_recent_events(self, time_window: float = 300.0) -> List[EventReference]:
+    def get_recent_events(self, time_window: float = 300.0) -> list[EventReference]:
         """
         Get recent events within time window.
 
@@ -501,7 +502,7 @@ class EchoState2(BaseModel):
         # (In practice, E_tags should be limited to recent N events)
         return self.E_tags[-10:] if len(self.E_tags) > 10 else self.E_tags
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert to dictionary (for serialization).
 
@@ -536,7 +537,7 @@ class EchoState2(BaseModel):
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> EchoState2:
+    def from_dict(cls, data: dict[str, Any]) -> EchoState2:
         """
         Create from dictionary (for deserialization).
 
@@ -631,7 +632,7 @@ class EchoState2Plus(EchoState2):
         description="Coherence (0.0-1.0): Measurement-state consistency (diagnostic). Low C → entropy boost signal"
     )
 
-    D: Optional[float] = Field(
+    D: float | None = Field(
         default=None,
         ge=0.0,
         le=1.0,
@@ -643,25 +644,25 @@ class EchoState2Plus(EchoState2):
     # ============================================================
 
     # Assumptions tracking (Karpathy Problem 1)
-    assumptions: List[Dict[str, Any]] = Field(
+    assumptions: list[dict[str, Any]] = Field(
         default_factory=list,
         description="List of assumptions extracted during code generation. Each assumption has: type, description, code_reference, confidence, evidence"
     )
 
     # Inconsistencies tracking (Karpathy Problem 2)
-    inconsistencies: List[Dict[str, Any]] = Field(
+    inconsistencies: list[dict[str, Any]] = Field(
         default_factory=list,
         description="List of inconsistencies detected between code, plan, tests, and requirements. Each inconsistency has: type, description, severity, code_reference, resolution_suggestion, evidence"
     )
 
     # Complexity metrics tracking (Karpathy Problem 7)
-    complexity_metrics: Optional[Dict[str, Any]] = Field(
+    complexity_metrics: dict[str, Any] | None = Field(
         default=None,
         description="Complexity metrics: cyclomatic, cognitive, nesting_depth, function_length, class_complexity"
     )
 
     # Complexity budget configuration
-    complexity_budget: Optional[Dict[str, Any]] = Field(
+    complexity_budget: dict[str, Any] | None = Field(
         default=None,
         description="Complexity budget limits: max_cyclomatic, max_cognitive, max_nesting, max_function_length, max_class_complexity"
     )
@@ -778,9 +779,9 @@ class EchoState2Plus(EchoState2):
 
     def update_coherence(
         self,
-        measurement: Dict[str, float],
-        state: Optional[Dict[str, float]] = None,
-        confidence: Optional[float] = None
+        measurement: dict[str, float],
+        state: dict[str, float] | None = None,
+        confidence: float | None = None
     ) -> None:
         """
         Update Coherence (C) from measurement-state consistency.
@@ -801,7 +802,7 @@ class EchoState2Plus(EchoState2):
         try:
             from phionyx_core.physics.coherence import (
                 calculate_coherence,
-                calculate_coherence_with_confidence
+                calculate_coherence_with_confidence,
             )
 
             if confidence is not None:
@@ -867,7 +868,9 @@ class EchoState2Plus(EchoState2):
             Adjusted process noise Q
         """
         try:
-            from phionyx_core.physics.inertia import apply_inertia_to_ukf_process_noise as apply_inertia
+            from phionyx_core.physics.inertia import (
+                apply_inertia_to_ukf_process_noise as apply_inertia,
+            )
             return apply_inertia(base_Q, self.I)
         except ImportError:
             # Fallback
@@ -889,14 +892,16 @@ class EchoState2Plus(EchoState2):
             Adjusted gain
         """
         try:
-            from phionyx_core.physics.inertia import apply_inertia_to_derivative_gain as apply_inertia
+            from phionyx_core.physics.inertia import (
+                apply_inertia_to_derivative_gain as apply_inertia,
+            )
             return apply_inertia(base_gain, self.I)
         except ImportError:
             # Fallback
             adjusted = base_gain * (1.0 - self.I)
             return max(0.1, min(1.0, adjusted))
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert to dictionary (includes v1.1 fields and Karpathy extensions).
 
@@ -920,9 +925,9 @@ class EchoState2Plus(EchoState2):
         self,
         assumption_type: str,
         description: str,
-        code_reference: Optional[str] = None,
+        code_reference: str | None = None,
         confidence: float = 1.0,
-        evidence: Optional[List[str]] = None
+        evidence: list[str] | None = None
     ) -> None:
         """
         Add an assumption to state.
@@ -947,9 +952,9 @@ class EchoState2Plus(EchoState2):
         inconsistency_type: str,
         description: str,
         severity: str,
-        code_reference: Optional[str] = None,
-        resolution_suggestion: Optional[str] = None,
-        evidence: Optional[List[str]] = None
+        code_reference: str | None = None,
+        resolution_suggestion: str | None = None,
+        evidence: list[str] | None = None
     ) -> None:
         """
         Add an inconsistency to state.
@@ -1030,7 +1035,7 @@ class EchoState2Plus(EchoState2):
         I_default: float = 0.6,
         R_default: float = 0.05,
         C_default: float = 0.5,
-        D_default: Optional[float] = None
+        D_default: float | None = None
     ) -> EchoState2Plus:
         """
         Create EchoState2Plus from EchoState2 (backward compatibility).
@@ -1076,7 +1081,7 @@ class EchoState2Plus(EchoState2):
         )
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> EchoState2Plus:
+    def from_dict(cls, data: dict[str, Any]) -> EchoState2Plus:
         """
         Create from dictionary (includes v1.1 fields).
 

--- a/phionyx_core/state/ethics.py
+++ b/phionyx_core/state/ethics.py
@@ -11,7 +11,6 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Dict, Optional
 from dataclasses import dataclass
 
 
@@ -32,7 +31,7 @@ class EthicsVector:
     boundary_violation_risk: float = 0.0
     child_on_child_risk: float = 0.0  # KCSIE Part 5: Child-on-Child Sexual Violence and Sexual Harassment
 
-    def to_dict(self) -> Dict[str, float]:
+    def to_dict(self) -> dict[str, float]:
         """Convert to dictionary."""
         return {
             "harm_risk": self.harm_risk,
@@ -391,8 +390,8 @@ class EthicsRiskAssessor:
         self,
         text: str,
         resonance_score: float = 0.0,
-        measurement_vector: Optional[Dict[str, float]] = None,
-        state: Optional[Dict[str, float]] = None,
+        measurement_vector: dict[str, float] | None = None,
+        state: dict[str, float] | None = None,
         is_group_scenario: bool = False  # KCSIE Part 5: Child-on-Child detection
     ) -> EthicsVector:
         """

--- a/phionyx_core/state/ethics_enforcement.py
+++ b/phionyx_core/state/ethics_enforcement.py
@@ -12,8 +12,8 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional, Tuple, Literal
 from dataclasses import dataclass
+from typing import Any, Literal
 
 # Import wrapper for backward compatibility
 try:
@@ -44,8 +44,8 @@ except (ImportError, ValueError):
         from phionyx_core.state.ethics import EthicsVector
     except ImportError:
         # Fallback: direct import (for standalone execution)
-        import sys
         import os
+        import sys
         parent_dir = os.path.dirname(os.path.abspath(__file__))
         if parent_dir not in sys.path:
             sys.path.insert(0, parent_dir)
@@ -64,10 +64,10 @@ class EthicsPolicyConfig:
     entropy_boost: float = 0.95
     message_style: Literal["pedagogical", "game_context", "professional", "quality_gate"] = "pedagogical"
     damping_curve: Literal["linear", "exponential", "sigmoid"] = "linear"
-    attachment_risk_threshold: Optional[float] = None
-    manipulation_risk_threshold: Optional[float] = None
-    harm_risk_threshold: Optional[float] = None
-    boundary_violation_risk_threshold: Optional[float] = None
+    attachment_risk_threshold: float | None = None
+    manipulation_risk_threshold: float | None = None
+    harm_risk_threshold: float | None = None
+    boundary_violation_risk_threshold: float | None = None
 
     def get_risk_threshold_for_type(self, risk_type: str) -> float:
         """Get threshold for specific risk type."""
@@ -100,8 +100,8 @@ def apply_ethics_enforcement(
     ethics_vector: EthicsVector,
     current_entropy: float,
     base_amplitude: float,
-    config: Optional[EthicsEnforcementConfig] = None
-) -> Dict[str, Any]:
+    config: EthicsEnforcementConfig | None = None
+) -> dict[str, Any]:
     """
     Apply ethics enforcement if any risk exceeds threshold.
 
@@ -213,8 +213,8 @@ def check_ethics_before_response(
     ethics_vector: EthicsVector,
     current_entropy: float,
     base_amplitude: float,
-    config: Optional[EthicsEnforcementConfig] = None
-) -> Tuple[bool, Dict[str, Any]]:
+    config: EthicsEnforcementConfig | None = None
+) -> tuple[bool, dict[str, Any]]:
     """
     Check ethics before response generation (pre-gate).
 
@@ -246,8 +246,8 @@ def apply_ethics_after_response(
     response_text: str,
     current_entropy: float,
     base_amplitude: float,
-    config: Optional[EthicsEnforcementConfig] = None
-) -> Dict[str, Any]:
+    config: EthicsEnforcementConfig | None = None
+) -> dict[str, Any]:
     """
     Apply ethics enforcement after response generation (post-gate).
 
@@ -289,10 +289,10 @@ def apply_ethics_after_response(
 
 
 def apply_forced_damping(
-    state: Dict[str, Any],
+    state: dict[str, Any],
     ethics_vector: EthicsVector,
     policy: EthicsPolicyConfig
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Apply forced damping based on policy configuration.
 

--- a/phionyx_core/state/ethics_enforcement_wrapper.py
+++ b/phionyx_core/state/ethics_enforcement_wrapper.py
@@ -5,12 +5,10 @@ Ethics Enforcement Wrapper
 Wrapper class for backward compatibility with tests.
 """
 
-from typing import Dict, Any, Optional
-from .ethics_enforcement import (
-    apply_ethics_enforcement,
-    EthicsEnforcementConfig
-)
+from typing import Any
+
 from .ethics import EthicsVector
+from .ethics_enforcement import EthicsEnforcementConfig, apply_ethics_enforcement
 
 
 class EthicsEnforcement:
@@ -20,7 +18,7 @@ class EthicsEnforcement:
     Wraps apply_ethics_enforcement function for class-based API.
     """
 
-    def __init__(self, config: Optional[EthicsEnforcementConfig] = None):
+    def __init__(self, config: EthicsEnforcementConfig | None = None):
         """Initialize ethics enforcement."""
         self.config = config or EthicsEnforcementConfig()
 
@@ -29,7 +27,7 @@ class EthicsEnforcement:
         ethics_vector: EthicsVector,
         current_entropy: float,
         base_amplitude: float
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Check risk and apply enforcement if needed.
 

--- a/phionyx_core/state/measurement_mapper.py
+++ b/phionyx_core/state/measurement_mapper.py
@@ -13,11 +13,12 @@ This module maps LLM text output to measurement vector.
 from __future__ import annotations
 
 import logging
-from typing import Dict, Any, Optional, List, TYPE_CHECKING
-from datetime import datetime
-from pydantic import BaseModel, Field
-import re
 import math
+import re
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from phionyx_core.state.measurement_packet import MeasurementPacket
@@ -64,7 +65,7 @@ class MeasurementVector(BaseModel):
         description="Measurement confidence (0.0-1.0)"
     )
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "A_meas": self.A_meas,
@@ -74,7 +75,7 @@ class MeasurementVector(BaseModel):
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> MeasurementVector:
+    def from_dict(cls, data: dict[str, Any]) -> MeasurementVector:
         """Create from dictionary."""
         return cls(
             A_meas=data.get("A_meas", 0.5),
@@ -123,8 +124,8 @@ class MeasurementMapper:
     def map_text_to_measurement(
         self,
         raw_llm_output: str,
-        provider_metadata: Optional[Dict[str, Any]] = None,
-        llm_output: Optional[Dict[str, Any]] = None  # Deprecated: use raw_llm_output
+        provider_metadata: dict[str, Any] | None = None,
+        llm_output: dict[str, Any] | None = None  # Deprecated: use raw_llm_output
     ) -> MeasurementVector:
         """
         Map LLM text output to measurement vector.
@@ -179,7 +180,7 @@ class MeasurementMapper:
     def _adjust_confidence_by_provider(
         self,
         base_confidence: float,
-        provider_metadata: Dict[str, Any]
+        provider_metadata: dict[str, Any]
     ) -> float:
         """
         Adjust confidence based on provider metadata.
@@ -232,8 +233,8 @@ class MeasurementMapper:
 
     def _parse_structured_output(
         self,
-        llm_output: Dict[str, Any]
-    ) -> Optional[MeasurementVector]:
+        llm_output: dict[str, Any]
+    ) -> MeasurementVector | None:
         """
         Parse structured output from LLM (if available).
 
@@ -270,8 +271,8 @@ class MeasurementMapper:
 
     def _extract_float(
         self,
-        data: Dict[str, Any],
-        keys: List[str],
+        data: dict[str, Any],
+        keys: list[str],
         default: float
     ) -> float:
         """Extract float value from dict using multiple possible keys."""
@@ -404,7 +405,7 @@ class MeasurementMapper:
         confidence: float,
         base_noise: float = 0.05,
         state_dim: int = 6
-    ) -> List[List[float]]:
+    ) -> list[list[float]]:
         """
         Create measurement noise covariance matrix R.
 
@@ -428,7 +429,7 @@ class MeasurementMapper:
     def map_text_to_measurement_packet(
         self,
         raw_llm_output: str,
-        provider_metadata: Optional[Dict[str, Any]] = None,
+        provider_metadata: dict[str, Any] | None = None,
         enable_dominance: bool = False
     ) -> MeasurementPacket:
         """
@@ -448,11 +449,12 @@ class MeasurementMapper:
         """
         # Import MeasurementPacket (avoid circular import)
         try:
-            from phionyx_core.state.measurement_packet import MeasurementPacket, EvidenceSpan
+            from phionyx_core.state.measurement_packet import EvidenceSpan, MeasurementPacket
         except ImportError:
             # Fallback: create minimal MeasurementPacket-like object
-            from pydantic import BaseModel
             from datetime import datetime
+
+            from pydantic import BaseModel
 
             class EvidenceSpan(BaseModel):
                 text: str
@@ -463,14 +465,14 @@ class MeasurementMapper:
             class MeasurementPacket(BaseModel):
                 A: float
                 V: float
-                D: Optional[float] = None
+                D: float | None = None
                 H: float
                 confidence: float
-                provider: Dict[str, Any]
+                provider: dict[str, Any]
                 timestamp: datetime
-                evidence_spans: List[EvidenceSpan] = []
+                evidence_spans: list[EvidenceSpan] = []
 
-                def to_dict(self) -> Dict[str, Any]:
+                def to_dict(self) -> dict[str, Any]:
                     """Convert to dictionary."""
                     return {
                         "A": self.A,

--- a/phionyx_core/state/measurement_mapper_v2.py
+++ b/phionyx_core/state/measurement_mapper_v2.py
@@ -9,10 +9,10 @@ Per Echoism Core v1.1 / Faz 2.1:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional, List
 from datetime import datetime, timezone
-from pydantic import BaseModel, Field
+from typing import Any
 
+from pydantic import BaseModel, Field
 
 
 class EvidenceSpan(BaseModel):
@@ -35,14 +35,14 @@ class MeasurementPacket(BaseModel):
     """
     A: float = Field(ge=-1.0, le=1.0, description="Arousal measurement")
     V: float = Field(ge=-1.0, le=1.0, description="Valence measurement")
-    D: Optional[float] = Field(default=None, ge=-1.0, le=1.0, description="Dominance measurement (optional)")
+    D: float | None = Field(default=None, ge=-1.0, le=1.0, description="Dominance measurement (optional)")
     H: float = Field(ge=0.0, le=1.0, description="Entropy measurement")
     confidence: float = Field(ge=0.0, le=1.0, description="Measurement confidence")
-    provider: Dict[str, Any] = Field(default_factory=dict, description="Provider metadata")
+    provider: dict[str, Any] = Field(default_factory=dict, description="Provider metadata")
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Measurement timestamp")
-    evidence_spans: List[EvidenceSpan] = Field(default_factory=list, description="Evidence spans")
+    evidence_spans: list[EvidenceSpan] = Field(default_factory=list, description="Evidence spans")
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         return {
             "A": self.A,
@@ -56,7 +56,7 @@ class MeasurementPacket(BaseModel):
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> MeasurementPacket:
+    def from_dict(cls, data: dict[str, Any]) -> MeasurementPacket:
         """Create from dictionary."""
         evidence_spans = [
             EvidenceSpan(**span) if isinstance(span, dict) else span

--- a/phionyx_core/state/physics_integration.py
+++ b/phionyx_core/state/physics_integration.py
@@ -9,14 +9,15 @@ Ensures all physics formulas use state.dt as SINGLE SOURCE OF TRUTH.
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
+from typing import Any
+
 from phionyx_core.state.echo_state_2 import EchoState2
 from phionyx_core.state.time_manager import TimeManager
 
 
 def get_time_delta_from_state(
-    echo_state2: Optional[EchoState2] = None,
-    time_manager: Optional[TimeManager] = None,
+    echo_state2: EchoState2 | None = None,
+    time_manager: TimeManager | None = None,
     fallback_dt: float = 1.0
 ) -> float:
     """
@@ -47,7 +48,7 @@ def calculate_phi_v2_with_state(
     stability: float,
     context_mode: str = "DEFAULT",
     gamma: float = 0.15
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Calculate Phi v2 using state.dt as SINGLE SOURCE OF TRUTH.
 
@@ -77,10 +78,10 @@ def calculate_phi_v2_with_state(
 
 
 def update_physics_params_with_state(
-    physics_params: Dict[str, Any],
-    echo_state2: Optional[EchoState2] = None,
-    time_manager: Optional[TimeManager] = None
-) -> Dict[str, Any]:
+    physics_params: dict[str, Any],
+    echo_state2: EchoState2 | None = None,
+    time_manager: TimeManager | None = None
+) -> dict[str, Any]:
     """
     Update physics_params with state.dt (SINGLE SOURCE OF TRUTH).
 

--- a/phionyx_core/state/state_adapter.py
+++ b/phionyx_core/state/state_adapter.py
@@ -10,10 +10,10 @@ UnifiedEchoState format when needed.
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
+from typing import Any
 
-from phionyx_core.state.echo_state_2 import EchoState2
 from phionyx_core.state.aux_state import AuxState
+from phionyx_core.state.echo_state_2 import EchoState2
 
 
 class EchoState2Adapter:
@@ -29,7 +29,7 @@ class EchoState2Adapter:
     def __init__(
         self,
         echo_state2: EchoState2,
-        aux_state: Optional[AuxState] = None
+        aux_state: AuxState | None = None
     ):
         """
         Initialize adapter.
@@ -94,7 +94,7 @@ class EchoState2Adapter:
     # Dictionary Format (Backward Compatibility)
     # ============================================================
 
-    def to_physics_state(self) -> Dict[str, Any]:
+    def to_physics_state(self) -> dict[str, Any]:
         """
         Convert to physics_state dict format (backward compatibility).
 
@@ -118,7 +118,7 @@ class EchoState2Adapter:
             "t_global": self.echo_state2.t_global
         }
 
-    def to_unified_echo_state_dict(self) -> Dict[str, Any]:
+    def to_unified_echo_state_dict(self) -> dict[str, Any]:
         """
         Convert to UnifiedEchoState dict format (backward compatibility).
 
@@ -171,7 +171,7 @@ class EchoState2Adapter:
     # Update Methods
     # ============================================================
 
-    def update_from_physics_state(self, physics_state: Dict[str, Any]) -> None:
+    def update_from_physics_state(self, physics_state: dict[str, Any]) -> None:
         """
         Update EchoState2 from physics_state dict (backward compatibility).
 

--- a/phionyx_core/state/state_migration.py
+++ b/phionyx_core/state/state_migration.py
@@ -14,12 +14,12 @@ Migration utilities for converting between:
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
 from datetime import datetime
+
+from phionyx_core.state.aux_state import AuxState
 
 # Import new state models
 from phionyx_core.state.echo_state_2 import EchoState2
-from phionyx_core.state.aux_state import AuxState
 
 # Import old state model (optional, for backward compatibility)
 OLD_STATE_AVAILABLE = False
@@ -34,8 +34,8 @@ except (ImportError, ModuleNotFoundError):
 
 def unified_to_echo_state2(
     old_state: UnifiedEchoState,
-    relationship_start: Optional[datetime] = None
-) -> Tuple[EchoState2, AuxState]:
+    relationship_start: datetime | None = None
+) -> tuple[EchoState2, AuxState]:
     """
     Convert UnifiedEchoState (LEGACY) to EchoState2 + AuxState (CANONICAL).
 
@@ -115,7 +115,7 @@ def unified_to_echo_state2(
 
 def echo_state2_to_unified(
     echo_state2: EchoState2,
-    aux_state: Optional[AuxState] = None
+    aux_state: AuxState | None = None
 ) -> UnifiedEchoState:
     """
     Convert EchoState2 + AuxState (CANONICAL) to UnifiedEchoState (LEGACY).

--- a/phionyx_core/state/state_snapshot.py
+++ b/phionyx_core/state/state_snapshot.py
@@ -8,12 +8,12 @@ Serialization and deserialization utilities for EchoState2 and AuxState.
 from __future__ import annotations
 
 import json
-from typing import Dict, Any, Optional
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
-from phionyx_core.state.echo_state_2 import EchoState2
 from phionyx_core.state.aux_state import AuxState
+from phionyx_core.state.echo_state_2 import EchoState2
 
 
 class StateSnapshot:
@@ -31,9 +31,9 @@ class StateSnapshot:
     @staticmethod
     def serialize(
         echo_state2: EchoState2,
-        aux_state: Optional[AuxState] = None,
+        aux_state: AuxState | None = None,
         include_derived: bool = True
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Serialize EchoState2 (+ AuxState) to dictionary.
 
@@ -66,7 +66,7 @@ class StateSnapshot:
         return snapshot
 
     @staticmethod
-    def deserialize(data: Dict[str, Any]) -> tuple[EchoState2, Optional[AuxState]]:
+    def deserialize(data: dict[str, Any]) -> tuple[EchoState2, AuxState | None]:
         """
         Deserialize dictionary to EchoState2 (+ AuxState).
 
@@ -94,9 +94,9 @@ class StateSnapshot:
     @staticmethod
     def to_json(
         echo_state2: EchoState2,
-        aux_state: Optional[AuxState] = None,
+        aux_state: AuxState | None = None,
         include_derived: bool = True,
-        indent: Optional[int] = 2
+        indent: int | None = 2
     ) -> str:
         """
         Serialize to JSON string.
@@ -114,7 +114,7 @@ class StateSnapshot:
         return json.dumps(snapshot, indent=indent, ensure_ascii=False)
 
     @staticmethod
-    def from_json(json_str: str) -> tuple[EchoState2, Optional[AuxState]]:
+    def from_json(json_str: str) -> tuple[EchoState2, AuxState | None]:
         """
         Deserialize from JSON string.
 
@@ -131,7 +131,7 @@ class StateSnapshot:
     def save_to_file(
         file_path: str | Path,
         echo_state2: EchoState2,
-        aux_state: Optional[AuxState] = None,
+        aux_state: AuxState | None = None,
         include_derived: bool = True
     ) -> None:
         """
@@ -148,7 +148,7 @@ class StateSnapshot:
         file_path.write_text(json_str, encoding='utf-8')
 
     @staticmethod
-    def load_from_file(file_path: str | Path) -> tuple[EchoState2, Optional[AuxState]]:
+    def load_from_file(file_path: str | Path) -> tuple[EchoState2, AuxState | None]:
         """
         Load state from file.
 
@@ -165,9 +165,9 @@ class StateSnapshot:
     @staticmethod
     def create_snapshot(
         echo_state2: EchoState2,
-        aux_state: Optional[AuxState] = None,
-        metadata: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+        aux_state: AuxState | None = None,
+        metadata: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """
         Create a complete snapshot with metadata.
 

--- a/phionyx_core/state/time_manager.py
+++ b/phionyx_core/state/time_manager.py
@@ -13,8 +13,8 @@ Ensures:
 
 from __future__ import annotations
 
-from typing import Optional
 from datetime import datetime
+
 from phionyx_core.state.echo_state_2 import EchoState2
 
 
@@ -40,7 +40,7 @@ class TimeManager:
 
     def advance_turn(
         self,
-        current_time: Optional[datetime] = None
+        current_time: datetime | None = None
     ) -> float:
         """
         Advance turn and update all time fields.
@@ -118,7 +118,7 @@ class TimeManager:
         """
         return self.state.t_now
 
-    def validate_dt(self, external_dt: Optional[float] = None) -> float:
+    def validate_dt(self, external_dt: float | None = None) -> float:
         """
         Validate and return dt.
 

--- a/phionyx_core/state/ukf_adaptive_noise.py
+++ b/phionyx_core/state/ukf_adaptive_noise.py
@@ -10,7 +10,6 @@ Per Echoism Core v1.1:
 
 from __future__ import annotations
 
-from typing import Optional, List
 import numpy as np
 
 
@@ -97,8 +96,8 @@ def create_dynamic_measurement_noise_matrix(
 
 
 def calculate_emotional_volatility(
-    dA_history: List[float],
-    dV_history: List[float],
+    dA_history: list[float],
+    dV_history: list[float],
     window_size: int = 5
 ) -> float:
     """
@@ -214,8 +213,8 @@ def create_dynamic_process_noise_matrix(
 
 
 def get_sensor_quality_from_provider(
-    provider: Optional[str] = None,
-    model: Optional[str] = None
+    provider: str | None = None,
+    model: str | None = None
 ) -> float:
     """
     Get sensor quality coefficient from LLM provider metadata.

--- a/phionyx_core/state/ukf_measurement_integration.py
+++ b/phionyx_core/state/ukf_measurement_integration.py
@@ -12,7 +12,8 @@ Ensures:
 
 from __future__ import annotations
 
-from typing import Optional, Dict, Any
+from typing import Any
+
 import numpy as np
 
 from phionyx_core.state.measurement_mapper import MeasurementMapper, MeasurementVector
@@ -37,7 +38,7 @@ class UKFMeasurementIntegration:
     - Update UKF with measurement
     """
 
-    def __init__(self, measurement_mapper: Optional[MeasurementMapper] = None):
+    def __init__(self, measurement_mapper: MeasurementMapper | None = None):
         """
         Initialize UKF measurement integration.
 
@@ -49,7 +50,7 @@ class UKFMeasurementIntegration:
     def create_measurement_from_llm(
         self,
         llm_text: str,
-        llm_output: Optional[Dict[str, Any]] = None
+        llm_output: dict[str, Any] | None = None
     ) -> MeasurementVector:
         """
         Create measurement vector from LLM output.
@@ -66,7 +67,7 @@ class UKFMeasurementIntegration:
     def convert_measurement_to_ukf_state(
         self,
         measurement: MeasurementVector,
-        current_state: Optional[EchoStateVector] = None
+        current_state: EchoStateVector | None = None
     ) -> EchoStateVector:
         """
         Convert measurement vector to UKF state vector.
@@ -121,7 +122,7 @@ class UKFMeasurementIntegration:
         self,
         ukf_estimator: EchoStateEstimator,
         measurement: MeasurementVector,
-        current_state: Optional[EchoStateVector] = None
+        current_state: EchoStateVector | None = None
     ) -> EchoStateVector:
         """
         Update UKF with measurement from mapper.
@@ -185,8 +186,8 @@ class UKFMeasurementIntegration:
         self,
         ukf_estimator: EchoStateEstimator,
         llm_text: str,
-        llm_output: Optional[Dict[str, Any]] = None,
-        current_state: Optional[EchoStateVector] = None
+        llm_output: dict[str, Any] | None = None,
+        current_state: EchoStateVector | None = None
     ) -> tuple[MeasurementVector, EchoStateVector]:
         """
         Process LLM output and update UKF in one step.

--- a/phionyx_core/state/ukf_process_model.py
+++ b/phionyx_core/state/ukf_process_model.py
@@ -16,14 +16,15 @@ State transition rules:
 
 from __future__ import annotations
 
-from typing import Dict, Any, Optional
+from typing import Any
+
 import numpy as np
 
 
 def echoism_process_model(
     x: np.ndarray,
     dt: float,
-    u: Optional[Dict[str, Any]] = None
+    u: dict[str, Any] | None = None
 ) -> np.ndarray:
     """
     Non-linear process model f(x, dt, u) for Echoism Core v1.0.
@@ -166,9 +167,9 @@ def echoism_process_model(
 
 def create_echoism_process_model(
     dt: float,
-    event_features: Optional[Dict[str, Any]] = None,
+    event_features: dict[str, Any] | None = None,
     trace_strength: float = 0.0,
-    task_outcome: Optional[str] = None,
+    task_outcome: str | None = None,
     confidence: float = 0.5
 ) -> callable:
     """
@@ -191,7 +192,7 @@ def create_echoism_process_model(
         "confidence": confidence
     }
 
-    def process_model(x: np.ndarray, control: Optional[Dict[str, Any]] = None) -> np.ndarray:
+    def process_model(x: np.ndarray, control: dict[str, Any] | None = None) -> np.ndarray:
         """
         Process model with pre-configured control inputs.
 

--- a/phionyx_core/telemetry/opentelemetry_config.py
+++ b/phionyx_core/telemetry/opentelemetry_config.py
@@ -14,7 +14,6 @@ Features:
 
 import logging
 import os
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +25,8 @@ _tracer = None
 def initialize_opentelemetry(
     service_name: str = "phionyx-echo-server",
     service_version: str = "2.5.0",
-    otlp_endpoint: Optional[str] = None,
-    enabled: Optional[bool] = None,
+    otlp_endpoint: str | None = None,
+    enabled: bool | None = None,
     sampling_rate: float = 1.0,
     enable_metrics: bool = False
 ) -> bool:
@@ -62,10 +61,10 @@ def initialize_opentelemetry(
     # Try to import OpenTelemetry packages
     try:
         from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
-        from opentelemetry.sdk.resources import Resource, SERVICE_NAME, SERVICE_VERSION
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
     except ImportError as e:
         logger.warning(f"OpenTelemetry packages not installed: {e}")
         logger.warning("Install with: pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp")

--- a/phionyx_core/telemetry/otel_metrics.py
+++ b/phionyx_core/telemetry/otel_metrics.py
@@ -12,7 +12,6 @@ Metrics:
 """
 
 import logging
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +25,9 @@ _llm_cost_counter = None
 
 try:
     from opentelemetry import metrics
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
     _metrics_available = True
 except ImportError:
     logger.debug("OpenTelemetry metrics not available")
@@ -106,7 +105,7 @@ def initialize_otel_metrics(
         return False
 
 
-def record_entropy(entropy: float, block_id: Optional[str] = None):
+def record_entropy(entropy: float, block_id: str | None = None):
     """
     Record entropy value.
 
@@ -124,7 +123,7 @@ def record_entropy(entropy: float, block_id: Optional[str] = None):
             logger.debug(f"Failed to record entropy metric: {e}")
 
 
-def record_ethics_blocking(block_id: str, reason: Optional[str] = None):
+def record_ethics_blocking(block_id: str, reason: str | None = None):
     """
     Record ethics blocking event.
 
@@ -143,7 +142,7 @@ def record_ethics_blocking(block_id: str, reason: Optional[str] = None):
             logger.debug(f"Failed to record ethics blocking metric: {e}")
 
 
-def record_latency(latency_seconds: float, block_id: Optional[str] = None):
+def record_latency(latency_seconds: float, block_id: str | None = None):
     """
     Record pipeline or block latency.
 

--- a/phionyx_core/telemetry/sampling.py
+++ b/phionyx_core/telemetry/sampling.py
@@ -12,7 +12,6 @@ Features:
 """
 
 import logging
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +66,7 @@ class ErrorAwareSampler:
         return f"ErrorAwareSampler(base_rate={self.base_sampling_rate})"
 
 
-def create_production_sampler(sampling_rate: float = 0.1) -> Optional[object]:
+def create_production_sampler(sampling_rate: float = 0.1) -> object | None:
     """
     Create a production-ready sampler.
 

--- a/phionyx_core/templates/__init__.py
+++ b/phionyx_core/templates/__init__.py
@@ -6,10 +6,10 @@ Provides template-based responses for common intents to reduce LLM calls.
 """
 
 from phionyx_core.templates.response_templates import (
+    IntentType,
     ResponseTemplate,
     TemplateManager,
     get_template_manager,
-    IntentType
 )
 
 __all__ = [

--- a/phionyx_core/templates/response_templates.py
+++ b/phionyx_core/templates/response_templates.py
@@ -13,9 +13,9 @@ Features:
 """
 
 import logging
-from typing import Dict, Optional, List, Any
-from enum import Enum
 from dataclasses import dataclass
+from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class ResponseTemplate:
     template: str
     min_entropy: float = 0.0
     max_entropy: float = 0.5
-    variables: Optional[List[str]] = None
+    variables: list[str] | None = None
 
     def render(self, **kwargs: Any) -> str:
         """
@@ -69,7 +69,7 @@ class TemplateManager:
 
     def __init__(self):
         """Initialize template manager with default templates."""
-        self._templates: Dict[IntentType, List[ResponseTemplate]] = {}
+        self._templates: dict[IntentType, list[ResponseTemplate]] = {}
         self._metrics = {
             "hits": 0,
             "misses": 0,
@@ -153,7 +153,7 @@ class TemplateManager:
         intent: IntentType,
         entropy: float,
         **kwargs: Any
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Get template response for intent and entropy level.
 
@@ -218,7 +218,7 @@ class TemplateManager:
 
         return len(eligible_templates) > 0
 
-    def get_metrics(self) -> Dict[str, Any]:
+    def get_metrics(self) -> dict[str, Any]:
         """
         Get template metrics.
 
@@ -245,7 +245,7 @@ class TemplateManager:
 
 
 # Global template manager instance (singleton pattern)
-_global_template_manager: Optional[TemplateManager] = None
+_global_template_manager: TemplateManager | None = None
 
 
 def get_template_manager() -> TemplateManager:

--- a/phionyx_core/templates/tests/test_response_templates.py
+++ b/phionyx_core/templates/tests/test_response_templates.py
@@ -2,12 +2,13 @@
 Unit tests for Response Templates
 """
 import pytest
+
 from phionyx_core.templates.response_templates import (
+    IntentType,
     ResponseTemplate,
     TemplateManager,
-    IntentType,
     get_template_manager,
-    reset_global_template_manager
+    reset_global_template_manager,
 )
 
 

--- a/phionyx_core/use_cases/__init__.py
+++ b/phionyx_core/use_cases/__init__.py
@@ -5,25 +5,17 @@ Use Cases Package
 Business logic use cases extracted from API route handlers.
 """
 
-from .process_decision_use_case import (
-    ProcessDecisionUseCase,
-    ProcessDecisionInput,
-    ProcessDecisionOutput
-)
-from .draw_cards_use_case import (
-    DrawCardsUseCase,
-    DrawCardsInput,
-    DrawCardsOutput
-)
-from .play_card_use_case import (
-    PlayCardUseCase,
-    PlayCardInput,
-    PlayCardOutput
-)
 from .bootstrap_session_use_case import (
-    BootstrapSessionUseCase,
     BootstrapSessionInput,
-    BootstrapSessionOutput
+    BootstrapSessionOutput,
+    BootstrapSessionUseCase,
+)
+from .draw_cards_use_case import DrawCardsInput, DrawCardsOutput, DrawCardsUseCase
+from .play_card_use_case import PlayCardInput, PlayCardOutput, PlayCardUseCase
+from .process_decision_use_case import (
+    ProcessDecisionInput,
+    ProcessDecisionOutput,
+    ProcessDecisionUseCase,
 )
 
 __all__ = [

--- a/phionyx_core/use_cases/bootstrap_session_use_case.py
+++ b/phionyx_core/use_cases/bootstrap_session_use_case.py
@@ -7,8 +7,8 @@ Extracted from API route handler to core layer.
 """
 
 import logging
-from typing import Optional, Any
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -18,14 +18,14 @@ class BootstrapSessionInput:
     """Input for bootstrap session use case."""
     actor_ref: str
     character_id: str
-    content_profile: Optional[str] = None
+    content_profile: str | None = None
 
 
 @dataclass
 class BootstrapSessionOutput:
     """Output from bootstrap session use case."""
     scenario: Any  # EchoScenario
-    persona: Optional[Any] = None  # Persona object
+    persona: Any | None = None  # Persona object
 
 
 class BootstrapSessionUseCase:

--- a/phionyx_core/use_cases/draw_cards_use_case.py
+++ b/phionyx_core/use_cases/draw_cards_use_case.py
@@ -7,8 +7,8 @@ Extracted from API route handler to core layer.
 """
 
 import logging
-from typing import Dict, Any, Optional
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -17,21 +17,21 @@ logger = logging.getLogger(__name__)
 class DrawCardsInput:
     """Input for draw cards use case."""
     character_id: str
-    profile_name: Optional[str] = None
-    content_profile: Optional[str] = None
-    user_id: Optional[str] = None
+    profile_name: str | None = None
+    content_profile: str | None = None
+    user_id: str | None = None
 
 
 @dataclass
 class DrawCardsOutput:
     """Output from draw cards use case."""
-    cards: Dict[str, Any]
+    cards: dict[str, Any]
     character_name: str
     character_archetype: str
     profile_name: str
     character_class: str = "Shadow"
-    initial_integrity: Optional[float] = None
-    background: Optional[str] = None
+    initial_integrity: float | None = None
+    background: str | None = None
 
 
 class DrawCardsUseCase:

--- a/phionyx_core/use_cases/play_card_use_case.py
+++ b/phionyx_core/use_cases/play_card_use_case.py
@@ -7,8 +7,8 @@ Extracted from API route handler to core layer.
 """
 
 import logging
-from typing import Dict, Any, Optional
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -18,19 +18,19 @@ class PlayCardInput:
     """Input for play card use case."""
     character_id: str
     card_id: str
-    user_input: Optional[str] = None
-    scene_context: Optional[str] = None
-    user_id: Optional[str] = None
+    user_input: str | None = None
+    scene_context: str | None = None
+    user_id: str | None = None
 
 
 @dataclass
 class PlayCardOutput:
     """Output from play card use case."""
-    result: Dict[str, Any]
+    result: dict[str, Any]
     character_name: str
     character_archetype: str
-    background: Optional[str] = None
-    user_age_category: Optional[str] = None
+    background: str | None = None
+    user_age_category: str | None = None
 
 
 class PlayCardUseCase:

--- a/phionyx_core/use_cases/process_decision_use_case.py
+++ b/phionyx_core/use_cases/process_decision_use_case.py
@@ -7,8 +7,8 @@ Extracted from API route handler to core layer.
 """
 
 import logging
-from typing import Dict, Any, Optional
 from dataclasses import dataclass
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -20,24 +20,24 @@ class ProcessDecisionInput:
     character_id: str
     character_archetype: str
     profile_name: str
-    conversation_id: Optional[str] = None
-    actor_ref: Optional[str] = None
-    participant_type: Optional[str] = None
-    mode: Optional[str] = None
-    strategy: Optional[str] = None
-    turn_envelope: Optional[Dict[str, Any]] = None
-    request_id: Optional[str] = None
+    conversation_id: str | None = None
+    actor_ref: str | None = None
+    participant_type: str | None = None
+    mode: str | None = None
+    strategy: str | None = None
+    turn_envelope: dict[str, Any] | None = None
+    request_id: str | None = None
     debug: bool = False
 
 
 @dataclass
 class ProcessDecisionOutput:
     """Output from process decision use case."""
-    result: Dict[str, Any]
+    result: dict[str, Any]
     conversation_id: str
-    participant: Optional[Any] = None
-    envelope: Optional[Any] = None
-    delivery_ack: Optional[Any] = None
+    participant: Any | None = None
+    envelope: Any | None = None
+    delivery_ack: Any | None = None
 
 
 class ProcessDecisionUseCase:
@@ -57,7 +57,7 @@ class ProcessDecisionUseCase:
         engine: Any,  # UnifiedEchoEngineRefactored
         envelope_store: Any,  # TurnEnvelopeStore
         turn_lock_guard: Any,  # TurnLockGuard
-        capability_deriver: Optional[Any] = None
+        capability_deriver: Any | None = None
     ):
         """
         Initialize use case.
@@ -84,15 +84,15 @@ class ProcessDecisionUseCase:
             ProcessDecisionOutput with result and metadata
         """
         # Import here to avoid circular dependencies
-        from ..contracts.envelopes.turn_envelope import TurnEnvelope, DeliveryAck
+        from ..contracts.envelopes.turn_envelope import DeliveryAck, TurnEnvelope
         from ..contracts.participants import ParticipantRef, ParticipantType
 
         # Step 1: Validate and process TurnEnvelope
-        envelope: Optional[TurnEnvelope] = None
-        delivery_ack: Optional[DeliveryAck] = None
-        _conversation_id_from_envelope: Optional[str] = None
-        _turn_id_from_envelope: Optional[int] = None
-        _message_id_from_envelope: Optional[str] = None
+        envelope: TurnEnvelope | None = None
+        delivery_ack: DeliveryAck | None = None
+        _conversation_id_from_envelope: str | None = None
+        _turn_id_from_envelope: int | None = None
+        _message_id_from_envelope: str | None = None
         turn_lock_result = None
 
         if input_data.turn_envelope:

--- a/phionyx_core/utils/__init__.py
+++ b/phionyx_core/utils/__init__.py
@@ -6,9 +6,9 @@ Utility modules for Phionyx Core.
 """
 
 from .thread_safety import (
+    SessionLocalStorage,
     ThreadSafeDict,
     ThreadSafeList,
-    SessionLocalStorage,
     synchronized,
 )
 

--- a/phionyx_core/utils/thread_safety.py
+++ b/phionyx_core/utils/thread_safety.py
@@ -5,10 +5,11 @@ Thread Safety Utilities
 Utilities for thread-safe operations in multi-tenant environments.
 """
 
-import threading
-from typing import TypeVar, Callable, Any
-from functools import wraps
 import logging
+import threading
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/world/__init__.py
+++ b/phionyx_core/world/__init__.py
@@ -6,8 +6,8 @@ Temporal tracking, state versioning, and world-state management
 for Phionyx cognitive substrate.
 """
 
-from .temporal_tracker import TemporalTracker, EntityTimeline, TemporalQuery
-from .state_versioning import StateVersioning, StateSnapshot, StateDiff
+from .state_versioning import StateDiff, StateSnapshot, StateVersioning
+from .temporal_tracker import EntityTimeline, TemporalQuery, TemporalTracker
 
 __all__ = [
     "TemporalTracker",

--- a/phionyx_core/world/state_versioning.py
+++ b/phionyx_core/world/state_versioning.py
@@ -13,18 +13,18 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 
 @dataclass
 class StateSnapshot:
     """A versioned, hash-verified snapshot of world state."""
     version: int
-    state: Dict[str, Any]
+    state: dict[str, Any]
     hash: str
     timestamp: str
     turn_index: int
-    parent_version: Optional[int] = None
+    parent_version: int | None = None
 
     def verify(self) -> bool:
         """Verify hash integrity."""
@@ -37,9 +37,9 @@ class StateDiff:
     """Difference between two state snapshots."""
     from_version: int
     to_version: int
-    added: Dict[str, Any] = field(default_factory=dict)
-    removed: Dict[str, Any] = field(default_factory=dict)
-    changed: Dict[str, Dict[str, Any]] = field(default_factory=dict)  # key → {old, new}
+    added: dict[str, Any] = field(default_factory=dict)
+    removed: dict[str, Any] = field(default_factory=dict)
+    changed: dict[str, dict[str, Any]] = field(default_factory=dict)  # key → {old, new}
 
     @property
     def is_empty(self) -> bool:
@@ -50,7 +50,7 @@ class StateDiff:
         return len(self.added) + len(self.removed) + len(self.changed)
 
     @property
-    def changed_keys(self) -> Set[str]:
+    def changed_keys(self) -> set[str]:
         return set(self.added.keys()) | set(self.removed.keys()) | set(self.changed.keys())
 
 
@@ -76,11 +76,11 @@ class StateVersioning:
 
     def __init__(self, max_versions: int = 50):
         self.max_versions = max(1, max_versions)
-        self._snapshots: List[StateSnapshot] = []
+        self._snapshots: list[StateSnapshot] = []
         self._current_version: int = 0
 
     @staticmethod
-    def compute_hash(state: Dict[str, Any]) -> str:
+    def compute_hash(state: dict[str, Any]) -> str:
         """Compute SHA256 hash of a state dict."""
         canonical = json.dumps(state, sort_keys=True, default=str)
         return hashlib.sha256(canonical.encode()).hexdigest()
@@ -95,9 +95,9 @@ class StateVersioning:
 
     def snapshot(
         self,
-        state: Dict[str, Any],
+        state: dict[str, Any],
         turn_index: int = 0,
-        timestamp: Optional[str] = None,
+        timestamp: str | None = None,
     ) -> StateSnapshot:
         """
         Create a new versioned snapshot.
@@ -125,18 +125,18 @@ class StateVersioning:
 
         return snap
 
-    def get_snapshot(self, version: int) -> Optional[StateSnapshot]:
+    def get_snapshot(self, version: int) -> StateSnapshot | None:
         """Get a specific version snapshot."""
         for snap in self._snapshots:
             if snap.version == version:
                 return snap
         return None
 
-    def get_latest(self) -> Optional[StateSnapshot]:
+    def get_latest(self) -> StateSnapshot | None:
         """Get the most recent snapshot."""
         return self._snapshots[-1] if self._snapshots else None
 
-    def diff(self, from_version: int, to_version: int) -> Optional[StateDiff]:
+    def diff(self, from_version: int, to_version: int) -> StateDiff | None:
         """Compute diff between two versions."""
         snap_from = self.get_snapshot(from_version)
         snap_to = self.get_snapshot(to_version)
@@ -204,7 +204,7 @@ class StateVersioning:
                 return False
         return True
 
-    def get_history(self) -> List[Dict[str, Any]]:
+    def get_history(self) -> list[dict[str, Any]]:
         """Get version history summary."""
         return [
             {

--- a/phionyx_core/world/temporal_tracker.py
+++ b/phionyx_core/world/temporal_tracker.py
@@ -11,8 +11,7 @@ Roadmap Faz 4.2: World Model Hardening — Temporal Tracking
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
-
+from typing import Any
 
 # Module-level tunable defaults (Tier A — PRE surfaces)
 temporal_decay_rate = 0.02
@@ -43,10 +42,10 @@ class EntityTimeline:
     """Full timeline of an entity's attribute changes."""
     entity_id: str
     attribute: str
-    states: List[EntityState] = field(default_factory=list)
+    states: list[EntityState] = field(default_factory=list)
 
     @property
-    def current(self) -> Optional[EntityState]:
+    def current(self) -> EntityState | None:
         return self.states[-1] if self.states else None
 
     @property
@@ -99,9 +98,9 @@ class TemporalTracker:
         self.decay_rate = max(0.0, min(1.0, decay_rate))
         self.max_history = max_history_per_entity
         self.conflict_strategy = conflict_strategy
-        self._timelines: Dict[str, Dict[str, EntityTimeline]] = {}
+        self._timelines: dict[str, dict[str, EntityTimeline]] = {}
         self._current_turn: int = 0
-        self._conflicts: List[ConflictResolution] = []
+        self._conflicts: list[ConflictResolution] = []
 
     def advance_turn(self) -> int:
         """Advance the turn counter. Returns new turn index."""
@@ -119,8 +118,8 @@ class TemporalTracker:
         value: Any,
         confidence: float = 1.0,
         source: str = "observation",
-        timestamp: Optional[str] = None,
-    ) -> Optional[ConflictResolution]:
+        timestamp: str | None = None,
+    ) -> ConflictResolution | None:
         """
         Record a state change for an entity attribute.
 
@@ -169,7 +168,7 @@ class TemporalTracker:
         self,
         entity_id: str,
         attribute: str,
-        at_turn: Optional[int] = None,
+        at_turn: int | None = None,
     ) -> TemporalQuery:
         """
         Query entity state, optionally at a specific turn.
@@ -230,19 +229,19 @@ class TemporalTracker:
             reasoning=f"Value from turn {state.turn_index}, {turns_elapsed} turns ago, decay={decay:.3f}",
         )
 
-    def get_timeline(self, entity_id: str, attribute: str) -> Optional[EntityTimeline]:
+    def get_timeline(self, entity_id: str, attribute: str) -> EntityTimeline | None:
         """Get full timeline for an entity attribute."""
         return self._get_timeline(entity_id, attribute)
 
-    def get_entity_attributes(self, entity_id: str) -> List[str]:
+    def get_entity_attributes(self, entity_id: str) -> list[str]:
         """List all tracked attributes for an entity."""
         return list(self._timelines.get(entity_id, {}).keys())
 
-    def get_all_entities(self) -> List[str]:
+    def get_all_entities(self) -> list[str]:
         """List all tracked entity IDs."""
         return list(self._timelines.keys())
 
-    def get_conflicts(self) -> List[ConflictResolution]:
+    def get_conflicts(self) -> list[ConflictResolution]:
         """Return all recorded conflicts."""
         return list(self._conflicts)
 
@@ -258,7 +257,7 @@ class TemporalTracker:
             for tl in entity_timelines.values()
         )
 
-    def _get_timeline(self, entity_id: str, attribute: str) -> Optional[EntityTimeline]:
+    def _get_timeline(self, entity_id: str, attribute: str) -> EntityTimeline | None:
         return self._timelines.get(entity_id, {}).get(attribute)
 
     def _resolve_conflict(


### PR DESCRIPTION
Ruff was configured in pyproject.toml but never run, so the codebase had drifted: **3,231 lint findings** on a clean check, mostly minor (PEP 585 typing migrations, import order, comprehension shape, unused imports). Running it now and folding the result in is the cheapest way to lock the codebase to a green baseline.

## Mechanical cleanup (293 files, 2,883 fixes)

- **2,859 auto-fixable** — typing.List/Dict/Optional → list/dict/X | None, import sorting, redundant comprehensions, simple unused imports. Applied with `ruff check --fix`.
- **9 auto-fixable with --unsafe-fixes** — typing.Optional removals where the symbol was the only typing import.
- **12 manual fixes**:
  - 4 × B904: bare `raise ValueError(...)` inside `except` blocks now chain via `from err` or `from None`.
  - 1 × B007: unused loop variable `bin_idx` → `_bin_idx`.
  - 4 × F401: unused typing imports that remained after annotation migration.
  - Misc C-rules (sorted/list/dict literal) auto-resolved.

## CI

`test` job gains a `ruff check phionyx_core` step (matrix Python 3.10/3.11/3.12). Runs after install + version log, before pytest, so a lint regression fails fast.

## Verification

```
$ ruff check phionyx_core
All checks passed!  (was 3,231 errors)

$ pytest tests/core tests/contract tests/benchmarks -q
1130 passed, 7 skipped, 0 failed

$ python -m build
... wheel + sdist clean

$ pip install dist/phionyx_core-*.whl  # in fresh venv
$ python -c "from phionyx_core import EchoState2, calculate_phi_v2_1; ..."
wheel smoke ok after ruff baseline
```

## How to review

Diff is **293 files / +2,909 / -2,948**. Every change is mechanical typing or formatting. Review by sampling one file per directory rather than reading the whole thing — patterns repeat. Notable files to spot-check: `phionyx_core/state/echo_state_2.py`, `phionyx_core/governance/kill_switch.py`, `phionyx_core/contracts/telemetry/__init__.py`.

## Out of scope

- mypy baseline → follow-up (PR #26 plan).
- ruff format (the formatter, distinct from check) → not enabled here; can be a follow-up to lock bracket / quote style.
- Public API: unchanged. Wheel smoke test verified `from phionyx_core import EchoState2, calculate_phi_v2_1, PipelineBlock` and `KillSwitch` still resolve and behave.