### PR TITLE
examples: scripts/demo.sh + tests/integration/test_pypi_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ pip install phionyx-core
 python -c "import phionyx_core; print('Phionyx Core ready —', phionyx_core.__version__)"
 ```
 
+Or one command end-to-end (fresh venv → install → smoke flow):
+
+```bash
+bash <(curl -sSL https://raw.githubusercontent.com/halvrenofviryel/phionyx-research/main/scripts/demo.sh)
+```
+
 Most AI frameworks let the LLM decide. Phionyx doesn't. Every LLM response passes through a 46-block deterministic pipeline with safety gates, ethics checks, and physics-based state tracking — before it reaches the user.
 
 The substrate is demonstrable in seconds **without an LLM, server, or API key** — see the [demo table](#try-it-in-30-seconds) below.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,9 @@ addopts = [
     "--strict-markers",
     "--tb=short",
 ]
+markers = [
+    "integration: opt-in tests that hit the network / PyPI / external services. Run with `-m integration`. Excluded from the default CI matrix.",
+]
 
 [tool.coverage.run]
 source = ["phionyx_core"]

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Phionyx — one-command local demo.
+#
+# Creates a fresh virtual environment, installs phionyx-core from PyPI,
+# then runs a short import + Φ + KillSwitch smoke flow. The point of
+# the script is that it works end-to-end on a clean machine — no
+# editable install, no source checkout, no API key.
+#
+# Usage:
+#   bash scripts/demo.sh
+#
+# Optional: override the install target (e.g. for TestPyPI smoke):
+#   PHIONYX_INSTALL_TARGET="phionyx-core==0.2.1" bash scripts/demo.sh
+#   PHIONYX_PIP_INDEX_ARGS="--index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/" \
+#     PHIONYX_INSTALL_TARGET="phionyx-core" bash scripts/demo.sh
+
+set -euo pipefail
+
+VENV="${PHIONYX_DEMO_VENV:-/tmp/phionyx-demo-venv}"
+TARGET="${PHIONYX_INSTALL_TARGET:-phionyx-core}"
+PIP_ARGS="${PHIONYX_PIP_INDEX_ARGS:-}"
+
+echo "==> creating fresh venv at ${VENV}"
+rm -rf "${VENV}"
+python3 -m venv "${VENV}"
+
+echo "==> installing ${TARGET}"
+# shellcheck disable=SC2086
+"${VENV}/bin/pip" install --quiet --upgrade pip
+# shellcheck disable=SC2086
+"${VENV}/bin/pip" install --quiet ${PIP_ARGS} "${TARGET}"
+
+echo "==> running smoke"
+"${VENV}/bin/python" - <<'PY'
+import phionyx_core
+from phionyx_core import EchoState2, calculate_phi_v2_1
+from phionyx_core.governance.kill_switch import KillSwitch
+from phionyx_core.contracts.telemetry import get_canonical_blocks
+
+print(f"phionyx_core version : {phionyx_core.__version__}")
+print(f"canonical blocks     : {len(get_canonical_blocks())}")
+
+state = EchoState2(A=0.6, V=0.3, H=0.4)
+phi = calculate_phi_v2_1(
+    valence=state.V, arousal=state.A, amplitude=state.A * 10.0,
+    time_delta=0.1, gamma=0.15, stability=state.stability,
+    entropy=state.H, w_c=0.6, w_p=0.4,
+)
+assert phi["phi"] > 0, "phi must be positive"
+
+ks = KillSwitch()
+result = ks.evaluate(ethics_max_risk=0.10, t_meta=0.85, drift_detected=False, turn_id=1)
+assert ks.state.value == "armed"
+assert result.triggered is False
+
+print(f"phi                  : {phi['phi']:.4f}")
+print(f"phi_cognitive        : {phi['phi_cognitive']:.4f}")
+print(f"kill switch state    : {ks.state.value}")
+print()
+print("local demo: ok")
+PY
+
+echo "==> done. venv kept at ${VENV} for further inspection (delete with rm -rf ${VENV})"

--- a/tests/integration/test_pypi_install.py
+++ b/tests/integration/test_pypi_install.py
@@ -1,0 +1,98 @@
+"""
+Integration test: install ``phionyx-core`` from PyPI in a *fresh* venv
+and exercise the public API.
+
+Why this exists separate from ``tests/core``:
+
+  Editable installs (``pip install -e .``) hide a class of packaging
+  bug — missing wheel files, MANIFEST drift, declared-but-unshipped
+  modules, broken module top-level imports under default deps. The
+  unit suite passes against the working tree, so it can't catch these.
+  This test goes through the same install path a real user uses
+  (``pip install phionyx-core``) and runs the public API in the
+  resulting venv.
+
+  CI does not run this by default — it requires network and is too
+  expensive for every PR. Opt in with:
+
+      pytest tests/integration -m integration
+
+  Or, as part of the CI surface, set the env var ``PHIONYX_RUN_PYPI``
+  to a non-empty value.
+
+Override the install target at runtime:
+
+  PHIONYX_INSTALL_TARGET="phionyx-core==0.2.1" pytest tests/integration -m integration
+  PHIONYX_INSTALL_TARGET="phionyx-core" \
+      PHIONYX_PIP_INDEX_ARGS="--index-url https://test.pypi.org/simple/ \
+                              --extra-index-url https://pypi.org/simple/" \
+      pytest tests/integration -m integration
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.integration
+
+
+def test_pypi_install_round_trip(tmp_path: Path) -> None:
+    target = os.environ.get("PHIONYX_INSTALL_TARGET", "phionyx-core")
+    pip_index_args = shlex.split(os.environ.get("PHIONYX_PIP_INDEX_ARGS", ""))
+
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
+    pip = venv_dir / "bin" / "pip"
+    py = venv_dir / "bin" / "python"
+    if not pip.exists():        # Windows fallback
+        pip = venv_dir / "Scripts" / "pip.exe"
+        py = venv_dir / "Scripts" / "python.exe"
+
+    subprocess.run(
+        [str(pip), "install", "--quiet", "--upgrade", "pip"],
+        check=True,
+    )
+    subprocess.run(
+        [str(pip), "install", "--quiet", *pip_index_args, target],
+        check=True,
+    )
+
+    # Smoke flow inside the freshly-installed venv. Each assert covers
+    # a different surface so a single failed assert points at the
+    # actual broken thing rather than a generic ImportError.
+    smoke = (
+        "import phionyx_core;"
+        "assert phionyx_core.__version__, 'no version';"
+        "from phionyx_core import EchoState2, calculate_phi_v2_1;"
+        "from phionyx_core.governance.kill_switch import KillSwitch;"
+        "from phionyx_core.contracts.telemetry import get_canonical_blocks;"
+        "assert len(get_canonical_blocks()) == 46, 'block count drift';"
+        "s = EchoState2(A=0.5, V=0.3, H=0.4);"
+        "r = calculate_phi_v2_1(valence=s.V, arousal=s.A, amplitude=5.0, "
+        "time_delta=0.1, gamma=0.15, stability=s.stability, entropy=s.H, "
+        "w_c=0.6, w_p=0.4);"
+        "assert r['phi'] > 0, 'phi must be positive';"
+        "assert KillSwitch().state.value == 'armed', 'kill switch should arm by default';"
+        "print('pypi-install round-trip: ok', phionyx_core.__version__)"
+    )
+
+    result = subprocess.run(
+        [str(py), "-c", smoke],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "smoke failed in fresh PyPI-install venv\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    assert "pypi-install round-trip: ok" in result.stdout


### PR DESCRIPTION
Two install-path artifacts that prove the published wheel actually works end-to-end.

## `scripts/demo.sh` — one-command local demo

```bash
bash scripts/demo.sh
```

Fresh venv → `pip install phionyx-core` → smoke flow (version, 46 canonical blocks, EchoState2, `calculate_phi_v2_1`, KillSwitch). Prints **`local demo: ok`** on success.

Two override env vars double the script as a TestPyPI dry-run helper:

- `PHIONYX_INSTALL_TARGET` — pin a version (e.g. `phionyx-core==0.2.1`)
- `PHIONYX_PIP_INDEX_ARGS` — extra pip flags (e.g. `--index-url ...`)

README gains a `curl | bash` one-liner as an alternative to the two-step `pip install` / smoke pair.

## `tests/integration/test_pypi_install.py` — opt-in PyPI round-trip

Spins up a tmp venv, pip-installs phionyx-core, runs the same smoke checks in a subprocess. Catches packaging regressions invisible on editable installs (missing wheel files, MANIFEST drift, declared-but-unshipped modules, broken top-level imports under default deps).

Marked `@pytest.mark.integration`. Default CI does **not** run it. Opt-in:

```bash
pytest tests/integration -m integration
```

Verified locally: 1 passed in 8.93 s (real pip install from PyPI).

## pyproject.toml

Registers the `integration` pytest marker so `--strict-markers` doesn't error.

No code change to `phionyx_core`, no public-API change.