### PR TITLE
examples: profile config YAMLs for 3 personas (closes #11)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ Every notebook runs end-to-end on a fresh `pip install phionyx-core`. No LLM, no
 |---------|-------------|--------|
 | [FastAPI](fastapi/) | HTTP `/govern` endpoint over the governance pipeline | Planned |
 | [`envelopes/governed_response.json`](envelopes/governed_response.json) | Canonical governed-response envelope sample (output of notebook 04) | Reference |
+| [`profiles/`](profiles/) | Three runnable profile YAMLs — `education`, `creative_writing`, `customer_support`. All validate against `phionyx_core.Profile` | Reference |
 
 ## Running Notebooks
 

--- a/examples/profiles/README.md
+++ b/examples/profiles/README.md
@@ -1,0 +1,42 @@
+# Example Profiles
+
+Three runnable profile YAMLs covering common deployment shapes:
+
+| File | Persona | Notable dials |
+|------|---------|---------------|
+| [`education.yaml`](education.yaml) | School / EdTech / tutoring | `BaseMode=SCHOOL`, `pii_mode=FULL`, `audit_level=VERBOSE`, `entropy_penalty_k=1.2`, `safety_bias=0.85` |
+| [`creative_writing.yaml`](creative_writing.yaml) | Fiction, brainstorming, editorial | `entropy=0.55`, `entropy_penalty_k=0.8`, `pii_mode=PARTIAL`, `routing=BALANCED` |
+| [`customer_support.yaml`](customer_support.yaml) | B2B/B2C support agents | `pii_mode=FULL`, `audit_level=VERBOSE`, `routing=COST_OPTIMIZED` |
+
+## Why these three
+
+They occupy three different points in the safety / freedom / cost cube:
+
+- **Education** — strict and quiet. Strong PII scrubbing, verbose audit
+  for compliance regimes (KCSIE-style retention), low entropy so the
+  language stays predictable.
+- **Creative writing** — the only profile that asks for *more* entropy.
+  Safety gates still run; this profile only relaxes tone and physics
+  dampening.
+- **Customer support** — full audit, full PII scrubbing, cost-optimized
+  routing because volume usually beats per-turn quality budget.
+
+## Validate
+
+```python
+import yaml
+from phionyx_core import Profile
+
+profile = Profile.model_validate(yaml.safe_load(open("examples/profiles/education.yaml")))
+print(profile.name, profile.governance.audit_level, profile.routing.llm_tier_strategy)
+# education_default VERBOSE QUALITY_OPTIMIZED
+```
+
+All three files validate cleanly against `phionyx_core.Profile`.
+
+## Dial-by-dial map
+
+For the full surface (every field, every range), see
+[`phionyx_core/profiles/schema.py`](../../phionyx_core/profiles/schema.py).
+The configs here only set the dials that *differ* between profiles —
+everything else falls back to the schema's documented defaults.

--- a/examples/profiles/creative_writing.yaml
+++ b/examples/profiles/creative_writing.yaml
@@ -1,0 +1,51 @@
+# Creative writing profile — relaxed entropy, stylistic range allowed,
+# audit standard but PII scrubbing only partial.
+#
+# Use for fiction tools, brainstorming assistants, editorial drafting.
+# The user wants surprise and texture, so reactivity is higher and the
+# entropy penalty is lighter. Safety is not disarmed — kill switch and
+# ethics gates still run — but the tone-shaping dials make room for
+# voice.
+
+name: creative_writing
+description: |
+  Profile for fiction, brainstorming, and editorial assistants.
+  Permits higher entropy and stylistic range. Safety gates remain
+  enabled; this profile only relaxes tone and physics-side dampening.
+
+physics:
+  reactivity: 0.65         # responsive to provocations / mood shifts
+  resilience: 0.5          # average — let the prose breathe
+  safety_bias: 0.5         # neutral — gates do the safety work
+  base_mode: DEFAULT
+
+  valence: 0.0             # let the writer set it
+  arousal: 0.6             # mid-high — warmth without spike
+  amplitude: 6.0
+  entropy: 0.55            # higher — variety is the point
+
+  stability: 0.6
+  gamma: 0.20
+  w_c: 0.55                # less cognitive weight
+  w_p: 0.45                # more physical (stylistic) weight
+  entropy_penalty_k: 0.8   # softer than default — chaos is sometimes the answer
+
+pedagogy:
+  vygotsky_level: 0.5
+  scaffolding_aggressiveness: 0.3  # writers don't want hand-holding
+  intervention_threshold: 0.5      # only step in for actual harm
+
+governance:
+  policy_id: editorial
+  pii_mode: PARTIAL                # email/phone scrub; leave names alone
+  audit_level: STANDARD
+
+routing:
+  llm_tier_strategy: BALANCED
+  enable_graph_rag: false
+
+version: "1.0.0"
+tags:
+  - creative
+  - editorial
+  - relaxed-entropy

--- a/examples/profiles/customer_support.yaml
+++ b/examples/profiles/customer_support.yaml
@@ -1,0 +1,50 @@
+# Customer support profile — balanced physics, full audit, deterministic
+# routing.
+#
+# Use for B2B/B2C support assistants where every turn may be reviewed.
+# Audit is verbose, PII scrubbing is FULL (queries often include
+# customer identifiers), and routing is COST_OPTIMIZED — quality matters
+# but volume is usually higher than in a single classroom.
+
+name: customer_support
+description: |
+  Profile for customer-support assistants. Verbose audit, FULL PII
+  scrubbing, cost-optimized routing. Physics is balanced so the agent
+  can match a friendly tone without drifting into excitement.
+
+physics:
+  reactivity: 0.45
+  resilience: 0.7
+  safety_bias: 0.7
+  base_mode: DEFAULT
+
+  valence: 0.2             # mildly positive — warm but not effusive
+  arousal: 0.45
+  amplitude: 5.0
+  entropy: 0.35
+
+  stability: 0.8
+  gamma: 0.15
+  w_c: 0.7
+  w_p: 0.3
+  entropy_penalty_k: 1.0
+
+pedagogy:
+  vygotsky_level: 0.4              # explain enough but don't lecture
+  scaffolding_aggressiveness: 0.4
+  intervention_threshold: 0.45
+
+governance:
+  policy_id: support_default
+  pii_mode: FULL                   # ticket bodies often contain PII
+  audit_level: VERBOSE             # every turn is review-able
+
+routing:
+  llm_tier_strategy: COST_OPTIMIZED
+  enable_graph_rag: false
+
+version: "1.0.0"
+tags:
+  - customer-support
+  - b2b
+  - audit-heavy

--- a/examples/profiles/education.yaml
+++ b/examples/profiles/education.yaml
@@ -1,0 +1,51 @@
+# Education profile — strict safety + privacy, calm physics, audit-heavy.
+#
+# Use when the target audience includes minors, schools, or supervised
+# learning environments. The dial choices below are conservative on
+# purpose: low arousal floor, high stability, FULL PII scrubbing,
+# VERBOSE audit, QUALITY_OPTIMIZED routing (fewer hallucinations matter
+# more than cost).
+
+name: education_default
+description: |
+  Educational profile for K-12, EdTech platforms, and tutoring tools.
+  Conservative defaults: low cognitive arousal, FULL PII scrubbing,
+  VERBOSE audit logs, quality-optimized model routing.
+
+physics:
+  reactivity: 0.2          # low — don't react sharply to provocations
+  resilience: 0.9          # high — maintain steady tone under pressure
+  safety_bias: 0.85        # strict
+  base_mode: SCHOOL
+
+  # Circumplex defaults that suit a calm classroom register.
+  valence: 0.1             # slightly positive
+  arousal: 0.4             # moderate — not flat, not excited
+  amplitude: 4.0
+  entropy: 0.25            # low — predictable phrasing
+
+  stability: 0.9
+  gamma: 0.15
+  w_c: 0.75                # cognitive weight dominates
+  w_p: 0.25
+  entropy_penalty_k: 1.2   # penalise chaotic phrasing harder than default
+
+pedagogy:
+  vygotsky_level: 0.7              # closer to ZPD, plenty of scaffolding
+  scaffolding_aggressiveness: 0.6
+  intervention_threshold: 0.35     # intervene early on self-talk drift
+
+governance:
+  policy_id: school_policy
+  pii_mode: FULL                   # mask names, emails, locations
+  audit_level: VERBOSE             # KCSIE-style retention
+
+routing:
+  llm_tier_strategy: QUALITY_OPTIMIZED
+  enable_graph_rag: false          # default off in school context
+
+version: "1.0.0"
+tags:
+  - education
+  - safety-first
+  - audit-heavy


### PR DESCRIPTION
Closes #11 (Demo Experience milestone). Three runnable profile YAMLs covering common deployment shapes; each validates cleanly against `phionyx_core.Profile`.

| File | Persona | Notable dials |
|------|---------|---------------|
| `education.yaml` | School / EdTech / tutoring | `BaseMode=SCHOOL`, `reactivity=0.2`, `safety_bias=0.85`, `entropy_penalty_k=1.2`, `pii_mode=FULL`, `audit_level=VERBOSE`, `routing=QUALITY_OPTIMIZED` |
| `creative_writing.yaml` | Fiction / brainstorming / editorial | The only profile that asks for *more* entropy: `entropy=0.55`, `entropy_penalty_k=0.8`, `reactivity=0.65`, `w_p=0.45`. `pii_mode=PARTIAL`, `audit_level=STANDARD`. Safety gates remain on; only tone dials relaxed. |
| `customer_support.yaml` | B2B/B2C support agents | Balanced physics, `pii_mode=FULL` because tickets contain customer identifiers, `audit_level=VERBOSE`, `routing=COST_OPTIMIZED` for volume. |

## examples/profiles/README.md

Persona summary + notable-dial table + 6-line `Profile.model_validate` snippet so contributors can confirm a new profile YAML before stand-up.

## examples/README.md

Integration table now references `examples/profiles/`.

## Verification

```
$ python -c "import yaml; from phionyx_core import Profile; ..."
ok  creative_writing.yaml: audit=STANDARD, llm=BALANCED
ok  customer_support.yaml: audit=VERBOSE,  llm=COST_OPTIMIZED
ok  education.yaml:        audit=VERBOSE,  llm=QUALITY_OPTIMIZED
```