### PR TITLE
release: PyPI publish workflow (OIDC) + v0.2.0 CHANGELOG entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+# Publishes a sdist + wheel to PyPI when a tag matching v* is pushed.
+# Uses PyPI's OIDC "trusted publisher" flow — no API token in repo or
+# secrets. The mapping (this repo + this workflow file + this job +
+# optional environment) must be configured once at
+# https://pypi.org/manage/account/publishing/. After that, every tag
+# v0.2.0, v0.3.0, ... triggers this run and uploads automatically.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Verify tag matches package version
+        run: |
+          tag="${GITHUB_REF##*/}"          # v0.2.0
+          tag_version="${tag#v}"           # 0.2.0
+          pkg_version=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag ${tag} does not match pyproject.toml version ${pkg_version}"
+            exit 1
+          fi
+          echo "tag=${tag}, version=${pkg_version}"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Twine check
+        run: python -m twine check dist/*
+
+      - name: Smoke install + import from built wheel
+        run: |
+          python -m venv /tmp/wheel-smoke
+          /tmp/wheel-smoke/bin/pip install --quiet dist/phionyx_core-*.whl
+          /tmp/wheel-smoke/bin/python -c "
+          import phionyx_core
+          from phionyx_core import EchoState2, calculate_phi_v2_1
+          from phionyx_core.governance.kill_switch import KillSwitch
+          from phionyx_core.contracts.telemetry import get_canonical_blocks
+          assert len(get_canonical_blocks()) == 46
+          s = EchoState2(A=0.5, V=0.3, H=0.4)
+          r = calculate_phi_v2_1(valence=s.V, arousal=s.A, amplitude=5.0,
+              time_delta=0.1, gamma=0.15, stability=s.stability,
+              entropy=s.H, w_c=0.6, w_p=0.4)
+          assert r['phi'] > 0
+          assert KillSwitch().state.value == 'armed'
+          print('release smoke: ok')
+          "
+
+      - name: Upload dist as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 30
+
+  publish:
+    name: publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/phionyx-core
+    permissions:
+      id-token: write   # required for OIDC trusted-publisher exchange
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No `with: password:` — trusted publisher flow uses OIDC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased] — Pipeline contract v3.8.0
+## [Unreleased]
+
+_(no changes yet)_
+
+---
+
+## [0.2.0] — 2026-05-01
+
+PyPI-readiness release. Public surface is unchanged from v0.2.0-dev;
+the work in this version is packaging hygiene, dependency correctness,
+and CI / release infrastructure so that `pip install phionyx-core`
+behaves as advertised on a clean machine.
+
+### Added
+
+- **CI matrix** — GitHub Actions running `ruff check phionyx_core`, smoke
+  imports, and `pytest tests/core tests/contract tests/benchmarks` on
+  Python 3.10 / 3.11 / 3.12 / 3.13 plus a build job that produces sdist
+  + wheel and verifies them with `twine check` and a fresh-venv install.
+- **Release workflow** — `.github/workflows/release.yml` triggers on
+  tags matching `v*`, builds the wheel, and publishes to PyPI via
+  OIDC trusted publisher (no API token in repo or secrets). The
+  workflow also cross-checks that the tag matches `pyproject.toml`
+  `project.version` before uploading.
+- **Demo notebooks** — `examples/notebooks/01_determinism_and_physics.ipynb`,
+  `02_kill_switch_in_action.ipynb`, `03_pipeline_blocks_and_audit.ipynb`
+  with a Try-It-In-30-Seconds entry in the README.
+
+### Changed
+
+- **Required dependencies** — `PyYAML >= 6.0` and `numpy >= 1.24` moved
+  from optional extras into base `dependencies`. They were imported at
+  module top level by `phionyx_core.physics.profiles`,
+  `phionyx_core.cep.cep_config`, and `phionyx_core.state.ukf_*`, so a
+  vanilla install previously raised `ModuleNotFoundError` on
+  `import phionyx_core`. `networkx` remains optional under `[graph]`.
+- **Single packaging metadata source** — removed legacy `setup.py` (it
+  duplicated and disagreed with `pyproject.toml`).
+- **Pydantic V2 idioms across the codebase** — 26 nested `class Config:`
+  blocks migrated to `model_config = ConfigDict(...)`, 5 `@validator`
+  to `@field_validator` + `@classmethod`, 3 `.dict()` to
+  `.model_dump()`. Clears all `PydanticDeprecatedSince20` warnings.
+- **PEP 585 typing across the codebase** — `typing.List/Dict/Optional`
+  rewritten to `list/dict/X | None`, import order normalized,
+  comprehension shape simplified. 293 files mechanically updated;
+  every change is type-annotation or formatting only — no behavioural
+  diff.
+- **`datetime.utcnow()` removed from tests** — 4 occurrences in
+  `tests/core/test_human_in_the_loop.py` replaced with
+  `datetime.now(timezone.utc)` to match the source layer and clear
+  the deprecation warning.
+- **README** — new "Try It In 30 Seconds" section above Quick Start
+  with a Φ heatmap from notebook 01; CI badge added; static test count
+  corrected from 2,571 (monorepo number) to 1,230 (this repo:
+  1,013 core + 107 contract + 10 benchmarks).
+
+### Fixed
+
+- **`tests/contract/test_product_registry.py`** — was failing on a clean
+  clone because it imported from `phionyx_products`, a monorepo-only
+  package. Now uses `pytest.importorskip` so the file skips cleanly
+  on the public release.
+- **`tests/contract/test_block_determinism.py::test_matrix_doc_in_sync`**
+  — invoked `scripts/active/generate_determinism_matrix.py`, which is
+  monorepo-only. Now skips with a clear reason if the script is
+  absent.
+- **`tests/core/test_mind_loop_validator.py`** — imported
+  `tests.behavioral_eval.conftest.CANONICAL_V3_5_0` which is
+  monorepo-only. Now loads the current canonical block list directly
+  from `phionyx_core.contracts.telemetry.get_canonical_blocks()`,
+  fixing 12 collection failures.
+- **`B904` (raise from)** — 4 `raise ValueError(...)` calls inside
+  `except` blocks now chain via `from err` or `from None` so the
+  triggering exception is preserved in tracebacks.
+
+### Tests
+
+- Clean-clone test count rose from 998 (pre-hardening, with one
+  failing test in `tests/core` and a collection error in
+  `tests/contract`) to **1,230 passed, 7 skipped, 0 failed**.
+
+---
+
+## [0.2.0-dev] — Pipeline contract v3.8.0
 
 ### Added
 


### PR DESCRIPTION
Adds the release pipeline that takes a tag → published PyPI artifact, plus the CHANGELOG entry that documents the v0.2.0 PyPI-readiness work.

## Workflow (`.github/workflows/release.yml`)

Triggers on tags matching `v*`. Two jobs:

- **build** — checkout, set up Python 3.12, verify the tag matches `pyproject.toml::project.version`, build sdist + wheel, `twine check`, install the wheel in a fresh venv and run a smoke import. Uploads `dist/` as a 30-day workflow artifact.
- **publish** — depends on `build`. Uses environment `pypi` and `permissions: id-token: write` for the OIDC trusted-publisher exchange. Calls `pypa/gh-action-pypi-publish@release/v1` with no `password:` argument; PyPI verifies the GitHub OIDC claim against a one-time mapping the maintainer configures on pypi.org.

### One-time founder setup before the first tag

1. PyPI account exists (or create one).
2. https://pypi.org/manage/account/publishing/ → **Add a new pending publisher** with:
   - Owner: `halvrenofviryel`
   - Project: `phionyx-research`
   - Workflow: `release.yml`
   - Environment: `pypi`
3. Push tag `v0.2.0`. Workflow runs end-to-end; if PyPI rejects the OIDC claim the publish job fails loudly with a clear error.

After step 2, every subsequent tag just works.

### Tag-vs-version guard

The build job reads `project.version` from `pyproject.toml` and refuses to proceed if the pushed tag doesn't match. Stops the classic mistake of pushing `v0.2.1` without bumping pyproject.

## CHANGELOG

- Promoted `[Unreleased]` → `[0.2.0] - 2026-05-01` with the full PyPI-readiness write-up: CI matrix, ruff baseline, Pydantic V2 migration, required-deps fix, datetime.utcnow cleanup, monorepo-only test skips, demo notebooks.
- Pipeline-contract-v3.8.0 work moved into a new `[0.2.0-dev]` entry to preserve prior history.
- Fresh empty `[Unreleased]` opened at top.

## Out of scope

- mypy baseline → deferred (387 errors across 101 files; multi-day cleanup, not a release-blocker).
- README `pip install phionyx-core` line → adds in a one-liner after the first successful PyPI upload completes (so the README never makes a claim that isn't true).

## Test plan

- [x] `yaml.safe_load(release.yml)` parses cleanly; jobs = [`build`, `publish`].
- [x] `twine check` and fresh-venv wheel smoke already verified locally and in PR #20 CI.
- [ ] Live verification is the first `v0.2.0` tag push after PyPI trusted-publisher mapping is configured.