### PR TITLE
examples: rewrite phionyx_quickstart.ipynb (closes #10)

### DIFF
--- a/examples/notebooks/phionyx_quickstart.ipynb
+++ b/examples/notebooks/phionyx_quickstart.ipynb
@@ -2,240 +2,345 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "c0288743",
    "metadata": {},
    "source": [
-    "# Phionyx Core SDK — Quick Start\n",
+    "# Phionyx Core — Hello in 5 Minutes\n",
     "\n",
-    "This notebook demonstrates the core concepts of the Phionyx deterministic AI runtime:\n",
-    "\n",
-    "1. **Structured State Vector** — Initialize and evolve cognitive state\n",
-    "2. **Phi (Cognitive Resonance)** — Calculate the quality of cognitive resonance\n",
-    "3. **Safety Gates** — Pre-response governance checks\n",
-    "4. **Canonical Pipeline** — The 46-block deterministic evaluation pipeline\n",
-    "5. **Governed Output Envelope** — Structured, auditable response\n",
-    "\n",
-    "## Installation\n",
+    "A zero-to-running tour of the SDK. No LLM, no server, no API key. Every\n",
+    "cell runs on a fresh `pip install phionyx-core`.\n",
     "\n",
     "```bash\n",
-    "git clone https://github.com/halvrenofviryel/phionyx-research.git\n",
-    "cd phionyx-research\n",
-    "pip install -e .\n",
-    "```"
+    "pip install phionyx-core\n",
+    "```\n",
+    "\n",
+    "What this notebook covers:\n",
+    "\n",
+    "1. The state vector\n",
+    "2. Φ — cognitive resonance\n",
+    "3. Determinism check\n",
+    "4. Kill switch\n",
+    "5. The 46-block canonical pipeline\n",
+    "6. Where to go next\n",
+    "\n",
+    "Total run time on a recent laptop: under 30 seconds.\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "033a6d4a",
    "metadata": {},
    "source": [
-    "## 1. Structured State Vector\n",
-    "\n",
-    "Phionyx represents cognitive state as a structured vector with 7 components.\n",
-    "This is **not** a prompt or a token — it's a deterministic state that evolves\n",
-    "according to physics-inspired equations."
+    "## 0. Imports + version"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 1,
+   "id": "d797b20f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T10:54:02.164429Z",
+     "iopub.status.busy": "2026-05-01T10:54:02.164296Z",
+     "iopub.status.idle": "2026-05-01T10:54:02.667266Z",
+     "shell.execute_reply": "2026-05-01T10:54:02.666988Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "phionyx_core: 0.2.1\n"
+     ]
+    }
+   ],
    "source": [
-    "from phionyx_core import EchoState2\n",
-    "\n",
-    "state = EchoState2(\n",
-    "    A=0.5,       # Arousal (0.0–1.0): cognitive activation level\n",
-    "    V=0.0,       # Valence (-1.0–1.0): positive/negative orientation\n",
-    "    H=0.3,       # Entropy (0.0–1.0): behavioral unpredictability\n",
-    "    dA=0.0,      # Arousal derivative: rate of change\n",
-    "    dV=0.0,      # Valence derivative: rate of change\n",
-    "    t_local=0.0, # Semantic time (local): interaction-scoped\n",
-    "    t_global=0.0 # Semantic time (global): session-scoped\n",
+    "import phionyx_core\n",
+    "from phionyx_core import (\n",
+    "    EchoState2,\n",
+    "    calculate_phi_v2_1,\n",
+    "    calculate_phi_cognitive,\n",
     ")\n",
-    "\n",
-    "print(f\"State vector: A={state.A}, V={state.V}, H={state.H}\")\n",
-    "print(f\"Semantic time: t_local={state.t_local}, t_global={state.t_global}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2. Phi — Cognitive Resonance\n",
-    "\n",
-    "Phi is the hybrid resonance score (0.0–1.0) that measures the quality of\n",
-    "cognitive processing. It combines cognitive and physical weight components.\n",
-    "\n",
-    "**Key insight:** Phi is *derived*, not stored. It's recalculated from state\n",
-    "on every pipeline pass — this is the non-persistence doctrine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from phionyx_core.physics.formulas import calculate_phi_v2_1\n",
-    "\n",
-    "phi_result = calculate_phi_v2_1(\n",
-    "    valence=state.V,\n",
-    "    arousal=state.A,\n",
-    "    amplitude=5.0,\n",
-    "    time_delta=0.1,\n",
-    "    gamma=0.15,\n",
-    "    stability=0.9,\n",
-    "    entropy=state.H,\n",
-    "    w_c=0.75,  # Cognitive weight\n",
-    "    w_p=0.25   # Physical weight\n",
-    ")\n",
-    "\n",
-    "print(f\"Phi (cognitive resonance): {phi_result['phi']:.4f}\")\n",
-    "print(f\"Components: {phi_result}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 3. Dynamic Entropy\n",
-    "\n",
-    "Entropy measures behavioral unpredictability using Kolmogorov Complexity\n",
-    "approximation (Zlib compression). High entropy = more unpredictable output."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from phionyx_core.physics.formulas import calculate_text_entropy_zlib\n",
-    "\n",
-    "# Low entropy: predictable, structured text\n",
-    "low_entropy = calculate_text_entropy_zlib(\"The system is operating normally. All checks passed.\")\n",
-    "\n",
-    "# High entropy: unpredictable, chaotic text  \n",
-    "high_entropy = calculate_text_entropy_zlib(\"Maybe? I think so but also not really, who knows what anything means.\")\n",
-    "\n",
-    "print(f\"Low entropy text:  {low_entropy:.4f}\")\n",
-    "print(f\"High entropy text: {high_entropy:.4f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. Canonical Pipeline — 46 Blocks\n",
-    "\n",
-    "The Phionyx pipeline consists of 46 deterministic blocks (contract v3.8.0)\n",
-    "executed in a fixed canonical order. Each block processes state and produces\n",
-    "an auditable result.\n",
-    "\n",
-    "Blocks are **never deleted** — only policy-bypassed with an audit trail."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from phionyx_core.governance.kill_switch import KillSwitch\n",
     "from phionyx_core.contracts.telemetry import get_canonical_blocks\n",
     "\n",
-    "blocks = get_canonical_blocks()  # v3.8.0 (current)\n",
-    "\n",
-    "print(f\"Pipeline: {len(blocks)} canonical blocks (v3.8.0)\")\n",
-    "print(f\"\\nFirst 10 blocks:\")\n",
-    "for i, block in enumerate(blocks[:10]):\n",
-    "    print(f\"  [{i+1:2d}] {block}\")\n",
-    "\n",
-    "print(f\"\\nLast 5 blocks:\")\n",
-    "for i, block in enumerate(blocks[-5:], len(blocks)-4):\n",
-    "    print(f\"  [{i:2d}] {block}\")"
+    "print(\"phionyx_core:\", phionyx_core.__version__)"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f03a0f5f",
    "metadata": {},
    "source": [
-    "## 5. Safety & Governance Overview\n",
+    "## 1. The state vector\n",
     "\n",
-    "Phionyx enforces **pre-response governance**: risk is prevented before output\n",
-    "generation, not filtered after. Key safety components:\n",
-    "\n",
-    "| Component | Purpose | Failure Mode |\n",
-    "|-----------|---------|-------------|\n",
-    "| Kill Switch | Emergency shutdown (4 triggers) | Fail-closed |\n",
-    "| Input Safety Gate | Validate input before processing | Block malicious input |\n",
-    "| Ethics Gate | 4-framework ethical reasoning | Reject unethical output |\n",
-    "| HITL Queue | Human review for uncertain decisions | Hold for review |\n",
-    "| Cognitive Envelope | Secure agent communication | Validate signatures |\n",
-    "| Response Revision Gate | Final output check (pass/damp/rewrite/reject) | Deterministic |\n",
-    "\n",
-    "The governance layer treats LLM output as a **noisy sensor measurement**,\n",
-    "not a direct decision. The symbolic layer always overrules the neural layer."
+    "Phionyx represents cognitive state as a small structured vector with three\n",
+    "primary attributes — arousal `A`, valence `V`, entropy `H` — plus derived\n",
+    "quantities like `resonance` and `stability` that are computed on demand\n",
+    "and never stored. That keeps the canonical state minimal and reproducible.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "id": "d7213edc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T10:54:02.668716Z",
+     "iopub.status.busy": "2026-05-01T10:54:02.668489Z",
+     "iopub.status.idle": "2026-05-01T10:54:02.670885Z",
+     "shell.execute_reply": "2026-05-01T10:54:02.670512Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Primary    A=0.6  V=0.3  H=0.4\n",
+      "Derived    resonance=0.4800  stability=0.6000\n"
+     ]
+    }
+   ],
    "source": [
-    "# Governance components available in the SDK\n",
-    "from phionyx_core.governance.kill_switch import KillSwitch\n",
-    "from phionyx_core.governance.deliberative_ethics import DeliberativeEthics\n",
+    "state = EchoState2(A=0.6, V=0.3, H=0.4)\n",
     "\n",
-    "# Kill switch: 4 trigger types, fail-closed design\n",
+    "print(f\"Primary    A={state.A}  V={state.V}  H={state.H}\")\n",
+    "print(f\"Derived    resonance={state.resonance:.4f}  stability={state.stability:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d93555c",
+   "metadata": {},
+   "source": [
+    "## 2. Φ — Cognitive resonance\n",
+    "\n",
+    "`calculate_phi_v2_1` is the canonical Hybrid Resonance Model. Same\n",
+    "inputs, same outputs, byte for byte — see the next cell.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4820e3fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T10:54:02.671949Z",
+     "iopub.status.busy": "2026-05-01T10:54:02.671820Z",
+     "iopub.status.idle": "2026-05-01T10:54:02.687131Z",
+     "shell.execute_reply": "2026-05-01T10:54:02.686727Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  phi                1.5250\n",
+      "  phi_cognitive      0.1774\n",
+      "  phi_physical       3.5464\n",
+      "  weight_cognitive   0.6000\n",
+      "  weight_physical    0.4000\n"
+     ]
+    }
+   ],
+   "source": [
+    "phi = calculate_phi_v2_1(\n",
+    "    valence=state.V,\n",
+    "    arousal=state.A,\n",
+    "    amplitude=state.A * 10.0,   # arousal-to-amplitude scaling\n",
+    "    time_delta=0.1,\n",
+    "    gamma=0.15,\n",
+    "    stability=state.stability,\n",
+    "    entropy=state.H,\n",
+    "    w_c=0.6,                    # cognitive weight\n",
+    "    w_p=0.4,                    # physical weight\n",
+    ")\n",
+    "\n",
+    "for k, v in phi.items():\n",
+    "    print(f\"  {k:<18} {v:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b49571f1",
+   "metadata": {},
+   "source": [
+    "## 3. Determinism check\n",
+    "\n",
+    "If anything in the substrate were stochastic, the next cell would print a\n",
+    "number greater than 1. It will print exactly `1`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9f7fe8be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T10:54:02.688337Z",
+     "iopub.status.busy": "2026-05-01T10:54:02.688242Z",
+     "iopub.status.idle": "2026-05-01T10:54:02.700144Z",
+     "shell.execute_reply": "2026-05-01T10:54:02.699795Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "unique Φ values across 100 runs: 1\n",
+      "Φ = 1.065914479372\n"
+     ]
+    }
+   ],
+   "source": [
+    "inputs = dict(\n",
+    "    valence=0.5, arousal=0.7, amplitude=5.0, time_delta=1.0,\n",
+    "    gamma=0.15, stability=0.9, entropy=0.3, w_c=0.75, w_p=0.25,\n",
+    ")\n",
+    "unique = {round(calculate_phi_v2_1(**inputs)[\"phi\"], 12) for _ in range(100)}\n",
+    "print(f\"unique Φ values across 100 runs: {len(unique)}\")\n",
+    "print(f\"Φ = {next(iter(unique))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e3cd33b",
+   "metadata": {},
+   "source": [
+    "## 4. Kill switch\n",
+    "\n",
+    "`KillSwitch` is the runtime safety primitive. It is **fail-closed** — any\n",
+    "evaluation error or out-of-band signal puts the agent into a locked\n",
+    "state that no prompt can talk past.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e466f3c0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T10:54:02.701204Z",
+     "iopub.status.busy": "2026-05-01T10:54:02.701077Z",
+     "iopub.status.idle": "2026-05-01T10:54:02.713262Z",
+     "shell.execute_reply": "2026-05-01T10:54:02.712982Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "KILL SWITCH TRIGGERED: ethics_max_risk_exceeded — Ethics max risk 0.970 exceeds threshold 0.95\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "initial state: armed  (armed = ready to fire if needed)\n",
+      "\n",
+      "healthy turn → triggered=False\n",
+      "ethics 0.97   → triggered=True  trigger=ethics_max_risk_exceeded\n"
+     ]
+    }
+   ],
+   "source": [
     "ks = KillSwitch()\n",
-    "print(f\"Kill Switch active: {ks.is_active()}\")\n",
-    "print(f\"Kill Switch can be disabled without audit: False (enforced by design)\")\n",
+    "print(f\"initial state: {ks.state.value}  (armed = ready to fire if needed)\")\n",
     "\n",
-    "# The key principle: these gates run BEFORE the response is built,\n",
-    "# not as post-hoc filters on generated text."
+    "# A healthy turn: low ethics risk, high meta-trust, no drift.\n",
+    "ok = ks.evaluate(ethics_max_risk=0.10, t_meta=0.85, drift_detected=False, turn_id=1)\n",
+    "print(f\"\\nhealthy turn → triggered={ok.triggered}\")\n",
+    "\n",
+    "# A catastrophic ethics signal trips the gate.\n",
+    "trip = ks.evaluate(ethics_max_risk=0.97, t_meta=0.8, turn_id=2)\n",
+    "print(f\"ethics 0.97   → triggered={trip.triggered}  trigger={trip.trigger.value}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "6410a1bc",
    "metadata": {},
    "source": [
-    "## 6. Profile Management\n",
+    "## 5. The 46-block canonical pipeline\n",
     "\n",
-    "Phionyx supports configurable profiles for different use cases.\n",
-    "Each profile adjusts physics parameters and governance thresholds."
+    "The pipeline contract is data, not code — versioned and inspectable. The\n",
+    "current contract is v3.8.0, 46 blocks. Each block declares a determinism\n",
+    "class (`strict`, `seeded`, or `noisy_sensor`).\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "ffc538f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T10:54:02.714482Z",
+     "iopub.status.busy": "2026-05-01T10:54:02.714391Z",
+     "iopub.status.idle": "2026-05-01T10:54:02.728994Z",
+     "shell.execute_reply": "2026-05-01T10:54:02.728562Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "canonical blocks (v3.8.0): 46\n",
+      "\n",
+      "first five (perception side):\n",
+      "   1. kill_switch_gate\n",
+      "   2. time_update_sot\n",
+      "   3. input_safety_gate\n",
+      "   4. intent_classification\n",
+      "   5. context_retrieval_rag\n",
+      "\n",
+      "last five (reflect / commit side):\n",
+      "  42. response_build\n",
+      "  43. memory_consolidation\n",
+      "  44. audit_layer\n",
+      "  45. outcome_feedback\n",
+      "  46. learning_gate\n"
+     ]
+    }
+   ],
    "source": [
-    "from phionyx_core import ProfileManager\n",
+    "blocks = get_canonical_blocks()\n",
+    "print(f\"canonical blocks (v3.8.0): {len(blocks)}\\n\")\n",
     "\n",
-    "manager = ProfileManager()\n",
-    "print(f\"Available profile types: edu, game, clinical\")\n",
-    "print(f\"\\nEach profile configures:\")\n",
-    "print(f\"  - Physics parameters (damping, resonance weights)\")\n",
-    "print(f\"  - Governance thresholds (safety sensitivity)\")\n",
-    "print(f\"  - Memory policies (retention, eviction)\")\n",
-    "print(f\"  - Pipeline block policies (which blocks are active)\")"
+    "print(\"first five (perception side):\")\n",
+    "for i, b in enumerate(blocks[:5], start=1):\n",
+    "    print(f\"  {i:>2}. {b}\")\n",
+    "\n",
+    "print(\"\\nlast five (reflect / commit side):\")\n",
+    "for i, b in enumerate(blocks[-5:], start=len(blocks) - 4):\n",
+    "    print(f\"  {i:>2}. {b}\")"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f4a81f7c",
    "metadata": {},
    "source": [
-    "## What's Next?\n",
+    "## What's next\n",
     "\n",
-    "- **Full pipeline execution:** See `EchoOrchestrator.execute_pipeline()` for end-to-end processing\n",
-    "- **Memory system:** Explore semantic time-based cache eviction in `phionyx_core.memory`\n",
-    "- **Evaluation:** Apply the [Phionyx Evaluation Standard](https://github.com/halvrenofviryel/phionyx-evaluation-standard) to your own AI systems\n",
-    "- **Research paper:** Read the [architecture paper](https://phionyx.ai/papers/phionyx) for formal proofs and benchmarks\n",
+    "You've seen the substrate. The other notebooks go deeper:\n",
     "\n",
-    "---\n",
+    "- [`01_determinism_and_physics.ipynb`](01_determinism_and_physics.ipynb) — 1000-run determinism proof, valence × arousal Φ heatmap, side-by-side with a noisy alternative.\n",
+    "- [`02_kill_switch_in_action.ipynb`](02_kill_switch_in_action.ipynb) — all four kill-switch triggers, NaN fail-closed guard, tamper-evident event log.\n",
+    "- [`03_pipeline_blocks_and_audit.ipynb`](03_pipeline_blocks_and_audit.ipynb) — implement and run a custom `PipelineBlock`.\n",
     "\n",
-    "*Phionyx Core SDK v0.2.0 — AGPL-3.0 | [GitHub](https://github.com/halvrenofviryel/phionyx-research) | [phionyx.ai](https://phionyx.ai)*"
+    "For the orchestrator path (governance pipeline + LLM provider), see\n",
+    "[`examples/fastapi/`](../fastapi/).\n",
+    "\n",
+    "Architecture deep dive: [Phionyx README](https://github.com/halvrenofviryel/phionyx-research#readme).\n",
+    "\n",
+    "Thanks for trying it.\n"
    ]
   }
  ],
