### PR TITLE
ci: add Python 3.13 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Python 3.13 was already declared in pyproject.toml `classifiers` but never exercised in CI. All required runtime deps ship 3.13 wheels:

- numpy ≥ 1.24 (3.13 supported since 1.26.4 / 2.0+)
- pydantic ≥ 2.0 (3.13 supported since 2.7)
- PyYAML ≥ 6.0 (3.13 wheels in 6.0.2+)

Adds `"3.13"` to the matrix so any drift surfaces as a failed CI run on the next PR rather than as a user bug report. Live verification is the first run on this PR.