### PR TITLE
examples: governed-response envelope notebook + sample JSON (closes #1)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,20 +4,22 @@ Practical examples demonstrating the Phionyx Core SDK.
 
 ## Notebooks
 
-| Notebook | Description |
-|----------|-------------|
-| [phionyx_quickstart.ipynb](notebooks/phionyx_quickstart.ipynb) | Core concepts: state vector, Phi, entropy, pipeline, safety gates |
-| [01_determinism_and_physics.ipynb](notebooks/01_determinism_and_physics.ipynb) | `EchoState2`, `calculate_phi_v2_1`, 1000-run determinism proof, valence × arousal heatmap, side-by-side with a noisy alternative |
-| [02_kill_switch_in_action.ipynb](notebooks/02_kill_switch_in_action.ipynb) | `KillSwitch` with the four documented triggers (ethics, T_meta, sustained drift, NaN fail-closed) and the tamper-evident event log |
-| [03_pipeline_blocks_and_audit.ipynb](notebooks/03_pipeline_blocks_and_audit.ipynb) | Canonical 46-block pipeline (v3.8.0), a custom `PipelineBlock` subclass, 100-run determinism check |
+| Notebook | Description | Run time |
+|----------|-------------|----------|
+| [phionyx_quickstart.ipynb](notebooks/phionyx_quickstart.ipynb) | "Hello Phionyx" — state vector, Φ, determinism check, kill switch, 46-block pipeline | <30 s |
+| [01_determinism_and_physics.ipynb](notebooks/01_determinism_and_physics.ipynb) | `EchoState2`, `calculate_phi_v2_1`, 1000-run determinism proof, valence × arousal Φ heatmap, side-by-side with a noisy alternative | ~30 s |
+| [02_kill_switch_in_action.ipynb](notebooks/02_kill_switch_in_action.ipynb) | `KillSwitch` with the four documented triggers + NaN fail-closed guard, tamper-evident event log | ~5 s |
+| [03_pipeline_blocks_and_audit.ipynb](notebooks/03_pipeline_blocks_and_audit.ipynb) | Canonical 46-block pipeline (v3.8.0), custom `PipelineBlock` subclass, 100-run determinism check | ~5 s |
+| [04_governed_envelope.ipynb](notebooks/04_governed_envelope.ipynb) | Build a governed-response envelope end-to-end (input safety → state → Φ → kill switch → narrative → tamper-evident hash). Produces [`envelopes/governed_response.json`](envelopes/governed_response.json) | <5 s |
 
-Each of the three demo notebooks runs end-to-end in seconds and embeds verified outputs.
+Every notebook runs end-to-end on a fresh `pip install phionyx-core`. No LLM, no API key.
 
 ## Integration Examples
 
 | Example | Description | Status |
 |---------|-------------|--------|
-| [FastAPI](fastapi/) | HTTP endpoint wrapping the governance pipeline | Planned |
+| [FastAPI](fastapi/) | HTTP `/govern` endpoint over the governance pipeline | Planned |
+| [`envelopes/governed_response.json`](envelopes/governed_response.json) | Canonical governed-response envelope sample (output of notebook 04) | Reference |
 
 ## Running Notebooks
 

--- a/examples/envelopes/governed_response.json
+++ b/examples/envelopes/governed_response.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "phionyx-governed-response/0.1",
+  "phionyx_core_version": "0.2.1",
+  "turn_id": 1,
+  "timestamp_utc": "2026-05-01T00:00:00+00:00",
+  "input": {
+    "user_text": "Walk me through the three layers Phionyx runs around an LLM.",
+    "safety": {
+      "allowed": true,
+      "reason": null
+    }
+  },
+  "state": {
+    "arousal": 0.4,
+    "valence": 0.2,
+    "entropy": 0.22,
+    "resonance": 0.32,
+    "stability": 0.78
+  },
+  "phi": {
+    "phi": 0.751476,
+    "phi_cognitive": 0.201674,
+    "phi_physical": 1.576179,
+    "weight_cognitive": 0.6,
+    "weight_physical": 0.4
+  },
+  "governance": {
+    "kill_switch_state": "armed",
+    "kill_switch_triggered": false,
+    "kill_switch_reason": "All safety checks passed",
+    "ethics_max_risk": 0.1,
+    "t_meta": 0.85,
+    "drift_detected": false
+  },
+  "response": {
+    "text": "(synthetic) You asked about Phionyx layers. \u03a6 = 0.751; the runtime resolved this turn through the deterministic substrate, the governance gates, and the audit layer.",
+    "narrative_layer": "synthetic_echo"
+  },
+  "pipeline": {
+    "contract_version": "3.8.0",
+    "block_count": 46
+  },
+  "audit": {
+    "hash_alg": "sha256",
+    "envelope_hash": "b3ea0af3e3efba99a4cb8da957afd3007ad6e65b7919b7981ba0d7e2f59ce41d"
+  }
+}

