### PR TITLE
release: bump to v0.2.1 for first PyPI publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           from phionyx_core import EchoState2, calculate_phi_v2_1
           from phionyx_core.governance.kill_switch import KillSwitch
           from phionyx_core.contracts.telemetry import get_canonical_blocks
-          assert phionyx_core.__version__ == '0.2.0'
+          assert phionyx_core.__version__, 'package __version__ should be set'
           assert len(get_canonical_blocks()) == 46
           s = EchoState2(A=0.5, V=0.3, H=0.4)
           r = calculate_phi_v2_1(valence=s.V, arousal=s.A, amplitude=5.0,

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -119,7 +119,7 @@ jobs:
           /tmp/testpypi-smoke/bin/python -c "
           import phionyx_core
           from phionyx_core import EchoState2, calculate_phi_v2_1
-          assert phionyx_core.__version__.startswith('0.2.0')
+          assert phionyx_core.__version__.startswith('0.2.'), phionyx_core.__version__
           s = EchoState2(A=0.5, V=0.3, H=0.4)
           calculate_phi_v2_1(valence=s.V, arousal=s.A, amplitude=5.0,
               time_delta=0.1, gamma=0.15, stability=s.stability,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ _(no changes yet)_
 
 ---
 
-## [0.2.0] — 2026-05-01
+## [0.2.1] — 2026-05-01
 
-PyPI-readiness release. Public surface is unchanged from v0.2.0-dev;
-the work in this version is packaging hygiene, dependency correctness,
-and CI / release infrastructure so that `pip install phionyx-core`
-behaves as advertised on a clean machine.
+First PyPI release. Public surface is unchanged from the v0.2.0
+GitHub release (2026-04-26); the work in this version is packaging
+hygiene, dependency correctness, and CI / release infrastructure so
+`pip install phionyx-core` behaves as advertised on a clean machine.
+
+The version bump from 0.2.0 to 0.2.1 is bookkeeping: the v0.2.0 tag
+was already attached to the GitHub-only release that introduced the
+public source drop, never reached PyPI, and stays untouched. v0.2.1
+is the first artifact that lives on pypi.org.
 
 ### Added
 

--- a/phionyx_core/__init__.py
+++ b/phionyx_core/__init__.py
@@ -32,7 +32,7 @@ Public API is organized into the following namespaces:
 - ``phionyx_core.cep``         -- Conscious Echo Proof engine, guards, config
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # ---------------------------------------------------------------------------
 # Pipeline (always available -- no external deps)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phionyx-core"
-version = "0.2.0"
+version = "0.2.1"
 description = "Deterministic, auditable AI cognition runtime — not an LLM wrapper"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Why

The `v0.2.0` tag is already attached to the [public GitHub release](https://github.com/halvrenofviryel/phionyx-research/releases/tag/v0.2.0) created on 2026-04-26 (commit `6077c6d3`, _"update: revised licensing strategy document"_). That release never reached PyPI — `release.yml` did not exist at the time.

Force-pushing `v0.2.0` forward would overwrite a public release page that external readers may have seen. Instead, this bumps the first PyPI artifact to **0.2.1**.

## Diff

- `pyproject.toml` → `project.version = "0.2.1"`
- `phionyx_core/__init__.py` → `__version__ = "0.2.1"`
- `CHANGELOG.md` → renames `[0.2.0] - 2026-05-01` to `[0.2.1] - 2026-05-01`, adds a one-paragraph note explaining the version-number bookkeeping.

The packaging-hygiene write-up (required deps, ruff baseline, Pydantic V2, datetime cleanup, 3.13 matrix, OIDC release workflow) stays exactly as it was — only the version label moved.

## After merge

```bash
git tag v0.2.1
git push origin v0.2.1
```

This fires `release.yml`, which now passes the tag-vs-pyproject guard and publishes to PyPI via the trusted-publisher mapping (Owner=halvrenofviryel, Project=phionyx-core, Workflow=release.yml, Environment=pypi).