### PR TITLE
fix(ci): mypy strategic-modules step uses --follow-imports=silent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,14 @@ jobs:
         # cleanest type surface so they cannot regress. Other modules
         # are tracked in `project_mypy_deferred.md` and will land
         # behind their own CI gate as each becomes clean.
-        run: mypy phionyx_core/governance phionyx_core/physics phionyx_core/contracts/v4 phionyx_core/contracts/telemetry
+        #
+        # `--follow-imports=silent` is the gating mechanism: mypy still
+        # *reads* transitive imports (so it can resolve types) but
+        # suppresses errors that originate outside the listed paths.
+        # Without it, errors from modules like
+        # phionyx_core/orchestrator/block_factory.py — tracked for a
+        # later wave — would fail this check.
+        run: mypy --follow-imports=silent phionyx_core/governance phionyx_core/physics phionyx_core/contracts/v4 phionyx_core/contracts/telemetry
 
       - name: Smoke import
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.4.0",
     "mypy>=1.0.0",
+    "types-PyYAML>=6.0",
 ]
 # All optional runtime adapters
 all = [


### PR DESCRIPTION
PR #43's mypy step passed locally but failed in CI with 233 errors originating *outside* the four strategic modules — primarily `phionyx_core/orchestrator/block_factory.py`, which is tracked for a later wave per `project_mypy_deferred.md`.

Locally pkg-test-venv had every optional adapter (networkx, opentelemetry, ...) installed, so mypy could resolve and silently accept the cross-module assignments. The CI venv only has `[dev]` extras, so the same imports surfaced the type problems they always had — outside the locked modules.

Adding `--follow-imports=silent` keeps the import resolution mypy needs (for cross-module types) but suppresses errors originating outside the listed paths. The four strategic modules are still fully checked.

Without this flag, CI fails with `Found 233 errors in 56 files`. With it, the four strategic modules pass cleanly and only their errors would surface.

This unblocks main, which was admin-merged in PR #43 with a known-failing check; this PR brings the CI signal back to green.