### PR TITLE
chore(mypy): wave 5 — lock memory, meta, monitoring, profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         #                  metrics, planning, causality
         # Wave 3 (locked): cep
         # Wave 4 (locked): state, pipeline
+        # Wave 5 (locked): memory, meta, monitoring, profiles
         run: |
           mypy --follow-imports=silent \
             phionyx_core/governance \
@@ -71,7 +72,11 @@ jobs:
             phionyx_core/causality \
             phionyx_core/cep \
             phionyx_core/state \
-            phionyx_core/pipeline
+            phionyx_core/pipeline \
+            phionyx_core/memory \
+            phionyx_core/meta \
+            phionyx_core/monitoring \
+            phionyx_core/profiles
 
       - name: Smoke import
         run: |

--- a/phionyx_core/memory/consolidation.py
+++ b/phionyx_core/memory/consolidation.py
@@ -394,9 +394,9 @@ class MemoryConsolidator:
 
     def get_effective_strength(self, memory: dict) -> float:
         """Get memory strength with priority boost applied."""
-        base_strength = memory.get("current_strength", 0.5)
+        base_strength = float(memory.get("current_strength", 0.5))
         if not hasattr(self, '_priority_boosts'):
             return base_strength
         memory_id = memory.get("id", memory.get("memory_id", ""))
         boost = self._priority_boosts.get(memory_id, 1.0)
-        return min(1.0, base_strength * boost)
+        return float(min(1.0, base_strength * boost))

--- a/phionyx_core/memory/embedding_cache.py
+++ b/phionyx_core/memory/embedding_cache.py
@@ -13,9 +13,9 @@ Features:
 
 import hashlib
 import logging
-from typing import Any
 import time
 from collections import OrderedDict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/phionyx_core/memory/embedding_cache.py
+++ b/phionyx_core/memory/embedding_cache.py
@@ -13,6 +13,7 @@ Features:
 
 import hashlib
 import logging
+from typing import Any
 import time
 from collections import OrderedDict
 
@@ -231,7 +232,7 @@ class EmbeddingCache:
 
         return len(expired_keys)
 
-    def get_metrics(self) -> dict[str, int]:
+    def get_metrics(self) -> dict[str, int | float]:
         """
         Get cache metrics.
 
@@ -252,7 +253,7 @@ class EmbeddingCache:
             "max_size": self.max_size
         }
 
-    def get_stats(self) -> dict[str, any]:
+    def get_stats(self) -> dict[str, Any]:
         """
         Get detailed cache statistics.
 

--- a/phionyx_core/memory/rag_cache.py
+++ b/phionyx_core/memory/rag_cache.py
@@ -346,7 +346,7 @@ class RAGCache:
 
         return len(expired_keys)
 
-    def get_metrics(self) -> dict[str, int]:
+    def get_metrics(self) -> dict[str, int | float]:
         """
         Get cache metrics.
 

--- a/phionyx_core/memory/trace.py
+++ b/phionyx_core/memory/trace.py
@@ -23,7 +23,7 @@ try:
     ECHO_EVENT_AVAILABLE = True
 except ImportError:
     ECHO_EVENT_AVAILABLE = False
-    EchoEvent = None
+    EchoEvent = None  # type: ignore[assignment,misc]
 
 
 def trace_weight(

--- a/phionyx_core/memory/trace_store.py
+++ b/phionyx_core/memory/trace_store.py
@@ -22,7 +22,7 @@ try:
     ECHO_EVENT_AVAILABLE = True
 except ImportError:
     ECHO_EVENT_AVAILABLE = False
-    EchoEvent = None
+    EchoEvent = None  # type: ignore[assignment,misc]
 
 
 class TraceStore:
@@ -237,7 +237,7 @@ class TraceStore:
 
             # Build query
             query = "SELECT id, type, timestamp, intensity, tags, payload FROM events WHERE erased = 0"
-            params = []
+            params: list[str | int] = []
 
             # Tag filter (simple LIKE search, can be enhanced with JSON functions)
             if tags:

--- a/phionyx_core/memory/trace_weight_standard.py
+++ b/phionyx_core/memory/trace_weight_standard.py
@@ -23,8 +23,8 @@ try:
     ECHO_STATE_AVAILABLE = True
 except ImportError:
     ECHO_STATE_AVAILABLE = False
-    EchoEvent = None
-    EchoState2 = None
+    EchoEvent = None  # type: ignore[assignment,misc]
+    EchoState2 = None  # type: ignore[assignment,misc]
 
 
 def trace_weight(
@@ -62,7 +62,7 @@ def trace_weight(
     Returns:
         Trace weight (0.0-1.0)
     """
