### PR TITLE
chore(mypy): wave 1 — lock 4 strategic modules in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
       - name: Lint (ruff)
         run: ruff check phionyx_core
 
+      - name: Type check (mypy — strategic modules)
+        # Wave 1 of the gradual mypy rollout: lock the modules with the
+        # cleanest type surface so they cannot regress. Other modules
+        # are tracked in `project_mypy_deferred.md` and will land
+        # behind their own CI gate as each becomes clean.
+        run: mypy phionyx_core/governance phionyx_core/physics phionyx_core/contracts/v4 phionyx_core/contracts/telemetry
+
       - name: Smoke import
         run: |
           python -c "import phionyx_core; print('phionyx_core', phionyx_core.__version__)"

--- a/phionyx_core/contracts/telemetry/__init__.py
+++ b/phionyx_core/contracts/telemetry/__init__.py
@@ -6,7 +6,18 @@ Supports backward compatibility with v3.7.0, v3.6.0, v3.5.0, v3.0.0, v2.5.0, and
 """
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
+
+
+def _read_contract_json(path: Path) -> dict[str, Any]:
+    """Load a JSON contract file with the type narrowed for mypy.
+
+    json.load returns Any; the contract files are object-typed by
+    construction and validated by tests/contract — this cast keeps the
+    public functions typed without weakening their return annotation.
+    """
+    with open(path) as f:
+        return cast(dict[str, Any], json.load(f))
 
 # Contract version management
 _CONTRACT_V2_4_0_PATH = Path(__file__).parent / "archive" / "canonical_blocks_v2_4_0.json"
@@ -25,47 +36,40 @@ def _load_contract(version: str | None = None) -> dict[str, Any]:
     # v3.8.0 support (state-driven response revision — 46 blocks)
     if version == "3.8.0" or version is None:
         if _CONTRACT_V3_8_0_PATH.exists():
-            with open(_CONTRACT_V3_8_0_PATH) as f:
-                return json.load(f)
+            return _read_contract_json(_CONTRACT_V3_8_0_PATH)
         if version == "3.8.0":
             raise FileNotFoundError("v3.8.0 contract file not found")
     # v3.7.0 support (CEP reactivation pipeline — 45 blocks)
     if version == "3.7.0" or version is None:
         if _CONTRACT_V3_7_0_PATH.exists():
-            with open(_CONTRACT_V3_7_0_PATH) as f:
-                return json.load(f)
+            return _read_contract_json(_CONTRACT_V3_7_0_PATH)
         if version == "3.7.0":
             raise FileNotFoundError("v3.7.0 contract file not found")
     # v3.6.0 support (feedback loop pipeline — 44 blocks)
     if version == "3.6.0" or version is None:
         if _CONTRACT_V3_6_0_PATH.exists():
-            with open(_CONTRACT_V3_6_0_PATH) as f:
-                return json.load(f)
+            return _read_contract_json(_CONTRACT_V3_6_0_PATH)
         if version == "3.6.0":
             raise FileNotFoundError("v3.6.0 contract file not found")
     # v3.5.0 support (full AGI pipeline — 43 blocks)
     if version == "3.5.0" or version is None:
         if _CONTRACT_V3_5_0_PATH.exists():
-            with open(_CONTRACT_V3_5_0_PATH) as f:
-                return json.load(f)
+            return _read_contract_json(_CONTRACT_V3_5_0_PATH)
         # Fall through to v3.0.0 if v3.5.0 not found and no explicit version requested
         if version == "3.5.0":
             raise FileNotFoundError("v3.5.0 contract file not found")
     # v3.0.0 support (AD-3: pipeline version coexistence)
     if version == "3.0.0" or version is None:
         if _CONTRACT_V3_0_0_PATH.exists():
-            with open(_CONTRACT_V3_0_0_PATH) as f:
-                return json.load(f)
+            return _read_contract_json(_CONTRACT_V3_0_0_PATH)
         if version == "3.0.0":
             raise FileNotFoundError("v3.0.0 contract file not found")
     if version == "2.5.0" or version is None:
         if _CONTRACT_V2_5_0_PATH.exists():
-            with open(_CONTRACT_V2_5_0_PATH) as f:
-                return json.load(f)
+            return _read_contract_json(_CONTRACT_V2_5_0_PATH)
     # Fallback to v2.4.0
     if _CONTRACT_V2_4_0_PATH.exists():
-        with open(_CONTRACT_V2_4_0_PATH) as f:
-            return json.load(f)
+        return _read_contract_json(_CONTRACT_V2_4_0_PATH)
     raise FileNotFoundError("Telemetry contract file not found")
 
 
@@ -83,7 +87,7 @@ def get_canonical_blocks(version: str | None = None) -> list[str]:
         List of block IDs in canonical order.
     """
     contract = _load_contract(version)
