### PR TITLE
docs: promote pip install phionyx-core now that PyPI is live

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -5,13 +5,13 @@
 - Python 3.10 or higher
 - pip ≥ 22
 
-## Install from source (current canonical path)
+## Install from PyPI (recommended)
 
 ```bash
-git clone https://github.com/halvrenofviryel/phionyx-research.git
-cd phionyx-research
-pip install -e .
+pip install phionyx-core
 ```
+
+[![PyPI](https://img.shields.io/pypi/v/phionyx-core.svg)](https://pypi.org/project/phionyx-core/) — first PyPI release: 0.2.1.
 
 After install, a one-line smoke test:
 
@@ -26,15 +26,16 @@ phi = calculate_phi_v2_1(
 print(phi["phi"])  # deterministic, reproducible
 ```
 
-## Install from PyPI
+## Install from source
 
-Coming soon. The package metadata, build, and `twine check` are clean,
-but the upload is gated on a TestPyPI verification run. Track
-[`#packaging/pypi-readiness`](https://github.com/halvrenofviryel/phionyx-research/pulls?q=label%3Apackaging)
-for status. Once uploaded the install will be:
+For contributors or anyone who wants to run the test suite / hack on
+the kernel:
 
 ```bash
-pip install phionyx-core
+git clone https://github.com/halvrenofviryel/phionyx-research.git
+cd phionyx-research
+pip install -e ".[dev]"
+pytest tests/core -q
 ```
 
 ## Required dependencies

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@
 **Deterministic AI runtime that treats LLM outputs as sensor measurements, not decisions.**
 
 [![CI](https://github.com/halvrenofviryel/phionyx-research/actions/workflows/ci.yml/badge.svg)](https://github.com/halvrenofviryel/phionyx-research/actions/workflows/ci.yml)
-[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/halvrenofviryel/phionyx-research)
+[![PyPI](https://img.shields.io/pypi/v/phionyx-core.svg)](https://pypi.org/project/phionyx-core/)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-1%2C013%20pass-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-1%2C230%20pass-brightgreen.svg)](tests/)
+
+```bash
+pip install phionyx-core
+```
 
 Most AI frameworks let the LLM decide. Phionyx doesn't. Every LLM response passes through a 46-block deterministic pipeline with safety gates, ethics checks, and physics-based state tracking — before it reaches the user.
 
@@ -46,11 +50,14 @@ no LLM is involved at this layer.
 ![Phi cognitive across valence × arousal](docs/img/phi_heatmap.png)
 
 ```bash
+pip install phionyx-core jupyter matplotlib
 git clone https://github.com/halvrenofviryel/phionyx-research.git
-cd phionyx-research
-pip install -e . jupyter matplotlib
-jupyter notebook examples/notebooks/
+jupyter notebook phionyx-research/examples/notebooks/
 ```
+
+(Cloning is only needed because the notebooks live in the repo, not the
+package. Source-only install is also supported — see
+[`INSTALLATION.md`](INSTALLATION.md).)
 
 ---
 


### PR DESCRIPTION
PyPI release v0.2.1 went up at https://pypi.org/project/phionyx-core/ and round-trip-installed cleanly in a fresh venv. Updates the README and INSTALLATION.md so a reader landing on the repo sees the simplest working install path first.

## README

- Replace static version badge with dynamic PyPI badge.
- Bump test-count badge from 1,013 to **1,230** (1013 core + 107 contract + 10 benchmarks).
- Add a `pip install phionyx-core` code block right under the badges.
- Try-It-In-30-Seconds block now uses `pip install phionyx-core` for the package; clones the repo only because the demo notebooks ship with source.

## INSTALLATION.md

- Promote **Install from PyPI** to the first section; remove the coming-soon stub.
- Add PyPI badge inline.
- Source-install section reframed as the contributor / test-runner path (`pip install -e ".[dev]"` + pytest).

Documentation only — no code changes.