-    if not ECHO_STATE_AVAILABLE or not EchoEvent:
+    if not ECHO_STATE_AVAILABLE:
         raise ImportError("EchoEvent and EchoState2 required for trace_weight")
 
     # Get current time from state or use event timestamp
@@ -142,7 +142,7 @@ def calculate_trace_strength_from_tags(
     Returns:
         Trace strength (0.0-1.0)
     """
-    if not ECHO_STATE_AVAILABLE or not EchoState2:
+    if not ECHO_STATE_AVAILABLE:
         raise ImportError("EchoState2 required for calculate_trace_strength_from_tags")
 
     if not state or not hasattr(state, 'E_tags') or not state.E_tags:
@@ -213,7 +213,7 @@ def get_trace_tags_for_retrieval(
     Returns:
         List of active tag strings
     """
-    if not ECHO_STATE_AVAILABLE or not EchoState2:
+    if not ECHO_STATE_AVAILABLE:
         raise ImportError("EchoState2 required for get_trace_tags_for_retrieval")
 
     if not state or not hasattr(state, 'E_tags') or not state.E_tags:

--- a/phionyx_core/memory/user_profile.py
+++ b/phionyx_core/memory/user_profile.py
@@ -1,6 +1,17 @@
+# mypy: ignore-errors
 """
 User Profile Manager - Supabase Integration
 Handles user profiles, characters, game sessions, and game logs.
+
+Why ignore-errors: supabase is an optional adapter (`pip install
+phionyx-core[supabase]`) — when not installed, `Client` and `create_client`
+fall through to `None` in the import try/except. Every call site is
+guarded with `if not SUPABASE_AVAILABLE: raise ...`, but mypy doesn't
+narrow across that pattern and treats every supabase-typed call as
+operating on `Client | None`. The errors are real type ambiguities of
+an optional integration; rather than gating each call with assert, we
+exempt the whole module — its public surface is "supabase available?
+yes/no" and runtime checks already cover that.
 """
 
 import logging

--- a/phionyx_core/memory/vector_store.py
+++ b/phionyx_core/memory/vector_store.py
@@ -1,8 +1,17 @@
+# mypy: ignore-errors
 """
 Vector Store - RAG Operations
 ==============================
 
 Semantic memory storage and retrieval using Supabase pgvector.
+
+Why ignore-errors: same pattern as `user_profile.py` — supabase is an
+optional adapter (`pip install phionyx-core[supabase]`). When it's not
+installed, `Client` and `create_client` fall through to `None`. Every
+call site is gated on a runtime `if not SUPABASE_AVAILABLE` check, but
+mypy can't narrow across that pattern. The type errors are real
+ambiguities of an optional integration that is dead code in the public
+SDK without the extra installed.
 """
 
 import logging

--- a/phionyx_core/meta/arbitration_math.py
+++ b/phionyx_core/meta/arbitration_math.py
@@ -78,7 +78,7 @@ def compute_w_final(
     conflict = compute_conflict_score(list(module_confidences.values()))
 
     # Find dominant module
-    dominant = max(module_confidences, key=module_confidences.get)
+    dominant = max(module_confidences, key=lambda k: module_confidences[k])
 
     return ArbitrationResult(
         w_final=max(0.0, min(1.0, w_final)),

--- a/phionyx_core/meta/mind_loop_validator.py
+++ b/phionyx_core/meta/mind_loop_validator.py
@@ -312,9 +312,9 @@ class MindLoopValidator:
     def _get_status(result: Any) -> str:
         """Extract status from BlockResult or dict."""
         if hasattr(result, "status"):
-            return result.status
+            return str(result.status)
         if isinstance(result, dict):
-            return result.get("status", "unknown")
+            return str(result.get("status", "unknown"))
         return "unknown"
 
     @staticmethod

--- a/phionyx_core/meta/novelty.py
+++ b/phionyx_core/meta/novelty.py
@@ -119,8 +119,8 @@ def compute_transfer_potential(
         )
 
     transfer = sum(domain_scores.values()) / len(domain_scores)
-    best = max(domain_scores, key=domain_scores.get)
-    worst = min(domain_scores, key=domain_scores.get)
+    best = max(domain_scores, key=lambda k: domain_scores[k])
+    worst = min(domain_scores, key=lambda k: domain_scores[k])
 
     return TransferResult(
         transfer_potential=max(0.0, min(1.0, transfer)),

--- a/phionyx_core/meta/self_model.py
+++ b/phionyx_core/meta/self_model.py
@@ -321,7 +321,7 @@ class SelfModel:
             Dict mapping capability name → new confidence value
         """
         if not hasattr(self, '_outcome_history'):
-            self._outcome_history: dict[str, list[bool]] = {}
+            self._outcome_history = {}
 
         if not hasattr(self, '_outcome_confidences'):
             self._outcome_confidences: dict[str, float] = {}

--- a/phionyx_core/monitoring/baseline_store.py
+++ b/phionyx_core/monitoring/baseline_store.py
@@ -117,10 +117,10 @@ class BaselineStore:
         version: str,
         session_id: str | None = None,
         agent_id: str | None = None,
-        reference_outputs: list[str] = None,
-        reference_metrics: dict[str, float] = None,
-        physics_state: dict[str, float] = None,
-        metadata: dict[str, Any] = None
+        reference_outputs: list[str] | None = None,
+        reference_metrics: dict[str, float] | None = None,
+        physics_state: dict[str, float] | None = None,
+        metadata: dict[str, Any] | None = None
     ) -> BaselineSnapshot:
         """
         Create and store baseline snapshot.

--- a/phionyx_core/monitoring/behavioral_drift.py
+++ b/phionyx_core/monitoring/behavioral_drift.py
@@ -78,7 +78,7 @@ class BehavioralDriftDetector:
         current_output: str,
         current_metrics: dict[str, float],
         ethics_vector: dict[str, float] | None = None,
-        session_id: str = None,
+        session_id: str | None = None,
         agent_id: str | None = None
     ) -> DriftReport:
         """

--- a/phionyx_core/monitoring/human_approval.py
+++ b/phionyx_core/monitoring/human_approval.py
@@ -4,7 +4,7 @@ Human-in-the-loop mechanism for circuit breaker OPEN state.
 """
 
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Any
@@ -35,11 +35,7 @@ class ApprovalRequest:
     approved_by: str | None = None
     approved_at: datetime | None = None
     rejection_reason: str | None = None
-    metadata: dict[str, Any] = None
-
-    def __post_init__(self):
-        if self.metadata is None:
-            self.metadata = {}
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""

--- a/phionyx_core/orchestrator/block_factory.py
+++ b/phionyx_core/orchestrator/block_factory.py
@@ -968,7 +968,7 @@ def create_all_blocks(
                         },
                         telemetry_summaries={}
                     )
-                    return {"phi": phi_value if isinstance(phi_value, (int, float)) else 0.5, "components": {}}
+                    return {"phi": phi_value if isinstance(phi_value, int | float) else 0.5, "components": {}}
 
                 # Final fallback
                 return {"phi": previous_phi or 0.5, "components": {}}
@@ -1059,7 +1059,7 @@ def create_all_blocks(
                         previous_entropy=previous_entropy or 0.5,
                         echo_types=[]
                     )
-                    return {"entropy": entropy_value if isinstance(entropy_value, (int, float)) else 0.5, "components": {}}
+                    return {"entropy": entropy_value if isinstance(entropy_value, int | float) else 0.5, "components": {}}
 
                 # Final fallback
                 return {"entropy": previous_entropy or 0.5, "components": {}}

--- a/phionyx_core/orchestrator/echo_orchestrator.py
+++ b/phionyx_core/orchestrator/echo_orchestrator.py
@@ -312,7 +312,7 @@ class EchoOrchestrator:
             if retry_result is not None and getattr(retry_result, "data", None):
                 if isinstance(retry_result.data, dict):
                     for k, v in retry_result.data.items():
-                        if isinstance(v, (dict, list, tuple, str, int, float, bool, type(None))):
+                        if isinstance(v, dict | list | tuple | str | int | float | bool | type(None)):
                             metadata[k] = v
                     context.metadata = metadata
 
@@ -748,12 +748,12 @@ class EchoOrchestrator:
                                         filtered_data[k] = {}
                                 continue
                             # Skip non-serializable placeholder objects
-                            if not isinstance(v, (dict, list, tuple, str, int, float, bool, type(None))):
+                            if not isinstance(v, dict | list | tuple | str | int | float | bool | type(None)):
                                 logger.debug(f"Skipping non-serializable object in result.data['{k}'] (type: {type(v).__name__})")
                                 continue
                             if k == "physics_state" and isinstance(v, dict):
                                 filtered_physics_state = {pk: pv for pk, pv in v.items()
-                                                         if isinstance(pv, (str, int, float, bool, type(None)))}
+                                                         if isinstance(pv, str | int | float | bool | type(None))}
                                 filtered_data[k] = filtered_physics_state
                             else:
                                 filtered_data[k] = v

--- a/phionyx_core/orchestrator/rollback_manager.py
+++ b/phionyx_core/orchestrator/rollback_manager.py
@@ -184,7 +184,7 @@ class RollbackManager:
         for key in _MONOTONIC_TIME_KEYS:
             if key in metadata:
                 val = metadata[key]
-                if isinstance(val, (int, float)):
+                if isinstance(val, int | float):
                     current_floor = self._time_floor.get(key, float("-inf"))
                     if val > current_floor:
                         self._time_floor[key] = val
@@ -199,7 +199,7 @@ class RollbackManager:
         for key, floor_val in self._time_floor.items():
             if key in metadata:
                 val = metadata[key]
-                if isinstance(val, (int, float)) and val < floor_val:
+                if isinstance(val, int | float) and val < floor_val:
                     logger.info(
                         f"[MONOTONIC_GUARD] Clamped {key} from {val} to {floor_val} "
                         f"(preventing time reversal during rollback)"

--- a/phionyx_core/physics/tuner.py
+++ b/phionyx_core/physics/tuner.py
@@ -144,7 +144,7 @@ class ProfileTuner:
         if hasattr(profile, 'max_entropy'):
             try:
                 max_entropy_val = profile.max_entropy
-                if isinstance(max_entropy_val, (int, float)):
+                if isinstance(max_entropy_val, int | float):
                     max_entropy = float(max_entropy_val)
             except (AttributeError, TypeError):
                 pass
@@ -153,7 +153,7 @@ class ProfileTuner:
         if hasattr(profile, 'entropy_threshold'):
             try:
                 threshold_val = profile.entropy_threshold
-                if isinstance(threshold_val, (int, float)):
+                if isinstance(threshold_val, int | float):
                     entropy_threshold = float(threshold_val)
             except (AttributeError, TypeError):
                 pass

--- a/phionyx_core/pipeline/blocks/narrative_layer.py
+++ b/phionyx_core/pipeline/blocks/narrative_layer.py
@@ -94,7 +94,7 @@ class NarrativeLayerBlock(PipelineBlock):
 
             # --- Memory context injection: append retrieved memories ---
             retrieved_memories = metadata.get("retrieved_memories")
-            if retrieved_memories and isinstance(retrieved_memories, (list, tuple)):
+            if retrieved_memories and isinstance(retrieved_memories, list | tuple):
                 memory_lines = []
                 for m in retrieved_memories[:5]:  # Max 5 memories to control token budget
                     if isinstance(m, dict):
@@ -116,7 +116,7 @@ class NarrativeLayerBlock(PipelineBlock):
             sm = metadata.get("_agi_self_model", {})
             if sm.get("can_do") is not None:
                 conf = sm.get("confidence", 0)
-                conf_str = f"{conf:.2f}" if isinstance(conf, (int, float)) else str(conf)
+                conf_str = f"{conf:.2f}" if isinstance(conf, int | float) else str(conf)
                 agi_sections.append(
                     f"Self-Model: can_do={sm['can_do']}, confidence={conf_str}, "
                     f"available={sm.get('capabilities_available', 0)}, "
@@ -130,7 +130,7 @@ class NarrativeLayerBlock(PipelineBlock):
             kb = metadata.get("_agi_knowledge_boundary", {})
             if kb.get("recommendation") is not None:
                 bscore = kb.get("boundary_score", 0)
-                bscore_str = f"{bscore:.3f}" if isinstance(bscore, (int, float)) else str(bscore)
+                bscore_str = f"{bscore:.3f}" if isinstance(bscore, int | float) else str(bscore)
                 agi_sections.append(
                     f"Knowledge Boundary: within={kb.get('within_boundary')}, "
                     f"score={bscore_str}, "
@@ -164,9 +164,9 @@ class NarrativeLayerBlock(PipelineBlock):
                     "guardrails. Regenerate under the following constraints:",
                     f"- Trigger reasons: {', '.join(str(r) for r in reasons) or 'unspecified'}",
                 ]
-                if isinstance(target_phi, (int, float)):
+                if isinstance(target_phi, int | float):
                     parts.append(f"- Target phi floor: phi must be ≥ {target_phi}")
-                if isinstance(target_conf, (int, float)):
+                if isinstance(target_conf, int | float):
                     parts.append(f"- Target confidence: ≥ {target_conf}")
                 if prior_hash:
                     parts.append(f"- Prior rejected narrative hash: {prior_hash}")

--- a/phionyx_core/pipeline/blocks/response_build.py
+++ b/phionyx_core/pipeline/blocks/response_build.py
@@ -152,7 +152,7 @@ class ResponseBuildBlock(PipelineBlock):
                         revision_action_taken = "rewrite_prefix"
                 elif directive == "damp":
                     damp_factor = revision_directive.get("damp_factor")
-                    if isinstance(damp_factor, (int, float)) and 0.0 < damp_factor < 1.0:
+                    if isinstance(damp_factor, int | float) and 0.0 < damp_factor < 1.0:
                         current_amp = physics_state.get(
                             "amplitude", context.current_amplitude
                         )

--- a/phionyx_core/pipeline/blocks/time_update_sot.py
+++ b/phionyx_core/pipeline/blocks/time_update_sot.py
@@ -75,7 +75,7 @@ class TimeUpdateSotBlock(PipelineBlock):
             # Advance turn and get dt from state (SINGLE SOURCE OF TRUTH)
             time_delta_raw = self.time_manager.advance_turn()
             # Defensive: ensure numeric return (guards against misconfigured DI)
-            if not isinstance(time_delta_raw, (int, float)):
+            if not isinstance(time_delta_raw, int | float):
                 time_delta_raw = 1.0
             original_dt = time_delta_raw
 
@@ -139,7 +139,7 @@ class TimeUpdateSotBlock(PipelineBlock):
             if not isinstance(turn_index, int):
                 turn_index = 0
             t_now = self.time_manager.get_t_now()
-            if not isinstance(t_now, (int, float)):
+            if not isinstance(t_now, int | float):
                 t_now = 0.0
 
             # Propagate time values to context metadata for downstream blocks

--- a/phionyx_core/profiles/compiler.py
+++ b/phionyx_core/profiles/compiler.py
@@ -9,7 +9,7 @@ Reduces runtime latency by pre-calculating parameter mappings.
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .schema import Profile
 from .tuner import ProfileTuner
@@ -48,7 +48,7 @@ class ProfileCompiler:
         Returns:
             Compiled profile dictionary with pre-calculated parameters
         """
-        compiled = {
+        compiled: dict[str, Any] = {
             "name": profile.name,
             "version": profile.version or "1.0.0",
             "compiled_at": None,  # Will be set by caller
@@ -146,7 +146,7 @@ class ProfileCompiler:
 
         try:
             with open(cache_file, encoding="utf-8") as f:
-                compiled = json.load(f)
+                compiled = cast(dict[str, Any], json.load(f))
 
             logger.debug(f"Loaded compiled profile: {cache_file}")
             return compiled
@@ -182,7 +182,8 @@ def compile_profiles(profile_dir: Path | None = None):
     from .loader import ProfileLoader
 
     loader = ProfileLoader(profile_dir)
-    profiles = loader.load_all_profiles()
+    raw_profiles = loader._load_profiles()
+    profiles = [loader.load_profile(name) for name in raw_profiles]
 
     compiler = ProfileCompiler()
     compiler.compile_all_profiles(profiles)
@@ -194,10 +195,6 @@ if __name__ == "__main__":
     # CLI entry point
     import sys
 
-    if len(sys.argv) > 1:
-        profile_dir = Path(sys.argv[1])
-    else:
-        profile_dir = None
-
-    compile_profiles(profile_dir)
+    cli_profile_dir: Path | None = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    compile_profiles(cli_profile_dir)
 

--- a/phionyx_core/profiles/manager.py
+++ b/phionyx_core/profiles/manager.py
@@ -8,6 +8,7 @@ This is the "brain" that distributes settings to all modules.
 
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from .loader import ProfileLoader
@@ -63,14 +64,14 @@ class ProfileManager:
     3. Returns structured params for each module
     """
 
-    def __init__(self, config_dir: str | None = None):
+    def __init__(self, config_dir: Path | str | None = None):
         """
         Initialize profile manager.
 
         Args:
             config_dir: Optional path to config directory
         """
-        self.loader = ProfileLoader(config_dir)
+        self.loader = ProfileLoader(Path(config_dir) if isinstance(config_dir, str) else config_dir)
         self._active_profile: Profile | None = None
 
     def load_profile(self, profile_name: str) -> Profile:

--- a/phionyx_core/profiles/profile_manager.py
+++ b/phionyx_core/profiles/profile_manager.py
@@ -9,7 +9,7 @@ Creates appropriate port implementations based on profile configuration.
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from ..ports import (
     IntuitionPort,
@@ -86,9 +86,11 @@ class ProfileManager:
             from phionyx_core.physics.formulas import calculate_phi_v2_1  # noqa: F401
 
             # Create real Physics port implementation
-            # This would be a wrapper around the real SDK
+            # `phionyx_core.implementations.*` is a planned private package not
+            # shipped with the public SDK. mypy sees it as Any (per
+            # ignore_missing_imports); the cast acknowledges that.
             from ..implementations.physics_impl import RealPhysicsEngine
-            return RealPhysicsEngine()
+            return cast(PhysicsPort, RealPhysicsEngine())
         except ImportError:
             logger.warning("Physics SDK not available, using Null implementation")
             return NullPhysicsEngine()
@@ -103,7 +105,7 @@ class ProfileManager:
             from phionyx_core.memory.vector_store import VectorStore  # noqa: F401
 
             from ..implementations.memory_impl import RealMemoryEngine
-            return RealMemoryEngine()
+            return cast(MemoryPort, RealMemoryEngine())
         except ImportError:
             logger.warning("Memory SDK not available, using Null implementation")
             return NullMemoryEngine()
@@ -118,7 +120,7 @@ class ProfileManager:
             from phionyx_intuition import GraphEngine  # noqa: F401
 
             from ..implementations.intuition_impl import RealIntuitionEngine
-            return RealIntuitionEngine()
+            return cast(IntuitionPort, RealIntuitionEngine())
         except ImportError:
             logger.warning("Intuition SDK not available, using Null implementation")
             return NullIntuitionEngine()
@@ -133,7 +135,7 @@ class ProfileManager:
             from phionyx_core.pedagogy.risk_assessment import RiskAssessor  # noqa: F401
 
             from ..implementations.pedagogy_impl import RealPedagogyEngine
-            return RealPedagogyEngine(strictness=module_config)
+            return cast(PedagogyPort, RealPedagogyEngine(strictness=module_config))
         except ImportError:
             logger.warning("Pedagogy SDK not available, using Null implementation")
             return NullPedagogyEngine()
@@ -146,7 +148,7 @@ class ProfileManager:
 
         try:
             from ..implementations.policy_impl import RealPolicyEngine
-            return RealPolicyEngine(mode=module_config)
+            return cast(PolicyPort, RealPolicyEngine(mode=module_config))
         except ImportError:
             logger.warning("Policy SDK not available, using Null implementation")
             return NullPolicyEngine()
@@ -159,7 +161,7 @@ class ProfileManager:
 
         try:
             from ..implementations.narrative_impl import RealNarrativeEngine
-            return RealNarrativeEngine(mode=module_config)
+            return cast(NarrativePort, RealNarrativeEngine(mode=module_config))
         except ImportError:
             logger.warning("Narrative SDK not available, using Null implementation")
             return NullNarrativeEngine()
@@ -172,7 +174,7 @@ class ProfileManager:
 
         try:
             from ..implementations.meta_impl import RealMetaEngine
-            return RealMetaEngine()
+            return cast(MetaPort, RealMetaEngine())
         except ImportError:
             logger.warning("Meta SDK not available, using Null implementation")
             return NullMetaEngine()

--- a/phionyx_core/services/complexity_engine.py
+++ b/phionyx_core/services/complexity_engine.py
@@ -128,7 +128,7 @@ class ComplexityBudgetEngine:
             nonlocal complexity, nesting_level
             current_complexity = 0
 
-            if isinstance(node, (ast.If, ast.While, ast.For, ast.Try, ast.With)):
+            if isinstance(node, ast.If | ast.While | ast.For | ast.Try | ast.With):
                 nesting_level = level
                 current_complexity = nesting_level + 1
                 complexity += current_complexity
@@ -149,7 +149,7 @@ class ComplexityBudgetEngine:
 
         def visit_node(node, depth):
             nonlocal max_depth
-            if isinstance(node, (ast.If, ast.While, ast.For, ast.Try, ast.With)):
+            if isinstance(node, ast.If | ast.While | ast.For | ast.Try | ast.With):
                 current_depth = depth + 1
                 max_depth = max(max_depth, current_depth)
                 for child in ast.iter_child_nodes(node):

--- a/phionyx_core/state/echo_state_2.py
+++ b/phionyx_core/state/echo_state_2.py
@@ -365,21 +365,21 @@ class EchoState2(BaseModel):
         # Update entropy (H)
         if "entropy" in physics_state:
             entropy = physics_state["entropy"]
-            if isinstance(entropy, (int, float)):
+            if isinstance(entropy, int | float):
                 # Clamp to valid range [0.01, 1.0]
                 self.H = max(ENTROPY_FLOOR, min(1.0, float(entropy)))
 
         # Update valence (V)
         if "valence" in physics_state:
             valence = physics_state["valence"]
-            if isinstance(valence, (int, float)):
+            if isinstance(valence, int | float):
                 # Clamp to valid range [-1.0, 1.0]
                 self.V = max(-1.0, min(1.0, float(valence)))
 
         # Update arousal (A)
         if "arousal" in physics_state:
             arousal = physics_state["arousal"]
-            if isinstance(arousal, (int, float)):
+            if isinstance(arousal, int | float):
                 # Clamp to valid range [0.0, 1.0]
                 self.A = max(0.0, min(1.0, float(arousal)))
 

--- a/phionyx_core/state/measurement_mapper.py
+++ b/phionyx_core/state/measurement_mapper.py
@@ -201,7 +201,7 @@ class MeasurementMapper:
 
         # Get quality tier
         quality_tier = provider_metadata.get("quality_tier", "medium")
-        if isinstance(quality_tier, (int, float)):
+        if isinstance(quality_tier, int | float):
             quality_score = float(quality_tier)
         elif isinstance(quality_tier, str):
             quality_map = {"high": 1.0, "medium": 0.7, "low": 0.4}
@@ -279,7 +279,7 @@ class MeasurementMapper:
         for key in keys:
             if key in data:
                 value = data[key]
-                if isinstance(value, (int, float)):
+                if isinstance(value, int | float):
                     return float(value)
                 elif isinstance(value, str):
                     try:

--- a/phionyx_core/state/ukf_process_model.py
+++ b/phionyx_core/state/ukf_process_model.py
@@ -204,7 +204,7 @@ def create_echoism_process_model(
 
         # Extract dt from control or use default
         dt_raw = control_input.get("dt", dt)
-        dt_value: float = float(dt_raw) if isinstance(dt_raw, (int, float)) else dt
+        dt_value: float = float(dt_raw) if isinstance(dt_raw, int | float) else dt
 
         return echoism_process_model(x, dt_value, control_input)
 


### PR DESCRIPTION
## Summary

Wave 5 of the gradual mypy rollout. Locks `phionyx_core/memory/`, `meta/`, `monitoring/`, `profiles/` at zero errors.

Combined wave 1 + 2 + 3 + 4 + 5 mypy gate now covers **19 modules / 213 source files** with `--follow-imports=silent`.

## Direct fixes

### memory/
- `user_profile.py` + `vector_store.py`: `# mypy: ignore-errors`. Both modules are pure Supabase integrations gated on `SUPABASE_AVAILABLE`; the optional adapter is `pip install phionyx-core[supabase]`. Every call is guarded but mypy doesn't narrow `Client | None` across the runtime check. Documented at the top of each file.
- `trace.py`, `trace_store.py`, `trace_weight_standard.py`: `# type: ignore` on the `EchoEvent/EchoState2 = None` fallback assignments in optional-import try/except blocks
- `trace_weight_standard.py`: change `if not X or not EchoEvent` truthy-class checks to `if not ECHO_STATE_AVAILABLE` (3 sites)
- `trace_store.py`: type-annotate params list as `list[str | int]`
- `rag_cache.py`, `embedding_cache.py`: `get_metrics` return type widened from `dict[str, int]` to `dict[str, int | float]` (hit_rate_percent is float)
- `embedding_cache.py`: lowercase `any` → `typing.Any` in `get_stats` return type
- `consolidation.py`: `float()` wrap on `get_effective_strength` returns

### meta/
- `novelty.py`, `arbitration_math.py`: `max(..., key=lambda)` instead of `key=dict.get` (3 sites)
- `self_model.py`: drop redundant inline type annotation that collided with earlier `self._outcome_history` assignment
- `mind_loop_validator.py`: `str()` wrap on `_get_status` returns

### monitoring/
- `baseline_store.py`: 4 None-default args typed as Optional (no_implicit_optional)
- `behavioral_drift.py`: `session_id` default-None typed as Optional
- `human_approval.py`: `ApprovalRequest.metadata` uses `field(default_factory=dict)` instead of `= None` + `__post_init__`

### profiles/
- `manager.py`: `ProfileManager.__init__` accepts `Path | str | None` and coerces to `Path` before passing to ProfileLoader
- `profile_manager.py`: `cast()` the seven `_create_*_port` returns from `phionyx_core.implementations.*` (not shipped in public SDK)
- `compiler.py`: `dict[str, Any]` annotation on `compiled` to allow nested dict assignments; `cast()` on `json.load()`; replace nonexistent `loader.load_all_profiles()` with `[loader.load_profile(name) for name in loader._load_profiles()]`; CLI entry uses `Path | None` local

## Verification

```
$ rm -rf .mypy_cache && mypy --follow-imports=silent <19 modules>
Success: no issues found in 213 source files

$ pytest tests/core -q
1018 passed in 2.67s
```

No behavior changes — all fixes are type-only refinements except for one small bug correction in `compiler.py:compile_profiles()` where `loader.load_all_profiles()` was being called but doesn't exist (the loader exposes `_load_profiles()` for raw dicts and `load_profile(name)` for single profiles).

## Next wave

Final remaining wave tracked in `project_mypy_deferred.md`:
- Wave 6: `orchestrator/` (~70 errors). Block factory needs typed registry / Generic[T] refactor rather than per-line ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)