### PR TITLE
docs: register Zenodo DOIs for v0.3.0 (concept + version)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,10 +21,13 @@ keywords:
   - llm-safety
   - cognitive-architecture
   - auditable-ai
-# identifiers:
-#   - type: doi
-#     value: 10.5281/zenodo.XXXXXXX
-#     description: Archived Zenodo release for v0.3.0 (uncomment after first archive)
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.20027534
+    description: Concept DOI (always points to the latest archived version)
+  - type: doi
+    value: 10.5281/zenodo.20027535
+    description: Version DOI for v0.3.0
 preferred-citation:
   type: article
   title: "Phionyx: A Deterministic AI Runtime Architecture with Structured State Management and Pre-Response Governance"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Deterministic AI runtime that treats LLM outputs as sensor measurements, not dec
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-1%2C137%20pass-brightgreen.svg)](tests/)
 [![Mypy](https://img.shields.io/badge/mypy-strict%20%7C%200%20errors-brightgreen.svg)](.github/workflows/ci.yml)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20027534.svg)](https://doi.org/10.5281/zenodo.20027534)
 
 ```bash
 pip install phionyx-core
@@ -280,10 +281,13 @@ If you use Phionyx Core in academic work, please cite both the software and the 
   title     = {Phionyx Core SDK},
   year      = {2026},
   publisher = {Phionyx Research},
-  version   = {0.2.1},
-  url       = {https://github.com/halvrenofviryel/phionyx-research}
+  version   = {0.3.0},
+  doi       = {10.5281/zenodo.20027534},
+  url       = {https://doi.org/10.5281/zenodo.20027534}
 }
 ```
+
+The DOI above is the **concept DOI** — it always resolves to the latest archived version. To pin a specific release, use the version DOI in [`CITATION.cff`](CITATION.cff): v0.3.0 is `10.5281/zenodo.20027535`.
 
 **Architecture paper (companion):**
 
@@ -297,4 +301,4 @@ If you use Phionyx Core in academic work, please cite both the software and the 
 }
 ```
 
-A machine-readable [`CITATION.cff`](CITATION.cff) is provided for GitHub's “Cite this repository” widget. A persistent Zenodo DOI for archived releases is planned — once issued it will be added here as a badge and to `CITATION.cff` under `identifiers:`.
+A machine-readable [`CITATION.cff`](CITATION.cff) is provided for GitHub's “Cite this repository” widget; both the concept and version DOIs are registered there.


### PR DESCRIPTION
## Summary

First Zenodo-archived release of \`phionyx-core\`. Two DOIs are now active:

- **Concept DOI:** [10.5281/zenodo.20027534](https://doi.org/10.5281/zenodo.20027534) — always resolves to the latest archived version. README badge points here.
- **Version DOI v0.3.0:** [10.5281/zenodo.20027535](https://doi.org/10.5281/zenodo.20027535) — pinned to this specific release. Use this for reproducibility-critical citations.

## Changes

**CITATION.cff** — uncomment the \`identifiers:\` slot, register both DOIs (concept first, then version) with descriptions matching Zenodo conventions.

**README.md** — add a Zenodo DOI badge below the existing CI/PyPI/Tests/Mypy badges. Update the \`@software\` bibtex to include the DOI and bump version 0.2.1 → 0.3.0. Replace the "DOI is planned" footnote with the concept/version explanation.

## Verification

The Zenodo archive page is live at https://zenodo.org/records/20027535 (v0.3.0) and includes the \`reproducibility_pack_v0.3.0.zip\` from the GitHub release asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)