### PR TITLE
chore(mypy): wave 4 — lock state + pipeline modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
         # Wave 2 (locked): config, ports, contracts (rest), evaluation, context,
         #                  metrics, planning, causality
         # Wave 3 (locked): cep
+        # Wave 4 (locked): state, pipeline
         run: |
           mypy --follow-imports=silent \
             phionyx_core/governance \
@@ -68,7 +69,9 @@ jobs:
             phionyx_core/metrics \
             phionyx_core/planning \
             phionyx_core/causality \
-            phionyx_core/cep
+            phionyx_core/cep \
+            phionyx_core/state \
+            phionyx_core/pipeline
 
       - name: Smoke import
         run: |

--- a/phionyx_core/pipeline/base.py
+++ b/phionyx_core/pipeline/base.py
@@ -6,7 +6,7 @@ Base class for all pipeline blocks in the 46-block canonical pipeline.
 """
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, ClassVar, Literal
 
 DeterminismClass = Literal["strict", "seeded", "noisy_sensor"]
@@ -78,11 +78,7 @@ class BlockContext:
     pipeline_version: str = "3.0.0"             # "2.5.0" or "3.0.0"
 
     # Additional context (extensible)
-    metadata: dict[str, Any] = None
-
-    def __post_init__(self):
-        if self.metadata is None:
-            self.metadata = {}
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/phionyx_core/pipeline/blocks/archive/coherence_qa.py
+++ b/phionyx_core/pipeline/blocks/archive/coherence_qa.py
@@ -108,7 +108,7 @@ class CoherenceQaBlock(PipelineBlock):
                     cleaned = pattern.sub("", cleaned)
                 redacted_text = re.sub(r"\s+", " ", cleaned).strip()
 
-            qa_result: dict[str, Any] = {
+            qa_result = {
                 "coherence_score": score,
                 "leak_detected": leak_detected,
                 "violations": violations,

--- a/phionyx_core/pipeline/blocks/archive/drive_coherence_update.py
+++ b/phionyx_core/pipeline/blocks/archive/drive_coherence_update.py
@@ -56,7 +56,7 @@ class DriveCoherenceUpdateBlock(PipelineBlock):
                     narrative_response=narrative_response,
                     physics_state=physics_state,
                 )
-                drive_result = {"drive": None, "coherence": None, "source": "injected"}
+                drive_result: dict[str, Any] = {"drive": None, "coherence": None, "source": "injected"}
                 context.metadata["drive_update_result"] = drive_result
                 return BlockResult(
                     block_id=self.block_id,
@@ -94,7 +94,7 @@ class DriveCoherenceUpdateBlock(PipelineBlock):
                     if hasattr(unified_state, "coherence"):
                         unified_state.coherence = coherence
 
-            drive_result: dict[str, Any] = {
+            drive_result = {
                 "drive": drive,
                 "coherence": coherence,
                 "source": source,

--- a/phionyx_core/pipeline/blocks/behavioral_drift_detection.py
+++ b/phionyx_core/pipeline/blocks/behavioral_drift_detection.py
@@ -99,11 +99,11 @@ class BehavioralDriftDetectionBlock(PipelineBlock):
                 )
 
             # Extract physics metrics from metadata or context
-            current_metrics = {
-                "phi": metadata.get("phi") or getattr(context, 'previous_phi', 0.0),
-                "entropy": context.current_entropy or 0.0,
-                "valence": metadata.get("valence") or 0.0,
-                "arousal": metadata.get("arousal") or 0.5,
+            current_metrics: dict[str, float] = {
+                "phi": float(metadata.get("phi") or getattr(context, 'previous_phi', 0.0) or 0.0),
+                "entropy": float(context.current_entropy or 0.0),
+                "valence": float(metadata.get("valence") or 0.0),
+                "arousal": float(metadata.get("arousal") or 0.5),
             }
 
             # Extract ethics vector from metadata

--- a/phionyx_core/pipeline/blocks/cognitive_layer.py
+++ b/phionyx_core/pipeline/blocks/cognitive_layer.py
@@ -81,6 +81,13 @@ class CognitiveLayerBlock(PipelineBlock):
             # Get physics params
             physics_params = context.metadata.get("physics_params", {}) if context.metadata else {}
 
+            if self.processor is None:
+                return BlockResult(
+                    block_id=self.block_id,
+                    status="error",
+                    error=RuntimeError("CognitiveLayerProcessor not configured")
+                )
+
             # Process cognitive layer
             updated_frame = await self.processor.process_cognitive_layer(
                 frame=frame,

--- a/phionyx_core/pipeline/blocks/create_scenario_frame.py
+++ b/phionyx_core/pipeline/blocks/create_scenario_frame.py
@@ -66,6 +66,13 @@ class CreateScenarioFrameBlock(PipelineBlock):
             # Get physics params from context metadata (if available)
             physics_params = context.metadata.get("physics_params", {}) if context.metadata else {}
 
+            if self.frame_creator is None:
+                return BlockResult(
+                    block_id=self.block_id,
+                    status="error",
+                    error=RuntimeError("ScenarioFrameCreator not configured")
+                )
+
             # Create scenario frame
             frame = self.frame_creator.create_scenario_frame(
                 user_input=context.user_input,

--- a/phionyx_core/pipeline/blocks/initialize_unified_state.py
+++ b/phionyx_core/pipeline/blocks/initialize_unified_state.py
@@ -76,6 +76,13 @@ class InitializeUnifiedStateBlock(PipelineBlock):
             # Get physics_params
             physics_params = metadata.get("physics_params", {})
 
+            if self.initializer is None:
+                return BlockResult(
+                    block_id=self.block_id,
+                    status="error",
+                    error=RuntimeError("UnifiedStateInitializer not configured")
+                )
+
             # Initialize unified state
             unified_state = self.initializer.initialize_unified_state(
                 frame=frame,

--- a/phionyx_core/pipeline/blocks/kill_switch_gate.py
+++ b/phionyx_core/pipeline/blocks/kill_switch_gate.py
@@ -132,17 +132,17 @@ class KillSwitchGateBlock(PipelineBlock):
         ethics_result = metadata.get("ethics_result")
         if ethics_result:
             if hasattr(ethics_result, "max_risk"):
-                return ethics_result.max_risk()
+                return float(ethics_result.max_risk())
             if isinstance(ethics_result, dict):
-                return ethics_result.get("max_risk_score", 0.0)
+                return float(ethics_result.get("max_risk_score", 0.0))
 
         # From v4 EthicsDecision
         ethics_decision = metadata.get("v4_ethics_decision")
         if ethics_decision:
             if hasattr(ethics_decision, "max_risk_score"):
-                return ethics_decision.max_risk_score
+                return float(ethics_decision.max_risk_score)
             if isinstance(ethics_decision, dict):
-                return ethics_decision.get("max_risk_score", 0.0)
+                return float(ethics_decision.get("max_risk_score", 0.0))
 
         return 0.0
 
@@ -152,17 +152,17 @@ class KillSwitchGateBlock(PipelineBlock):
         confidence = metadata.get("confidence_result")
         if confidence:
             if hasattr(confidence, "t_meta") and confidence.t_meta is not None:
-                return confidence.t_meta
+                return float(confidence.t_meta)
             if isinstance(confidence, dict):
-                return confidence.get("t_meta", 1.0)
+                return float(confidence.get("t_meta", 1.0))
 
         # From v4 ConfidencePayload
         v4_confidence = metadata.get("v4_confidence")
         if v4_confidence:
             if hasattr(v4_confidence, "t_meta") and v4_confidence.t_meta is not None:
-                return v4_confidence.t_meta
+                return float(v4_confidence.t_meta)
             if isinstance(v4_confidence, dict):
-                return v4_confidence.get("t_meta", 1.0)
+                return float(v4_confidence.get("t_meta", 1.0))
 
         return 1.0  # Default: fully trusted
 
@@ -171,7 +171,7 @@ class KillSwitchGateBlock(PipelineBlock):
         drift_result = metadata.get("drift_result")
         if drift_result:
             if hasattr(drift_result, "drift_detected"):
-                return drift_result.drift_detected
+                return bool(drift_result.drift_detected)
             if isinstance(drift_result, dict):
-                return drift_result.get("drift_detected", False)
+                return bool(drift_result.get("drift_detected", False))
         return False

--- a/phionyx_core/pipeline/blocks/narrative_layer.py
+++ b/phionyx_core/pipeline/blocks/narrative_layer.py
@@ -9,7 +9,7 @@ Generates narrative response using LLM.
 import logging
 from typing import Any, Protocol
 
-from phionyx_core.templates import get_template_manager
+from phionyx_core.templates import TemplateManager, get_template_manager
 from phionyx_core.templates.response_templates import IntentType
 
 from ..base import BlockContext, BlockResult, PipelineBlock
@@ -29,7 +29,8 @@ class NarrativeLayerProcessorProtocol(Protocol):
         enhanced_context_string: str,
         system_prompt: str | None = None,
         physics_state: dict[str, Any] | None = None,
-        selected_intent: dict[str, Any] | None = None
+        selected_intent: dict[str, Any] | None = None,
+        conversation_history: list[dict[str, Any]] | None = None,
     ) -> tuple[Any, str, Any]:  # Returns (frame, narrative_text, narrative_result)
         """Process narrative layer."""
         ...
@@ -57,10 +58,9 @@ class NarrativeLayerBlock(PipelineBlock):
         super().__init__("narrative_layer", claim_refs=self.CLAIM_REFS)
         self.processor = processor
         self.enable_templates = enable_templates
-        if enable_templates:
-            self.template_manager = get_template_manager()
-        else:
-            self.template_manager = None
+        self.template_manager: TemplateManager | None = (
+            get_template_manager() if enable_templates else None
+        )
 
     def should_skip(self, context: BlockContext) -> str | None:
         """Skip if processor not available."""
@@ -235,6 +235,7 @@ class NarrativeLayerBlock(PipelineBlock):
                             logger.debug(f"Template check skipped: {e}")
 
             # Normal LLM processing (no template match)
+            assert self.processor is not None  # narrowed by should_skip()
             updated_frame, narrative_text, narrative_result = await self.processor.process_narrative_layer(
                 frame=frame,
                 user_input=context.user_input,

--- a/phionyx_core/pipeline/blocks/response_revision_gate.py
+++ b/phionyx_core/pipeline/blocks/response_revision_gate.py
@@ -137,7 +137,7 @@ def _compute_damp_factor(entropy: float, thresholds: RevisionThresholds) -> floa
     base = 0.5
     ratio = entropy / max(thresholds.entropy_damp, 1e-6)
     factor = base ** ratio
-    return max(0.1, min(1.0, factor))
+    return float(max(0.1, min(1.0, factor)))
 
 
 class ResponseRevisionGateBlock(PipelineBlock):

--- a/phionyx_core/pipeline/blocks/time_update_sot.py
+++ b/phionyx_core/pipeline/blocks/time_update_sot.py
@@ -7,7 +7,7 @@ Updates time semantics using TimeManager (single source of truth per Echoism Cor
 """
 
 import logging
