### PR TITLE
chore(security): workflow hardening (top-level read-only + SHA-pin third-party)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+# Default to read-only token for everything in this workflow.
+# CI does not push, comment, or release — only reads the repo and writes
+# build artifacts to the workflow scratch space (which does not need
+# write permissions on the repo). Defence-in-depth: even a compromised
+# step cannot mutate the repository or its issues.
+permissions:
+  contents: read
+
 # Cancel in-progress runs when a new commit is pushed to the same PR / branch.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release-testpypi.yml
+++ b/.github/workflows/release-testpypi.yml
@@ -26,6 +26,11 @@ on:
         default: ""
         type: string
 
+# Default to read-only at the workflow level. The single job below
+# elevates id-token: write for the OIDC trusted-publisher exchange.
+permissions:
+  contents: read
+
 jobs:
   publish-testpypi:
     name: build + publish to TestPyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ on:
     tags:
       - "v*"
 
+# Default to read-only at the workflow level. The two jobs that need
+# elevated permissions request them explicitly:
+#   - github-release: contents: write   (upload release asset)
+#   - publish:         id-token: write  (OIDC trusted-publisher exchange)
+permissions:
+  contents: read
+
 jobs:
   build:
     name: build sdist + wheel
@@ -125,7 +132,10 @@ jobs:
         # release notes still come from CHANGELOG.md / manual edits;
         # this step only ensures the reproducibility pack is downloadable
         # straight from the tag page.
-        uses: softprops/action-gh-release@v2
+        # SHA-pinned (v2 → 3bb12739…) for supply-chain hardening — this is
+        # the only third-party action in our release path; everything
+        # else is actions/* or pypa/*.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: ./pack/reproducibility_pack_v*.zip
           fail_on_unmatched_files: true


### PR DESCRIPTION
## Summary

Pre-Zenodo / pre-v0.3.0 tag audit pass. The repo is sound otherwise — no hardcoded secrets, no shell-injection patterns, no vulnerable deps (pip-audit: 0 CVEs across pydantic / numpy / PyYAML / networkx / opentelemetry / asyncpg), build + twine + smoke install all green. This PR closes the two hardening opportunities the audit surfaced.

## Changes

**Top-level `permissions: contents: read` on all three workflows.**

- `ci.yml` — read-only at workflow level. CI does not push, comment, or release.
- `release.yml` — read-only at workflow level. The two jobs that need elevated permissions request them explicitly:
  - `github-release` keeps `contents: write` (uploads release asset)
  - `publish` keeps `id-token: write` (OIDC trusted-publisher exchange)
  - `build` and `reproducibility-pack` now inherit read-only.
- `release-testpypi.yml` — read-only at workflow level; `publish-testpypi` keeps `id-token: write`.

Defence-in-depth: even a compromised step cannot mutate the repo, issues, or releases beyond what its job explicitly asked for.

**SHA-pin for the only third-party action in the release path.**

`softprops/action-gh-release@v2` → `softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2`. Everything else under release.yml is `actions/*` or `pypa/*` (org-trusted, mutable tags acceptable for those).

## What the audit also checked (no findings, no changes needed)

- ✅ Hardcoded secrets (sk-*, AKIA*, ghp_*, AIza*) — none in source or git history.
- ✅ Tracked .env / credential files — none. `.gitignore` covers .env / .env.local / .env.production.
- ✅ Shell injection patterns (`shell=True`, raw eval/exec/pickle.loads, os.system) — none.
- ✅ subprocess.run usage (3 sites) — all use list-arg form, no shell=True.
- ✅ FastAPI input — Pydantic BaseModel-validated.
- ✅ Logger output — vault URL is logged on connect; no secret material is logged.
- ✅ Dependencies — `pip-audit` reports 0 known CVEs across all listed deps.
- ✅ sdist/wheel build — `python -m build` + `twine check` PASS for both artifacts.
- ✅ Smoke install on a clean venv — version, blocks (46), Φ, kill switch all assert correctly.
- ✅ SECURITY.md present, with private-disclosure path + scope + acknowledgement window.

## After merge

The repo is ready for:
1. `git tag v0.3.0 && git push origin v0.3.0`
2. Zenodo connection at zenodo.org/account/settings/github/

🤖 Generated with [Claude Code](https://claude.com/claude-code)