### PR TITLE
examples: comparison with LangChain / LlamaIndex (P1.13)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,7 @@ Every notebook runs end-to-end on a fresh `pip install phionyx-core`. No LLM, no
 | [FastAPI](fastapi/) | HTTP `/govern` endpoint over the governance pipeline | Planned |
 | [`envelopes/governed_response.json`](envelopes/governed_response.json) | Canonical governed-response envelope sample (output of notebook 04) | Reference |
 | [`profiles/`](profiles/) | Three runnable profile YAMLs — `education`, `creative_writing`, `customer_support`. All validate against `phionyx_core.Profile` | Reference |
+| [`comparison/`](comparison/) | Phionyx as a governance layer on top of LangChain / LlamaIndex / any orchestrator (`with_orchestrator.py` + role-distinction note) | Reference |
 
 ## Running Notebooks
 

--- a/examples/comparison/README.md
+++ b/examples/comparison/README.md
@@ -1,0 +1,52 @@
+# Phionyx vs LangChain / LlamaIndex
+
+The most common question when Phionyx lands next to an existing LLM
+stack: *do I have to choose between this and LangChain?* No. They
+operate at different layers.
+
+This directory shows the distinction in code, not just prose.
+
+## The role distinction
+
+| Concern | LangChain / LlamaIndex | Phionyx |
+|---------|------------------------|---------|
+| Primary job | **Orchestrate** the LLM call: prompt assembly, tool calls, retrieval, agent loops, memory recall. | **Govern** the LLM output: input safety gate, deterministic state, kill switch, ethics gate, tamper-evident audit. |
+| Treats the LLM as | A reasoning engine. The model's output is the answer. | A noisy sensor. The model's output is a measurement, not the answer (Echoism Axiom 1). |
+| Determinism | Non-deterministic by design (chain output mirrors model sampling). | Strict in the substrate (Φ, gates, audit hash); the LLM stage is the single declared `noisy_sensor`. |
+| Default safety | Optional guardrails layered on top. | Mandatory gates that the agent cannot prompt-engineer past. |
+| State | Conversation history, vector memory. | Structured state vector (A, V, H, Φ, entropy) + audit chain. |
+| Composability | LangChain *can* be the producer; Phionyx wraps the result. | Phionyx *can* sit on top; the producer is interchangeable. |
+
+In a sentence: **LangChain decides what the LLM says next. Phionyx
+decides what the runtime does with what the LLM said.**
+
+## What the wrap pattern looks like
+
+A LangChain or LlamaIndex chain produces text. Phionyx takes that text
+through input safety, computes a state vector, runs the kill switch and
+ethics gate, attaches a tamper-evident envelope, and returns the
+governed result. The producer is interchangeable — same wrap, different
+upstream.
+
+See [`with_orchestrator.py`](with_orchestrator.py) for a runnable
+illustration. The script uses a `pretend_chain()` stand-in so you
+don't need a LangChain or LlamaIndex install to run it; the comment
+block at the top of the file shows the one-line swap to use the real
+ones.
+
+## When to reach for which
+
+- **You're building an agent** and need tool selection, RAG over a
+  corpus, and conversation memory → start with LangChain or
+  LlamaIndex. They have first-class APIs for those.
+- **You're shipping that agent into production** and need a runtime
+  contract — kill switch, ethics gate, deterministic Φ, audit chain
+  → wrap whatever the orchestrator returns in a Phionyx governance
+  layer. The producer becomes `noisy_sensor` input to the symbolic
+  layer.
+- **You only need the substrate** (deterministic state, governance
+  primitives, audit) — Phionyx alone is enough; the orchestrator
+  layer is optional.
+
+The two layers are orthogonal. The mistake is treating them as
+competitors and picking only one.