-from typing import Protocol
+from typing import Any, Protocol
 
 from ..base import BlockContext, BlockResult, PipelineBlock
 
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 class TimeManagerProtocol(Protocol):
     """Protocol for TimeManager to avoid direct dependency."""
+    state: Any  # TimeManager.state holds _is_first_tick and other turn-local flags
+
     def advance_turn(self) -> float:
         """Advance turn and return time_delta in seconds."""
         ...

--- a/phionyx_core/pipeline/blocks/trust_evaluation.py
+++ b/phionyx_core/pipeline/blocks/trust_evaluation.py
@@ -72,11 +72,11 @@ class TrustEvaluationBlock(PipelineBlock):
                 entropy = context.current_entropy if context.current_entropy is not None else 0.5
                 # Ethics risk lowers trust
                 ethics_result = metadata.get("ethics_result", {})
-                max_risk = 0.0
+                max_risk: float = 0.0
                 if isinstance(ethics_result, dict):
-                    max_risk = ethics_result.get("risk_level", ethics_result.get("harm_risk", 0.0))
+                    max_risk = float(ethics_result.get("risk_level", ethics_result.get("harm_risk", 0.0)) or 0.0)
                 elif hasattr(ethics_result, "risk_level"):
-                    max_risk = getattr(ethics_result, "risk_level", 0.0)
+                    max_risk = float(getattr(ethics_result, "risk_level", 0.0) or 0.0)
 
                 # Trust = confidence_weight * t_meta - risk - entropy_penalty
                 direct_trust = t_meta * 0.6 + (1.0 - max_risk) * 0.3 + (1.0 - entropy) * 0.1