-    return contract['canonical_block_order']
+    return cast(list[str], contract['canonical_block_order'])
 
 
 def get_canonical_block_order(version: str | None = None) -> list[str]:
@@ -110,7 +114,7 @@ def get_middleware_blocks(version: str | None = None) -> list[str]:
         List of middleware block IDs.
     """
     contract = _load_contract(version)
-    return contract.get('middleware_blocks', [])
+    return cast(list[str], contract.get('middleware_blocks', []))
 
 
 def get_block_mapping(version: str | None = None) -> dict[str, Any]:
@@ -124,20 +128,20 @@ def get_block_mapping(version: str | None = None) -> dict[str, Any]:
         Block mapping dictionary.
     """
     contract = _load_contract(version)
-    return contract.get('block_mapping', {})
+    return cast(dict[str, Any], contract.get('block_mapping', {}))
 
 
 def get_required_event_types(version: str | None = None) -> list[str]:
     """Returns required event types."""
     contract = _load_contract(version)
-    return contract['required_event_types']
+    return cast(list[str], contract['required_event_types'])
 
 
 def get_contract_version() -> str:
     """Returns current contract version."""
     try:
         contract = _load_contract()
-        return contract.get('contract_version', _CURRENT_VERSION)
+        return cast(str, contract.get('contract_version', _CURRENT_VERSION))
     except FileNotFoundError:
         return _FALLBACK_VERSION
 