--- a/examples/notebooks/04_governed_envelope.ipynb
+++ b/examples/notebooks/04_governed_envelope.ipynb
@@ -1,0 +1,564 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0d235da9",
+   "metadata": {},
+   "source": [
+    "# 04 — Governed Output Envelope\n",
+    "\n",
+    "A **governed response** in Phionyx is not just text — it is a structured\n",
+    "artifact that carries the provenance of how it was produced: which gates\n",
+    "ran, what state the runtime was in, which kill-switch checks fired, and\n",
+    "a tamper-evident audit hash. Anything downstream (a frontend, a compliance\n",
+    "log, a human reviewer) can verify the response against this envelope.\n",
+    "\n",
+    "This notebook builds one **without an LLM**. The narrative cell uses a\n",
+    "deterministic placeholder so the whole flow runs in seconds on a fresh\n",
+    "`pip install phionyx-core`. In production the placeholder is replaced by\n",
+    "a real model — the rest of the envelope shape is identical.\n",
+    "\n",
+    "**Public API used:** `EchoState2`, `calculate_phi_v2_1`,\n",
+    "`calculate_phi_cognitive`, `KillSwitch`, `get_canonical_blocks`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d99ffd09",
+   "metadata": {},
+   "source": [
+    "## 1. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d67fb6e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:21.481295Z",
+     "iopub.status.busy": "2026-05-01T11:02:21.481206Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.006005Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.005602Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "phionyx_core: 0.2.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "import hashlib\n",
+    "import json\n",
+    "from datetime import datetime, timezone\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import phionyx_core\n",
+    "from phionyx_core import (\n",
+    "    EchoState2,\n",
+    "    calculate_phi_v2_1,\n",
+    "    calculate_phi_cognitive,\n",
+    ")\n",
+    "from phionyx_core.governance.kill_switch import KillSwitch\n",
+    "from phionyx_core.contracts.telemetry import get_canonical_blocks\n",
+    "\n",
+    "print(\"phionyx_core:\", phionyx_core.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ac46fca",
+   "metadata": {},
+   "source": [
+    "## 2. Input + safety gate\n",
+    "\n",
+    "A safety gate is a deterministic function — no model, no fuzziness. It\n",
+    "rejects a known blocklist and flags inputs that fail length / charset\n",
+    "sanity. In the canonical pipeline this runs at position 3\n",
+    "(`input_safety_gate`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "80039506",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.007221Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.007054Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.009983Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.009601Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'allowed': True, 'reason': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "USER_INPUT = \"Walk me through the three layers Phionyx runs around an LLM.\"\n",
+    "\n",
+    "BLOCKED_PATTERNS = [\"ignore previous instructions\", \"system prompt\"]\n",
+    "\n",
+    "def input_safety_gate(text: str) -> dict:\n",
+    "    text_lower = text.lower()\n",
+    "    matched = [p for p in BLOCKED_PATTERNS if p in text_lower]\n",
+    "    if matched:\n",
+    "        return {\"allowed\": False, \"reason\": f\"blocked patterns: {matched}\"}\n",
+    "    if not text.strip() or len(text) > 4000:\n",
+    "        return {\"allowed\": False, \"reason\": \"length out of range\"}\n",
+    "    return {\"allowed\": True, \"reason\": None}\n",
+    "\n",
+    "safety = input_safety_gate(USER_INPUT)\n",
+    "print(safety)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea067050",
+   "metadata": {},
+   "source": [
+    "## 3. Build a state vector from input heuristics\n",
+    "\n",
+    "In a real run the state vector is updated by upstream blocks (sentiment,\n",
+    "arousal estimation, prior-turn memory). Here we derive a plausible state\n",
+    "from string heuristics so the demo is self-contained and deterministic.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f7de6b38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.011043Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.010960Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.024028Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.023699Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "state  A=0.4  V=0.2  H=0.22\n",
+      "derived  resonance=0.320  stability=0.780\n"
+     ]
+    }
+   ],
+   "source": [
+    "def state_from_input(text: str) -> EchoState2:\n",
+    "    # Cheap deterministic features.\n",
+    "    word_count = len(text.split())\n",
+    "    has_question = \"?\" in text\n",
+    "    has_negative = any(w in text.lower() for w in [\"hate\", \"angry\", \"broken\", \"bad\"])\n",
+    "\n",
+    "    arousal = min(1.0, 0.4 + 0.05 * has_question + 0.02 * (word_count > 12))\n",
+    "    valence = -0.4 if has_negative else 0.2\n",
+    "    entropy = max(0.1, min(0.6, word_count / 50.0))\n",
+    "\n",
+    "    return EchoState2(A=arousal, V=valence, H=entropy)\n",
+    "\n",
+    "\n",
+    "state = state_from_input(USER_INPUT)\n",
+    "print(f\"state  A={state.A}  V={state.V}  H={state.H}\")\n",
+    "print(f\"derived  resonance={state.resonance:.3f}  stability={state.stability:.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "381ac5f6",
+   "metadata": {},
+   "source": [
+    "## 4. Φ + entropy from physics\n",
+    "\n",
+    "Standard `calculate_phi_v2_1`. The `phi_cognitive` floor (Base Life\n",
+    "Support) is what stops a high-stress / negative-valence input from\n",
+    "collapsing the runtime to zero.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4174ef50",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.025111Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.025025Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.040594Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.040207Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Φ components:\n",
+      "  phi                0.7515\n",
+      "  phi_cognitive      0.2017\n",
+      "  phi_physical       1.5762\n",
+      "  weight_cognitive   0.6000\n",
+      "  weight_physical    0.4000\n"
+     ]
+    }
+   ],
+   "source": [
+    "phi = calculate_phi_v2_1(\n",
+    "    valence=state.V,\n",
+    "    arousal=state.A,\n",
+    "    amplitude=state.A * 10.0,\n",
+    "    time_delta=0.1,\n",
+    "    gamma=0.15,\n",
+    "    stability=state.stability,\n",
+    "    entropy=state.H,\n",
+    "    w_c=0.6,\n",
+    "    w_p=0.4,\n",
+    ")\n",
+    "\n",
+    "print(\"Φ components:\")\n",
+    "for k, v in phi.items():\n",
+    "    print(f\"  {k:<18} {v:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e8866cd",
+   "metadata": {},
+   "source": [
+    "## 5. Kill-switch evaluation\n",
+    "\n",
+    "Even with a synthetic narrative cell below, the kill-switch evaluation is\n",
+    "real. Inputs are bounded scalars, outputs are deterministic.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "572f805d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.041674Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.041556Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.051448Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.050959Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "kill switch state: armed\n",
+      "triggered:         False\n",
+      "reason:            All safety checks passed\n"
+     ]
+    }
+   ],
+   "source": [
+    "ks = KillSwitch()\n",
+    "ks_result = ks.evaluate(\n",
+    "    ethics_max_risk=0.10,        # placeholder for the ethics gate output\n",
+    "    t_meta=0.85,                 # meta-cognitive trust\n",
+    "    drift_detected=False,\n",
+    "    turn_id=1,\n",
+    ")\n",
+    "\n",
+    "print(f\"kill switch state: {ks.state.value}\")\n",
+    "print(f\"triggered:         {ks_result.triggered}\")\n",
+    "print(f\"reason:            {ks_result.reason}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fe69b82",
+   "metadata": {},
+   "source": [
+    "## 6. Narrative layer — placeholder\n",
+    "\n",
+    "In production this cell calls the LLM. For demo purposes we use a\n",
+    "deterministic echo so the notebook output is reproducible and so the\n",
+    "envelope shape can be verified without a model dependency.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "eee7d364",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.052468Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.052353Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.063181Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.062780Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(synthetic) You asked about Phionyx layers. Φ = 0.751; the runtime resolved this turn through the deterministic substrate, the governance gates, and the audit layer.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def narrative_layer_synthetic(user_input: str, phi_total: float) -> str:\n",
+    "    return (\n",
+    "        f\"(synthetic) You asked about Phionyx layers. Φ = {phi_total:.3f}; \"\n",
+    "        \"the runtime resolved this turn through the deterministic substrate, \"\n",
+    "        \"the governance gates, and the audit layer.\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "response_text = narrative_layer_synthetic(USER_INPUT, phi[\"phi\"])\n",
+    "print(response_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26489da3",
+   "metadata": {},
+   "source": [
+    "## 7. Build the governed envelope\n",
+    "\n",
+    "The envelope is a flat, JSON-serialisable dict that captures every piece\n",
+    "the demo just produced. In production this would be a Pydantic schema\n",
+    "with validation; here a plain dict keeps the shape transparent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "917bb1af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.064522Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.064437Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.075995Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.075687Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"schema_version\": \"phionyx-governed-response/0.1\",\n",
+      "  \"phionyx_core_version\": \"0.2.1\",\n",
+      "  \"turn_id\": 1,\n",
+      "  \"timestamp_utc\": \"2026-05-01T00:00:00+00:00\",\n",
+      "  \"input\": {\n",
+      "    \"user_text\": \"Walk me through the three layers Phionyx runs around an LLM.\",\n",
+      "    \"safety\": {\n",
+      "      \"allowed\": true,\n",
+      "      \"reason\": null\n",
+      "    }\n",
+      "  },\n",
+      "  \"state\": {\n",
+      "    \"arousal\": 0.4,\n",
+      "    \"valence\": 0.2,\n",
+      "    \"entropy\": 0.22,\n",
+      "    \"resonance\": 0.32,\n",
+      "    \"stability\": 0.78\n",
+      "  },\n",
+      "  \"phi\": {\n",
+      "    \"phi\": 0.751476,\n",
+      "    \"phi_cognitive\": 0.201674,\n",
+      "    \"phi_physical\": 1.576179,\n",
+      "    \"weight_cognitive\": 0.6,\n",
+      "    \"weight_physical\": 0.4\n",
+      "  },\n",
+      "  \"governance\": {\n",
+      "    \"kill_switch_state\": \"armed\",\n",
+      "    \"kill_switch_triggered\": false,\n",
+      "    \"kill_switch_reason\": \"All safety checks passed\",\n",
+      "    \"ethics_max_risk\": 0.1,\n",
+      "    \"t_meta\": 0.85,\n",
+      "    \"drift_detected\": false\n",
+      "  },\n",
+      "  \"response\": {\n",
+      "    \"text\": \"(synthetic) You asked about Phionyx layers. \\u03a6 = 0.751; the runtime resolved this turn through the deterministic substrate, the governance gates, and the audit layer.\",\n",
+      "    \"narrative_layer\": \"synthetic_echo\"\n",
+      "  },\n",
+      "  \"pipeline\": {\n",
+      "    \"contract_version\": \"3.8.0\",\n",
+      "    \"block_count\": 46\n",
+      "  },\n",
+      "  \"audit\": {\n",
+      "    \"hash_alg\": \"sha256\",\n",
+      "    \"envelope_hash\": \"b3ea0af3e3efba99a4cb8da957afd3007ad6e65b7919b7981ba0d7e2f59ce41d\"\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def audit_hash(payload: dict) -> str:\n",
+    "    # Canonical JSON, then SHA-256. In production: Ed25519-signed\n",
+    "    # AuditRecord with hash chain to prior turn.\n",
+    "    canonical = json.dumps(payload, sort_keys=True, separators=(',', ':')).encode(\"utf-8\")\n",
+    "    return hashlib.sha256(canonical).hexdigest()\n",
+    "\n",
+    "\n",
+    "timestamp = datetime(2026, 5, 1, 0, 0, 0, tzinfo=timezone.utc).isoformat()\n",
+    "\n",
+    "envelope = {\n",
+    "    \"schema_version\": \"phionyx-governed-response/0.1\",\n",
+    "    \"phionyx_core_version\": phionyx_core.__version__,\n",
+    "    \"turn_id\": 1,\n",
+    "    \"timestamp_utc\": timestamp,\n",
+    "    \"input\": {\n",
+    "        \"user_text\": USER_INPUT,\n",
+    "        \"safety\": safety,\n",
+    "    },\n",
+    "    \"state\": {\n",
+    "        \"arousal\": state.A,\n",
+    "        \"valence\": state.V,\n",
+    "        \"entropy\": state.H,\n",
+    "        \"resonance\": round(state.resonance, 6),\n",
+    "        \"stability\": round(state.stability, 6),\n",
+    "    },\n",
+    "    \"phi\": {k: round(v, 6) for k, v in phi.items()},\n",
+    "    \"governance\": {\n",
+    "        \"kill_switch_state\": ks.state.value,\n",
+    "        \"kill_switch_triggered\": ks_result.triggered,\n",
+    "        \"kill_switch_reason\": ks_result.reason,\n",
+    "        \"ethics_max_risk\": 0.10,\n",
+    "        \"t_meta\": 0.85,\n",
+    "        \"drift_detected\": False,\n",
+    "    },\n",
+    "    \"response\": {\n",
+    "        \"text\": response_text,\n",
+    "        \"narrative_layer\": \"synthetic_echo\",\n",
+    "    },\n",
+    "    \"pipeline\": {\n",
+    "        \"contract_version\": \"3.8.0\",\n",
+    "        \"block_count\": len(get_canonical_blocks()),\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "# Audit hash is the SHA-256 of everything above. Include it last so it\n",
+    "# covers the rest of the envelope deterministically.\n",
+    "envelope[\"audit\"] = {\n",
+    "    \"hash_alg\": \"sha256\",\n",
+    "    \"envelope_hash\": audit_hash(envelope),\n",
+    "}\n",
+    "\n",
+    "print(json.dumps(envelope, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd77641d",
+   "metadata": {},
+   "source": [
+    "## 8. Persist + verify\n",
+    "\n",
+    "The envelope is saved to `examples/envelopes/governed_response.json`.\n",
+    "Re-loading and re-hashing must produce the same digest — that's the\n",
+    "tamper-evident property in miniature.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "bac1c275",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-01T11:02:22.077259Z",
+     "iopub.status.busy": "2026-05-01T11:02:22.077171Z",
+     "iopub.status.idle": "2026-05-01T11:02:22.089638Z",
+     "shell.execute_reply": "2026-05-01T11:02:22.089324Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "wrote /tmp/phionyx-research/examples/envelopes/governed_response.json\n",
+      "saved hash      : b3ea0af3e3efba99a4cb8da957afd3007ad6e65b7919b7981ba0d7e2f59ce41d\n",
+      "recomputed hash : b3ea0af3e3efba99a4cb8da957afd3007ad6e65b7919b7981ba0d7e2f59ce41d\n",
+      "\n",
+      "verified: envelope is intact\n"
+     ]
+    }
+   ],
+   "source": [
+    "out_path = Path(\"../envelopes/governed_response.json\")\n",
+    "out_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "out_path.write_text(json.dumps(envelope, indent=2) + \"\\n\", encoding=\"utf-8\")\n",
+    "print(f\"wrote {out_path.resolve()}\")\n",
+    "\n",
+    "# Verify round trip.\n",
+    "loaded = json.loads(out_path.read_text(encoding=\"utf-8\"))\n",
+    "saved_hash = loaded.pop(\"audit\")[\"envelope_hash\"]\n",
+    "recomputed = audit_hash(loaded)\n",
+    "print(f\"saved hash      : {saved_hash}\")\n",
+    "print(f\"recomputed hash : {recomputed}\")\n",
+    "assert saved_hash == recomputed, \"audit hash drift — envelope was tampered with\"\n",
+    "print(\"\\nverified: envelope is intact\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d96ba419",
+   "metadata": {},
+   "source": [
+    "## What this proves\n",
+    "\n",
+    "- The envelope shape is reproducible from the public API.\n",
+    "- Every governance decision (safety gate, kill switch, Φ) is captured\n",
+    "  alongside the response, not behind it.\n",
+    "- A tamper-evident hash covers the whole envelope deterministically.\n",
+    "- None of this requires an LLM call. The narrative cell is a synthetic\n",
+    "  placeholder; replacing it with a real model leaves the rest of the\n",
+    "  envelope shape unchanged.\n",
+    "\n",
+    "In production:\n",
+    "\n",
+    "- Replace the synthetic narrative with an LLM provider.\n",
+    "- Replace the SHA-256 hash with `phionyx_core.contracts.v4.audit_record.AuditRecord`,\n",
+    "  which adds Ed25519 signing and a chain reference to the previous turn.\n",
+    "- Replace the dict with a Pydantic schema (versioned via\n",
+    "  `schema_version`).\n",
+    "\n",
+    "The committed sample at\n",
+    "[`examples/envelopes/governed_response.json`](../envelopes/governed_response.json)\n",
+    "is the exact output of this notebook on `phionyx-core 0.2.1`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #1 (Demo Experience milestone). Adds a fourth demo notebook that builds the governed-output envelope end-to-end and persists a canonical sample.

## `examples/notebooks/04_governed_envelope.ipynb` (18 cells, runs <5 s)

1. Imports + version print.
2. **Input safety gate** — deterministic blocklist + length/charset sanity. Mirrors the canonical pipeline's `input_safety_gate` (position 3).
3. **State vector** from string heuristics so the demo is LLM-free; in production `EchoState2` is updated by upstream blocks.
4. `calculate_phi_v2_1` — full result dict.
5. **Kill switch** evaluation (real, not synthetic) with placeholder `ethics_max_risk` and `t_meta` scalars.
6. **Narrative cell** — explicit synthetic placeholder. The notebook calls this out as the only piece a real model replaces.
7. **Envelope construction** — flat JSON-serialisable dict capturing input, safety, state, Φ, governance, response, and a SHA-256 audit hash covering the rest of the envelope deterministically.
8. **Persist + verify** — round-trips the JSON and re-hashes; asserts intact.

Ends with what to swap for production: real LLM in the narrative cell, `AuditRecord` (Ed25519 + chain ref) instead of plain SHA-256, Pydantic schema instead of dict.

## `examples/envelopes/governed_response.json`

Frozen sample produced by the notebook on `phionyx-core 0.2.1`. Treat as the reference shape; downstream consumers can validate against it without running the notebook.

## `examples/README.md`

Notebook table gains a **Run time** column and the new notebook 04 row. Integration table references the sample envelope JSON. Headline now says "no LLM, no API key" — the demo path this PR completes.

## Verification

```
$ jupyter nbconvert --to notebook --execute --inplace examples/notebooks/04_governed_envelope.ipynb
cells=18 errors=0
audit hash verified: envelope intact
```