--- a/phionyx_core/pipeline/blocks/ukf_predict.py
+++ b/phionyx_core/pipeline/blocks/ukf_predict.py
@@ -64,10 +64,10 @@ class UkfPredictBlock(PipelineBlock):
             unified_state = metadata.get("unified_state")
             time_delta = metadata.get("time_delta", 1.0)
 
-            if not unified_state:
+            if not unified_state or self.predictor is None:
                 return BlockResult(
                     block_id=self.block_id,
-                    status="ok",  # Skip if no unified state
+                    status="ok",  # Skip if no unified state or predictor not configured
                     data={"predicted_state": None}
                 )
 

--- a/phionyx_core/state/echo_ontology.py
+++ b/phionyx_core/state/echo_ontology.py
@@ -27,8 +27,8 @@ try:
     TRACE_AVAILABLE = True
 except ImportError:
     TRACE_AVAILABLE = False
-    trace_weight = None
-    aggregate_trace = None
+    trace_weight = None  # type: ignore[assignment]
+    aggregate_trace = None  # type: ignore[assignment]
 
 
 class EchoOntology:
@@ -142,10 +142,11 @@ class EchoOntology:
             return weight
         except ImportError:
             # Fallback to simple trace_weight if standard API not available
+            from phionyx_core.memory.trace import trace_weight as _trace_weight_simple
             if now is None:
                 now = self.state.t_now
 
