### PR TITLE
docs: phase 1 — Known limitations section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ runtime governance. To keep claims aligned with evidence, here is what we
 
 If a claim above feels too cautious for your context, write to founder@phionyx.ai — we will tell you what we have, what we do not, and what is on the roadmap.
 
+### Known limitations
+
+The following are real, not rhetorical. Treat them as load-bearing context when evaluating the project:
+
+- **Benchmarks are controlled reference benchmarks**, not third-party audits. Determinism, cache eviction and CPU overhead figures are reproducible from this repository on a clean clone; they have not yet been independently re-run.
+- **No third-party security review yet.** A paid independent review is on the roadmap; until it lands, treat the audit-trail and kill-switch implementations as research-grade.
+- **No production deployment claims.** Phionyx has not been operated in a regulated environment. Use it as a reference and pilot artifact, not as a certified runtime.
+- **LLM output quality is not guaranteed.** Phionyx governs *what reaches the user* (state, gates, audit) — it does not improve the model's own reasoning, hallucination rate, or domain accuracy.
+- **Compliance mappings (planned) are evidence mappings, not legal certification.** Tracing artifacts onto NIST AI RMF / EU AI Act / ISO 42001 produces inputs that an auditor or compliance officer can use; it does not constitute legal compliance on its own.
+- **The Φ (cognitive coherence) and entropy metrics are experimental.** They are useful as internal control signals and reproducible across runs, but they are not yet externally validated against established psychometric or behavioural benchmarks.
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## Summary

Driven by the 3rd external review: \"Known limitations\" was missing from the Scope section. This PR adds a real, load-bearing list right after the \"what we do not assert\" bullets.

Six items, each grounded in current reality:
- Benchmarks are controlled reference benchmarks (not third-party audits)
- No third-party security review yet
- No production deployment claims
- LLM output quality is not guaranteed by Phionyx
- Compliance mappings are evidence mappings, not legal certification
- Φ and entropy metrics are experimental, not externally validated

The same content is reflected on **phionyx.ai homepage** and cross-linked from the new **/evidence** Evidence Matrix page (companion monorepo commit).

## Why

External reviewer (\"3rd review\") noted that the \"Claims we do NOT make\" framing is good for legal/marketing surface, but reviewers also need a *technical* limitations list grounded in implementation reality (benchmarks scope, audit absence, metric maturity). This adds it.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)