--- a/examples/comparison/with_orchestrator.py
+++ b/examples/comparison/with_orchestrator.py
@@ -1,0 +1,167 @@
+"""
+Phionyx as a governance layer on top of an LLM orchestrator.
+
+The orchestrator (LangChain, LlamaIndex, raw API call, anything) produces
+some text. Phionyx wraps that text in a governed envelope: input safety
+gate → state vector → Φ → kill switch → audit hash. The wrap pattern is
+the same regardless of producer.
+
+Run:
+
+    pip install phionyx-core
+    python examples/comparison/with_orchestrator.py
+
+The producer here is a deterministic stand-in (``pretend_chain``) so the
+example runs without LangChain or LlamaIndex installed. To swap in the
+real ones, replace the producer with one of:
+
+    # LangChain (≥0.1):
+    from langchain_openai import ChatOpenAI
+    chain = ChatOpenAI(model="gpt-4o-mini")
+    text = chain.invoke(prompt).content
+
+    # LlamaIndex (≥0.10):
+    from llama_index.llms.openai import OpenAI
+    llm = OpenAI(model="gpt-4o-mini")
+    text = llm.complete(prompt).text
+
+…then drop the result into ``govern(prompt, text)`` below. The Phionyx
+side is unchanged.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from phionyx_core import EchoState2, calculate_phi_v2_1
+from phionyx_core.governance.kill_switch import KillSwitch
+
+
+# ---------------------------------------------------------------------------
+# Producer (the orchestrator). Replace this with LangChain / LlamaIndex.
+# ---------------------------------------------------------------------------
+
+def pretend_chain(prompt: str) -> str:
+    """Stand-in for a LangChain/LlamaIndex chain.
+
+    Returns a deterministic acknowledgement so the example produces
+    stable output. Real producers go through retrieval / tool selection
+    / model sampling; for governance purposes the only contract that
+    matters is `prompt -> text`.
+    """
+    return (
+        "I'd suggest splitting the proposal into two parts: a written "
+        "case study and a 5-minute screencast. Case study captures the "
+        f"durable claim, screencast captures the pace. (Re: '{prompt[:60]}…')"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phionyx governance layer.
+# ---------------------------------------------------------------------------
+
+BLOCKED_PATTERNS = ("ignore previous instructions", "system prompt:")
+
+
+def input_safety_gate(text: str) -> dict[str, Any]:
+    lowered = text.lower()
+    matched = [p for p in BLOCKED_PATTERNS if p in lowered]
+    if matched:
+        return {"allowed": False, "reason": f"blocked patterns: {matched}"}
+    if not text.strip() or len(text) > 4000:
+        return {"allowed": False, "reason": "length out of range"}
+    return {"allowed": True, "reason": None}
+
+
+def state_from_prompt(prompt: str) -> EchoState2:
+    """Cheap, deterministic state estimation from input features."""
+    word_count = len(prompt.split())
+    has_question = "?" in prompt
+    arousal = min(1.0, 0.4 + 0.05 * has_question + 0.02 * (word_count > 12))
+    return EchoState2(A=arousal, V=0.1, H=min(0.6, word_count / 50.0))
+
+
+def audit_hash(payload: dict[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def govern(
+    prompt: str,
+    producer: Callable[[str], str],
+    *,
+    turn_id: int = 1,
+) -> dict[str, Any]:
+    """Run a prompt through any producer and wrap the result in a
+    Phionyx governance envelope. The producer can be a LangChain
+    chain, a LlamaIndex query engine, or any callable taking ``str``
+    returning ``str``."""
+
+    safety = input_safety_gate(prompt)
+    if not safety["allowed"]:
+        return {
+            "schema_version": "phionyx-governed-response/0.1",
+            "turn_id": turn_id,
+            "input": {"user_text": prompt, "safety": safety},
+            "response": {"text": None, "narrative_layer": "rejected_at_input_gate"},
+            "audit": {"hash_alg": "sha256", "envelope_hash": None},
+        }
+
+    state = state_from_prompt(prompt)
+    phi = calculate_phi_v2_1(
+        valence=state.V, arousal=state.A, amplitude=state.A * 10.0,
+        time_delta=0.1, gamma=0.15, stability=state.stability,
+        entropy=state.H, w_c=0.6, w_p=0.4,
+    )
+
+    # The producer call. In a real run this is the LLM round-trip.
+    raw_text = producer(prompt)
+
+    ks = KillSwitch()
+    ks_result = ks.evaluate(
+        ethics_max_risk=0.10,
+        t_meta=0.85,
+        drift_detected=False,
+        turn_id=turn_id,
+    )
+
+    envelope = {
+        "schema_version": "phionyx-governed-response/0.1",
+        "turn_id": turn_id,
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "input": {"user_text": prompt, "safety": safety},
+        "state": {
+            "arousal": state.A, "valence": state.V, "entropy": state.H,
+            "resonance": round(state.resonance, 6),
+            "stability": round(state.stability, 6),
+        },
+        "phi": {k: round(v, 6) for k, v in phi.items()},
+        "governance": {
+            "kill_switch_state": ks.state.value,
+            "kill_switch_triggered": ks_result.triggered,
+            "kill_switch_reason": ks_result.reason,
+        },
+        "response": {"text": raw_text, "narrative_layer": producer.__name__},
+    }
+    envelope["audit"] = {
+        "hash_alg": "sha256",
+        "envelope_hash": audit_hash(envelope),
+    }
+    return envelope
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    prompt = "How should I package my proposal for an academic talk vs a podcast?"
+    envelope = govern(prompt, pretend_chain)
+    print(json.dumps(envelope, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes the last item in the Demo Experience push — a runnable illustration of how Phionyx sits *next to* (not against) LangChain or LlamaIndex.

The framing question this answers is the most common one when an existing-stack team meets Phionyx: *do I have to choose between this and LangChain?* The answer in code is **no**.

## `examples/comparison/README.md`

Role-distinction matrix. **LangChain / LlamaIndex decide what the LLM says next; Phionyx decides what the runtime does with what the LLM said.** Plus an explicit *When to reach for which* section so the layers stop being thought of as competitors.

## `examples/comparison/with_orchestrator.py`

Runnable wrap-pattern demo. A producer (any callable `str -> str`) sits in front; Phionyx wraps the result in a governance envelope (input safety, state vector, Φ, kill switch, audit hash).

The producer is a deterministic stand-in (`pretend_chain`) so the example runs **without** LangChain or LlamaIndex installed. The module docstring shows the 3-line swap to use the real ones:

```python
# LangChain
from langchain_openai import ChatOpenAI
chain = ChatOpenAI(model="gpt-4o-mini")
text = chain.invoke(prompt).content

# LlamaIndex
from llama_index.llms.openai import OpenAI
llm = OpenAI(model="gpt-4o-mini")
text = llm.complete(prompt).text
```

The Phionyx side is identical in either case.

## Verification

```
$ pip install phionyx-core
$ python examples/comparison/with_orchestrator.py
{
  "schema_version": "phionyx-governed-response/0.1",
  "state": { "arousal": 0.47, "valence": 0.1, ... },
  "phi": { "phi": 0.949, ... },
  "governance": { "kill_switch_state": "armed", ... },
  "response": { "text": "...", "narrative_layer": "pretend_chain" },
  "audit": { "envelope_hash": "0a610..." }
}
```

No new dependencies. Real LangChain/LlamaIndex imports remain optional — anyone runs the example on a vanilla install.