@@ -157,7 +161,7 @@ def migrate_block_id(old_block_id: str, from_version: str = "2.4.0", to_version:
     if from_version == "2.4.0" and to_version == "2.5.0":
         contract = _load_contract("2.5.0")
         mapping = contract.get('block_mapping', {}).get('v2.4.0_to_v2.5.0', {})
-        return mapping.get(old_block_id, old_block_id)
+        return cast(str, mapping.get(old_block_id, old_block_id))
     if from_version == "2.5.0" and to_version == "3.0.0":
         # v3.0.0 is additive — no block renames, only insertions
         return old_block_id

--- a/phionyx_core/governance/deliberative_ethics.py
+++ b/phionyx_core/governance/deliberative_ethics.py
@@ -343,7 +343,7 @@ class DeliberativeEthics:
         if not verdict_scores:
             return DeliberationOutcome.DEFER_TO_HUMAN.value, 0.0, False
 
-        best_verdict = max(verdict_scores, key=verdict_scores.get)
+        best_verdict = max(verdict_scores, key=lambda k: verdict_scores[k])
         best_score = verdict_scores[best_verdict]
         total_score = sum(verdict_scores.values())
         confidence = best_score / total_score if total_score > 0 else 0.0

--- a/phionyx_core/governance/kill_switch.py
+++ b/phionyx_core/governance/kill_switch.py
@@ -132,10 +132,13 @@ class KillSwitch:
             try:
                 if math.isnan(val):
                     logger.critical(f"KILL SWITCH: NaN detected in {name} — fail-closed")
+                    # `metrics` is dict[str, float]; the offending field name
+                    # is captured in `reason` instead so this dict stays
+                    # numeric.
                     return self._trigger(
                         KillSwitchTrigger.EVALUATION_ERROR,
                         f"NaN detected in {name} (fail-closed)",
-                        {"nan_field": name, "ethics_max_risk": 0.0, "t_meta": 0.0,
+                        {"ethics_max_risk": 0.0, "t_meta": 0.0,
                          "drift_detected": float(drift_detected),
                          "consecutive_drift_count": float(self._consecutive_drift_count)},
                         turn_id,

--- a/phionyx_core/physics/formulas.py
+++ b/phionyx_core/physics/formulas.py
@@ -675,7 +675,7 @@ def calculate_phi_v2(
     valence: float = 0.0,
     arousal: float = 1.0,
     entropy_penalty_k: float = entropy_penalty_k,
-) -> dict[str, float]:
+) -> dict[str, float | str]:
     """
     Calculate Total Echo Quality (Φ) using Hybrid Resonance Model v2.0 (backward compatible).
 

--- a/phionyx_core/physics/wasm_ready.py
+++ b/phionyx_core/physics/wasm_ready.py
@@ -55,7 +55,9 @@ def calculate_phi_v2_batch(
             gamma=gamma_array[i],
             context_mode=context_mode
         )
-        results.append(result.get("phi", 0.0))
+        # `result["phi"]` is always a float; `calculate_phi_v2` returns
+        # dict[str, float | str] only because "context" is a string label.
+        results.append(float(result.get("phi", 0.0)))
 
     return results
 


### PR DESCRIPTION
First wave of the gradual mypy rollout from `project_mypy_deferred.md`. Locks the four modules with the cleanest type surface so they cannot regress; the remaining ~370 errors across the rest of the codebase are tracked for later waves.

## What gets locked

| Module | Errors before | Errors after |
|--------|---------------|--------------|
| `phionyx_core/governance` | 2 | 0 |
| `phionyx_core/physics` | 1 | 0 |
| `phionyx_core/contracts/v4` | 0 | 0 |
| `phionyx_core/contracts/telemetry` | 13 | 0 |
| **Total** | **16** | **0** |

## Fixes

- **`governance/kill_switch.py`** — the NaN-fail-closed branch put `nan_field: name` (a str) into the metrics dict typed `dict[str, float]`. The offending field is already named in `reason`; dropping it from `metrics` keeps it numeric.
- **`governance/deliberative_ethics.py`** — `max(verdict_scores, key=verdict_scores.get)` failed mypy's overload check on `dict.get`. Replaced with `key=lambda k: verdict_scores[k]`.
- **`physics/formulas.py`** — `calculate_phi_v2` returned `dict[str, float]` but included `"context": context_mode` (str). Annotation widened to `dict[str, float | str]`.
- **`physics/wasm_ready.py`** — one call site of `calculate_phi_v2` collected `.get("phi")` into a `list[float]`. Wrapped in `float(...)` so mypy understands the value is a float (the annotation widening is only for the `context` label).
- **`contracts/telemetry/__init__.py`** — `json.load` returns `Any`, polluting every getter with `[no-any-return]`. Introduced a `_read_contract_json` helper that does an explicit `cast(dict[str, Any], ...)`, replaced 7 duplicated `with open(...) as f: return json.load(f)` patterns, and added localised casts on each public getter so its return annotation stays accurate.

## CI

Adds a new step:

```yaml
- name: Type check (mypy — strategic modules)
  run: mypy phionyx_core/governance phionyx_core/physics phionyx_core/contracts/v4 phionyx_core/contracts/telemetry
```

Runs after ruff, before pytest. Catches type regressions before pytest spends compute. Step comment references `project_mypy_deferred.md` so the rollout intent is visible.

## Verification

```
$ mypy phionyx_core/governance phionyx_core/physics phionyx_core/contracts/v4 phionyx_core/contracts/telemetry
Success: no issues found in 40 source files

$ pytest tests/core tests/contract tests/benchmarks -q
1130 passed, 7 skipped, 0 failed
```