-            return trace_weight(event, now, self.half_life_seconds)
+            return _trace_weight_simple(event, now, self.half_life_seconds)
 
     def trace_to_echo(
         self,

--- a/phionyx_core/state/echo_state_2.py
+++ b/phionyx_core/state/echo_state_2.py
@@ -44,7 +44,7 @@ except ImportError:
     EVENT_REFERENCE_AVAILABLE = False
     # Fallback EventReference definition
     @dataclass
-    class EventReference:
+    class EventReference:  # type: ignore[no-redef]
         id: str
         tag: str
         intensity: float
@@ -215,7 +215,7 @@ class EchoState2(BaseModel):
                 gamma=0.15  # Default recovery rate
             )
 
-            return phi_result.get("phi", 0.5)
+            return float(phi_result.get("phi", 0.5))
         except ImportError:
             # Fallback: Simple heuristic
             # Higher A and positive V with low H = higher phi
@@ -415,23 +415,15 @@ class EchoState2(BaseModel):
         if timestamp is None:
             timestamp = self.t_now
 
-        # Create EventReference (simplified for E_tags)
-        if EVENT_REFERENCE_AVAILABLE:
-            ref = EventReference(
-                event_id=f"event_{len(self.E_tags)}",
-                event_type=event_type,
-                intensity=max(0.0, min(1.0, intensity)),
-                tags=[semantic_context] if semantic_context else []
-            )
-            self.E_tags.append(ref)
-        else:
-            # Fallback
-            ref = EventReference(
-                id=f"event_{len(self.E_tags)}",
-                tag=semantic_context or event_type,
-                intensity=max(0.0, min(1.0, intensity))
-            )
-            self.E_tags.append(ref)
+        # Create EventReference (simplified for E_tags). Both branches use
+        # the same schema (id, tag, intensity); the import-availability flag
+        # only switches between the canonical class and its inline fallback.
+        ref = EventReference(
+            id=f"event_{len(self.E_tags)}",
+            tag=semantic_context or event_type,
+            intensity=max(0.0, min(1.0, intensity)),
+        )
+        self.E_tags.append(ref)
 
     def update_state(
         self,

--- a/phionyx_core/state/ethics_enforcement.py
+++ b/phionyx_core/state/ethics_enforcement.py
@@ -20,11 +20,11 @@ try:
     from .ethics_enforcement_wrapper import EthicsEnforcement
 except ImportError:
     # Create a minimal stub if wrapper import fails
-    class EthicsEnforcement:
+    class EthicsEnforcement:  # type: ignore[no-redef]
         """Stub EthicsEnforcement class."""
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
             pass
-        def check_risk(self, *args, **kwargs):
+        def check_risk(self, *args: Any, **kwargs: Any) -> Any:
             raise NotImplementedError("EthicsEnforcement.check_risk not implemented")
 
 __all__ = [
@@ -49,7 +49,7 @@ except (ImportError, ValueError):
         parent_dir = os.path.dirname(os.path.abspath(__file__))
         if parent_dir not in sys.path:
             sys.path.insert(0, parent_dir)
-        from ethics import EthicsVector
+        from ethics import EthicsVector  # type: ignore[no-redef]
 
 
 @dataclass

--- a/phionyx_core/state/measurement_mapper.py
+++ b/phionyx_core/state/measurement_mapper.py
@@ -456,13 +456,13 @@ class MeasurementMapper:
 
             from pydantic import BaseModel
 
-            class EvidenceSpan(BaseModel):
+            class EvidenceSpan(BaseModel):  # type: ignore[no-redef]
                 text: str
                 start: int
                 end: int
                 tag: str
 
-            class MeasurementPacket(BaseModel):
+            class MeasurementPacket(BaseModel):  # type: ignore[no-redef]
                 A: float
                 V: float
                 D: float | None = None

--- a/phionyx_core/state/state_adapter.py
+++ b/phionyx_core/state/state_adapter.py
@@ -136,7 +136,7 @@ class EchoState2Adapter:
             "trust_trend": self.aux_state.trust_trend,
             "risk_score": self.risk_score,
             "high_risk_flag": self.aux_state.high_risk_flag,
-            "memory_tags": [tag.semantic_context for tag in self.echo_state2.E_tags],
+            "memory_tags": [tag.tag for tag in self.echo_state2.E_tags],
             "memory_strength": 0.5,  # Default
             "metadata": {
                 **self.aux_state.metadata,

--- a/phionyx_core/state/state_migration.py
+++ b/phionyx_core/state/state_migration.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 """
 State Migration - UnifiedEchoState ↔ EchoState2 Adapter
 ========================================================
@@ -10,6 +11,14 @@ Per Echoism Core v1.0:
 Migration utilities for converting between:
 - UnifiedEchoState (old/legacy) -> EchoState2 + AuxState (new/canonical)
 - EchoState2 + AuxState -> UnifiedEchoState (backward compatibility)
+
+Why ignore-errors: UnifiedEchoState lives in `app.core.echo.unified_state` —
+a private legacy package not shipped with phionyx-core. The import is
+optional (try/except), and every public-facing call is gated on
+OLD_STATE_AVAILABLE. mypy cannot resolve the legacy type, so its
+attribute lookups, kwargs, and return types all surface as errors. None
+of it is reachable in the public SDK; the file exists purely so
+internal callers that still hold a UnifiedEchoState can migrate.
 """
 
 from __future__ import annotations

--- a/phionyx_core/state/ukf_process_model.py
+++ b/phionyx_core/state/ukf_process_model.py
@@ -16,6 +16,7 @@ State transition rules:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -171,7 +172,7 @@ def create_echoism_process_model(
     trace_strength: float = 0.0,
     task_outcome: str | None = None,
     confidence: float = 0.5
-) -> callable:
+) -> Callable[..., np.ndarray]:
     """
     Create process model function with fixed control inputs.
 
@@ -202,7 +203,8 @@ def create_echoism_process_model(
         control_input = control if control is not None else u
 
         # Extract dt from control or use default
-        dt_value = control_input.get("dt", dt)
+        dt_raw = control_input.get("dt", dt)
+        dt_value: float = float(dt_raw) if isinstance(dt_raw, (int, float)) else dt
 
         return echoism_process_model(x, dt_value, control_input)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,12 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
+plugins = ["pydantic.mypy"]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+warn_required_dynamic_aliases = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Wave 4 of the gradual mypy rollout. Locks `phionyx_core/state/` and `phionyx_core/pipeline/` at zero errors.

Combined wave 1 + 2 + 3 + 4 mypy gate now covers **15 modules / 172 source files** with `--follow-imports=silent`.

## Two structural improvements

- **pyproject.toml** — enable `pydantic.mypy` plugin. Without the plugin, every `Field(None, ge=0.0, ...)` default looks like a required arg to mypy, and ~49 errors across pipeline blocks (ConfidencePayload, ActionIntent, WorkspaceEvent, PerceptualFrame, WorldStateSnapshot, etc.) cascade from that one gap. With the plugin, those resolve automatically.
- **pipeline/base.py** — `BlockContext.metadata` was `= None` with a `__post_init__` workaround. Switched to `field(default_factory=dict)`. Same runtime, tighter typing.

## Direct fixes (~28 errors → 0)

### state/
- `state_migration.py`: `# mypy: ignore-errors` — the whole module is gated on `OLD_STATE_AVAILABLE` which is always `False` in the public SDK. mypy can't resolve the legacy `UnifiedEchoState` type and surfaces 23 phantom errors. Documented in the docstring.
- `ethics_enforcement.py`: `# type: ignore[no-redef]` on try/except fallback class
- `echo_state_2.py`: align `EventReference` call site to canonical `(id, tag, intensity)` schema. The dead-branch had stale kwargs `(event_id, event_type, tags)` that wouldn't run anyway. Plus `float()` wrap on `phi_result.get()`.
- `state_adapter.py`: `tag.semantic_context` → `tag.tag` (matches actual EventReference fields)
- `measurement_mapper.py`: `# type: ignore[no-redef]` on Pydantic fallback models
- `ukf_process_model.py`: `callable` → `Callable[..., np.ndarray]`; `isinstance` guard for `dt` from control dict
- `echo_ontology.py`: explicit import alias in except branch to avoid `trace_weight` type narrowing colliding with `trace_weight_standard`

### pipeline/
- `kill_switch_gate.py`: `float()`/`bool()` wraps on `_extract_*` return paths (10 errors)
- `blocks/ukf_predict.py`, `initialize_unified_state.py`, `create_scenario_frame.py`, `cognitive_layer.py`: explicit `None`-guard on Optional protocol attribute access. The `if not unified_state` truthy check wasn't narrowing the protocol field.
- `blocks/narrative_layer.py`: `TemplateManager` import made explicit, `assert self.processor is not None` (already gated by `should_skip()`), `conversation_history` added to `NarrativeLayerProcessorProtocol.process_narrative_layer` signature.
- `blocks/time_update_sot.py`: `TimeManagerProtocol.state` field declared
- `blocks/trust_evaluation.py`: `max_risk` explicit `float`
- `blocks/response_revision_gate.py`: `float()` wrap on `_calculate_damp_factor`
- `blocks/behavioral_drift_detection.py`: `current_metrics` typed `dict[str, float]` with `float()` wraps on each entry
- `blocks/archive/{coherence_qa,drive_coherence_update}.py`: drop late-bound inner type annotations that collided with the earlier branch's inferred type

## Verification

```
$ rm -rf .mypy_cache && mypy --follow-imports=silent <15 modules>
Success: no issues found in 172 source files

$ pytest tests/core -q
1018 passed in 2.62s
```

No behavior changes — type-only refinements + a structural improvement (`__post_init__` → `field`) and one bug fix (`tag.semantic_context` → `tag.tag` was actually broken at runtime).

## Next waves

Tracked in `project_mypy_deferred.md`:
- Wave 5: memory, meta, monitoring, profiles
- Wave 6: orchestrator (block factory needs typed registry / Generic[T])

🤖 Generated with [Claude Code](https://claude.com/claude-code)