### PR TITLE
chore: Zenodo DOI readiness — CITATION.cff + .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,37 @@
+{
+  "title": "Phionyx Core SDK",
+  "description": "Deterministic, auditable AI cognition runtime — not an LLM wrapper. Treats LLM outputs as sensor measurements inside a 46-block pipeline with safety gates, ethics checks, and physics-based state tracking.",
+  "creators": [
+    {
+      "name": "Abak, Ali Toygar",
+      "affiliation": "Phionyx Research",
+      "orcid": ""
+    }
+  ],
+  "upload_type": "software",
+  "license": "AGPL-3.0-or-later",
+  "access_right": "open",
+  "keywords": [
+    "deterministic-ai",
+    "runtime-architecture",
+    "ai-governance",
+    "pre-response-control",
+    "structured-state",
+    "llm-safety",
+    "cognitive-architecture",
+    "auditable-ai"
+  ],
+  "communities": [],
+  "related_identifiers": [
+    {
+      "identifier": "https://pypi.org/project/phionyx-core/",
+      "relation": "isPublishedIn",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://phionyx.ai",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
-message: "If you use this software, please cite the arXiv paper below."
+message: "If you use this software in your research, please cite it as below."
 title: "Phionyx Core SDK"
-version: 0.2.0
-date-released: "2026-04-23"
+version: 0.2.1
+date-released: "2026-05-01"
 authors:
   - family-names: Abak
     given-names: Ali Toygar
@@ -11,6 +11,7 @@ authors:
 license: AGPL-3.0-or-later
 url: "https://phionyx.ai"
 repository-code: "https://github.com/halvrenofviryel/phionyx-research"
+type: software
 keywords:
   - deterministic-ai
   - runtime-architecture
@@ -18,6 +19,12 @@ keywords:
   - pre-response-control
   - structured-state
   - llm-safety
+  - cognitive-architecture
+  - auditable-ai
+# identifiers:
+#   - type: doi
+#     value: 10.5281/zenodo.XXXXXXX
+#     description: Archived Zenodo release for v0.2.1 (uncomment after first archive)
 preferred-citation:
   type: article
   title: "Phionyx: A Deterministic AI Runtime Architecture with Structured State Management and Pre-Response Governance"

--- a/README.md
+++ b/README.md
@@ -213,6 +213,23 @@ A commercial license is available for use cases where AGPL-3.0 copyleft is not s
 
 ## Citation
 
+If you use Phionyx Core in academic work, please cite both the software and the architecture paper.
+
+**Software (this repository):**
+
+```bibtex
+@software{abak2026phionyxcore,
+  author    = {Abak, Ali Toygar},
+  title     = {Phionyx Core SDK},
+  year      = {2026},
+  publisher = {Phionyx Research},
+  version   = {0.2.1},
+  url       = {https://github.com/halvrenofviryel/phionyx-research}
+}
+```
+
+**Architecture paper (companion):**
+
 ```bibtex
 @techreport{abak2026phionyx,
   author      = {Abak, Ali Toygar},
@@ -222,3 +239,5 @@ A commercial license is available for use cases where AGPL-3.0 copyleft is not s
   url         = {https://github.com/halvrenofviryel/phionyx-research}
 }
 ```
+
+A machine-readable [`CITATION.cff`](CITATION.cff) is provided for GitHub's “Cite this repository” widget. A persistent Zenodo DOI for archived releases is planned — once issued it will be added here as a badge and to `CITATION.cff` under `identifiers:`.


### PR DESCRIPTION
## Summary

Prepares the repo for Zenodo archival on next GitHub release. No code changes.

- **CITATION.cff:** bump version to 0.2.1 (was 0.2.0, out of sync with pyproject.toml), add `type: software`, two new keywords, commented `identifiers:` block ready for the Zenodo DOI once issued
- **.zenodo.json:** full metadata block (title, description, creators, license, keywords, `related_identifiers` to PyPI + phionyx.ai) so Zenodo auto-populates the archive page from this file instead of GitHub-API defaults
- **README.md:** split Citation section into software + paper bibtex; short note about the planned DOI badge after first archive

## Why

Once we publish a versioned GitHub release (current target: v0.3.0), Zenodo will automatically archive the source tree and mint a DOI like `10.5281/zenodo.XXXXXXX`. Without `.zenodo.json`, the auto-archive uses GitHub-API defaults (no description, no keywords, generic creator). With this file, the archive page comes out clean and citable on day one.

This matters for academic visibility (Global Talent / paper companion artifact) — a DOI elevates the repo from "code I posted" to "citable research software."

## Next steps after merge

1. Cut the next release tag (v0.3.0 once mypy waves 4-6 land + any other v0.3 work)
2. Connect this repo to Zenodo (one-time at zenodo.org/account/settings/github/)
3. Zenodo auto-archives the release → DOI issued
4. Uncomment `identifiers:` block in CITATION.cff with the actual DOI
5. Add DOI badge to README header

🤖 Generated with [Claude Code](https://claude.com/claude-code)