@@ -246,10 +351,18 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Old notebook had three broken / stale sections that blocked a clean end-to-end run on a fresh `pip install phionyx-core`:

- cell 6 imported `calculate_text_entropy_zlib` from `phionyx_core.physics.formulas` — symbol does not exist.
- cell 10 called `KillSwitch.is_active()` — not a real method (actual API is `is_armed`/`is_triggered` properties + `state.value`).
- cell 12 used `ProfileManager()` with no profile file, which raises.
- cell 0 still pointed at `git clone + pip install -e .` instead of `pip install phionyx-core`.

## Replacement

Tighter 14-cell flow, runs end-to-end in **under 30 seconds**, uses only verified public-API symbols.

| # | What |
|---|------|
| 0 | Title, 5-min promise, `pip install phionyx-core` |
| 1-2 | Imports + version print |
| 3-4 | `EchoState2` — primary attrs + derived resonance/stability |
| 5-6 | `calculate_phi_v2_1` full result dict |
| 7-8 | Determinism check (100 runs → 1 unique value) |
| 9-10 | `KillSwitch` — armed → healthy → ethics trigger, locked state |
| 11-12 | `get_canonical_blocks()` — 46 blocks, first/last 5 |
| 13 | What's next — links to notebooks 01/02/03 + FastAPI |

## Verification

```
$ jupyter nbconvert --to notebook --execute --inplace examples/notebooks/phionyx_quickstart.ipynb
cells=14 errors=0
phionyx_core: 0.2.1
unique Φ values across 100 runs: 1
canonical blocks (v3.8.0): 46
```

Closes #10 (Demo Experience milestone).