### PR TITLE
chore: add issue/PR templates, code of conduct, dependabot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Something in phionyx-core behaves incorrectly or crashes.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please fill the fields below — they save a
+        round-trip on the most common questions. Security issues should
+        go through [SECURITY.md](../SECURITY.md), not here.
+
+  - type: input
+    id: version
+    attributes:
+      label: phionyx-core version
+      description: Output of `python -c "import phionyx_core; print(phionyx_core.__version__)"`
+      placeholder: "0.2.1"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      description: Output of `python --version`
+      placeholder: "Python 3.12.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install path
+      options:
+        - "pip install phionyx-core"
+        - "pip install -e . (from source clone)"
+        - "other / unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Smallest snippet that triggers the bug. Plain Python preferred — no orchestrator unless the bug is in the orchestrator path.
+      render: python
+      placeholder: |
+        from phionyx_core import EchoState2, calculate_phi_v2_1
+        # ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: Include the full traceback if there is one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional notes
+      description: Profile, capability config, anything that hints at the source of the bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/halvrenofviryel/phionyx-research/security/advisories/new
+    about: Use the private vulnerability report flow — see SECURITY.md.
+  - name: Discussion
+    url: https://github.com/halvrenofviryel/phionyx-research/discussions
+    about: Open-ended question, design feedback, or "how would you approach…".

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,62 @@
+name: Feature request
+description: Propose a new capability, block, port, or extension.
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Phionyx is a deterministic-by-design runtime, so feature
+        proposals get evaluated against three lenses before being
+        scoped: (1) does it preserve determinism; (2) does it map to
+        the mind-loop or to an adapter; (3) what does it cost in
+        complexity.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: The concrete situation where today's API is missing or awkward. Skip motivation by example.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: Sketch the API or block. Pseudocode is fine.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: layer
+    attributes:
+      label: Which layer does this touch?
+      options:
+        - "phionyx_core (kernel — physics, state, contracts, governance)"
+        - "phionyx_core.ports (adapter interface)"
+        - "Adapter implementation (graph / postgres / supabase / telemetry / ...)"
+        - "Examples / docs"
+        - "CI / release / packaging"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: determinism
+    attributes:
+      label: Determinism class of the new code
+      description: See `phionyx_core.pipeline.base.DeterminismClass`.
+      options:
+        - "strict (no randomness, no clock, no I/O)"
+        - "seeded (random derived from BlockContext)"
+        - "noisy_sensor (delegates to LLM / network / clock)"
+        - "n/a (docs / examples / build only)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Why doesn't an existing block / port / config combo cover this?

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,26 @@
+name: Question
+description: How does X work? Where do I find Y?
+title: "[q] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For longer-form discussion, the
+        [Discussions](https://github.com/halvrenofviryel/phionyx-research/discussions)
+        tab is usually a better fit than an issue. Use this template
+        when you suspect the question is short and the answer might
+        be reusable.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What you've already checked
+      description: README, INSTALLATION.md, CHANGELOG, examples/notebooks, docs/, the relevant source file, ChatGPT / search. Tells us where to point you.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for the PR. The shape below mirrors the questions a reviewer
+would ask anyway; pre-answering them speeds review.
+
+For very small PRs (typo, comment, version bump), the structure is
+optional — a one-line summary is fine.
+-->
+
+## Summary
+
+<!-- One or two sentences: what changes, why now. -->
+
+## Layer + determinism
+
+<!--
+Which layer does this touch? (phionyx_core kernel / phionyx_core.ports /
+adapter / examples / docs / CI / packaging)
+
+If it adds a `PipelineBlock`, declare its `determinism` class
+(`strict` / `seeded` / `noisy_sensor`) and why.
+-->
+
+## How to verify
+
+<!--
+Concrete steps. Prefer:
+
+  pytest tests/core -q
+  ruff check phionyx_core
+  python -m build && twine check dist/*
+
+over "I tested it locally". CI runs the same checks; if you can paste
+the local output it shortens the loop.
+-->
+
+## Risk
+
+<!--
+- Public API surface changed? List the symbols.
+- Determinism contract: any block now `noisy_sensor` that wasn't?
+- Audit-record schema touched? (compute_hash() value should not change
+  unless intentional — bump schema version if it does.)
+- Required dependency added? Justify; we keep the base set small so
+  `pip install phionyx-core` stays light.
+-->
+
+## Linked issues
+
+<!-- e.g. closes #123, refs #45 -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+# Keep both runtime deps (pyproject) and CI actions current. We
+# review and merge weekly; security updates fire as soon as they
+# show up regardless of schedule.
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      pydantic:
+        patterns:
+          - "pydantic*"
+      dev-tooling:
+        patterns:
+          - "ruff"
+          - "mypy"
+          - "pytest*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(actions)"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We — contributors and maintainers of `phionyx-core` and adjacent
+Phionyx Research projects — pledge to make participation in this
+community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Using welcoming and inclusive language.
+- Respecting differing viewpoints and experiences.
+- Gracefully accepting constructive criticism.
+- Focusing on what is best for the community.
+- Showing empathy towards other community members.
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and unwelcome sexual
+  attention or advances.
+- Trolling, insulting or derogatory comments, and personal or
+  political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or
+  electronic address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in
+  a professional setting.
+
+## Enforcement responsibilities
+
+Project maintainers are responsible for clarifying and enforcing the
+standards of acceptable behaviour and will take appropriate and fair
+corrective action in response to any behaviour they deem
+inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned with this Code of Conduct, and to
+ban temporarily or permanently any contributor for behaviour deemed
+inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — issues,
+discussions, pull requests, code reviews, and any communication
+identifying as part of the Phionyx Research project — and also when
+an individual is officially representing the project in public
+spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour
+may be reported to the maintainer at **founder@phionyx.ai**. All
+complaints will be reviewed and investigated promptly and fairly. The
+maintainer is obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version
+2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+For answers to common questions about this code of conduct, see
+<https://www.contributor-covenant.org/faq>.


### PR DESCRIPTION
Community ergonomics — drives drive-by contributors toward the information the maintainer would have asked for anyway.

## .github/ISSUE_TEMPLATE/

- **bug_report.yml** — version, Python, install path, repro, expected, actual.
- **feature_request.yml** — problem, proposed shape, layer, declared determinism class for any new block, alternatives.
- **question.yml** — short, reusable Q&A.
- **config.yml** — blank issues off; surfaces the security advisory flow and Discussions as contact links.

## .github/PULL_REQUEST_TEMPLATE.md

Summary, layer + determinism, how-to-verify (concrete commands), risk inventory (public API / determinism / audit schema / new required deps), linked issues.

## CODE_OF_CONDUCT.md

Contributor Covenant 2.1, verbatim. Enforcement contact: `founder@phionyx.ai`.

## .github/dependabot.yml

- Weekly Monday cadence (pip + github-actions).
- 5 open-PR ceiling per ecosystem.
- pydantic and dev-tooling grouped — one PR per cluster, not three.
- `chore(deps)` / `chore(actions)` prefix discipline.