### PR TITLE
docs(mappings): JSON Schema for compliance-mapping rows (v0.1)

### DIFF
--- a/docs/mappings/README.md
+++ b/docs/mappings/README.md
@@ -43,3 +43,14 @@ Mappings are re-verified:
 - After every Phionyx minor release (the `Mapping last verified` date is bumped).
 - When the target framework publishes a new version.
 - When an independent reviewer re-classifies a row (their note will be appended).
+
+## Machine-readable schema
+
+The structural complement to the human-readable Markdown mappings lives at
+[`schema/`](schema/) — JSON Schema (Draft 2020-12) for one mapping row plus a
+canonical example and validator. The schema enforces that every row MUST cite
+a Phionyx mechanism, MUST have at least one piece of reviewer-reproducible
+evidence, and MUST state the deployer's residual responsibility — even when
+coverage is `Full`. This is the stable row format other projects can adopt to
+produce their own evidence pages from the same data; Paper 2 (the evidence-
+protocol methodology paper) builds on this surface.

--- a/docs/mappings/schema/README.md
+++ b/docs/mappings/schema/README.md
@@ -1,0 +1,56 @@
+# Compliance-mapping JSON Schema (v0.1)
+
+This directory holds the machine-readable schema for one row of a Phionyx compliance mapping. It is the structural complement to the human-readable mappings in `docs/mappings/owasp-agentic-ai-2025.md`, `docs/mappings/eu-ai-act.md`, and `docs/mappings/nist-ai-rmf.md`.
+
+The schema is intentionally tight: every row MUST cite a Phionyx mechanism (file / block / contract / test), MUST have at least one piece of reviewer-reproducible evidence, and MUST state the deployer's residual responsibility — even when coverage is `Full`. Honest framing is encoded in the type system, not just in the prose.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`compliance_mapping_row.schema.json`](compliance_mapping_row.schema.json) | JSON Schema (Draft 2020-12) for one mapping row. |
+| [`example_row.json`](example_row.json) | Canonical example: EU AI Act Article 12 (Record-keeping) → AuditRecord v4. |
+| [`validate.py`](validate.py) | Tiny validator (uses `jsonschema`) confirming `example_row.json` conforms. |
+
+## Run
+
+```bash
+pip install jsonschema
+python docs/mappings/schema/validate.py
+```
+
+Expected output:
+
+```
+OK: example_row.json validates against compliance_mapping_row.schema.json
+     framework            = EU AI Act Regulation (EU) 2024/1689
+     identifier           = Article 12
+     coverage             = Full (within the runtime perimeter ...)
+     mechanisms           = 3
+     evidence_items       = 3
+```
+
+## Why this exists
+
+Paper 2 (the evidence-protocol methodology paper) argues that runtime-governance evaluations should produce *reproducible software evidence*, not just policy documentation. To make that argument concrete, the protocol needs a stable row format that other projects can adopt. This schema is that stable row format. A LangGraph- or AutoGen-based governance layer can write a JSON file conforming to this schema and produce its own `/evidence`-style page from the same data.
+
+## Required fields, at a glance
+
+| Field | Why required |
+|-------|--------------|
+| `framework` + `framework_version` + `framework_identifier` | Stable lookup key — without it, "Phionyx maps to Article 12" is unverifiable. |
+| `framework_text` | Forces the row author to paraphrase the obligation, not just hand-wave it. |
+| `phionyx_mechanism[]` | Every row MUST point at concrete artifacts. Empty mechanisms are not a row, they are a wish list. |
+| `coverage` (Full / Partial / Gap) | The honest answer. `Full` is rare; `Gap` is fine — both are more useful than a vague "it depends". |
+| `evidence[]` | At least one reproducible piece of evidence per row. A claim without evidence is not a claim. |
+| `deployer_responsibility` | REQUIRED on every row, including `Full` rows. Encodes the constitutional fact that no runtime ever satisfies a regulatory obligation by itself. |
+
+## Status
+
+`v0.1` — initial release alongside the OWASP / EU AI Act / NIST mappings. Schema fields may be tightened (e.g., enum validation for canonical block names) once the JSON form of all three mappings is generated.
+
+## Cross-references
+
+- Companion human-readable mappings: [`../owasp-agentic-ai-2025.md`](../owasp-agentic-ai-2025.md), [`../eu-ai-act.md`](../eu-ai-act.md), [`../nist-ai-rmf.md`](../nist-ai-rmf.md)
+- Governed-response envelope schema: [`../../../examples/envelopes/governed_response.schema.json`](../../../examples/envelopes/governed_response.schema.json)
+- Evidence Matrix (web): <https://phionyx.ai/evidence>

--- a/docs/mappings/schema/compliance_mapping_row.schema.json
+++ b/docs/mappings/schema/compliance_mapping_row.schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://phionyx.ai/schemas/compliance_mapping_row.schema.json",
+  "title": "Phionyx compliance-mapping row (v0.1)",
+  "description": "Schema for one row of an evidence mapping between an external framework requirement (OWASP Agentic AI, EU AI Act, NIST AI RMF, ISO/IEC 42001, …) and a Phionyx Core artifact. Used by docs/mappings/*.md and consumable by Paper 2's evaluation protocol.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "framework",
+    "framework_version",
+    "framework_identifier",
+    "framework_text",
+    "phionyx_mechanism",
+    "coverage",
+    "evidence",
+    "deployer_responsibility"
+  ],
+  "properties": {
+    "framework": {
+      "type": "string",
+      "description": "Name of the external framework being mapped from.",
+      "enum": [
+        "OWASP Agentic AI Threats",
+        "EU AI Act",
+        "NIST AI RMF",
+        "ISO/IEC 42001",
+        "Other"
+      ]
+    },
+    "framework_version": {
+      "type": "string",
+      "description": "Version of the framework being mapped (e.g., 'v1.0', '2024/1689', '1.0', '2023').",
+      "minLength": 1
+    },
+    "framework_identifier": {
+      "type": "string",
+      "description": "Stable identifier *within* the framework: an OWASP threat ID (T1...T15), an EU AI Act article (Article 9...15), a NIST AI RMF function/category (GOVERN, MEASURE.1.1...), an ISO/IEC 42001 control ID, etc.",
+      "minLength": 1
+    },
+    "framework_text": {
+      "type": "string",
+      "description": "Paraphrased excerpt of the obligation, threat, or requirement. NOT a verbatim copy (avoids licence questions); MUST preserve the obligation flag (shall / should / must / etc.) where applicable.",
+      "minLength": 20
+    },
+    "phionyx_mechanism": {
+      "type": "array",
+      "description": "Concrete Phionyx Core artifacts that produce evidence for this row. Each entry is a stable file path or a canonical pipeline-block identifier.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "ref"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["file", "block", "contract", "test", "doc", "release_artifact"]
+          },
+          "ref": {
+            "type": "string",
+            "description": "For 'file': repo-relative path. For 'block': canonical pipeline block name (e.g., 'kill_switch_gate', 'audit_layer'). For 'contract': contract path under phionyx_core/contracts/. For 'test': pytest node id. For 'doc': repo-relative markdown path. For 'release_artifact': zip / wheel / sdist / DOI URL.",
+            "minLength": 1
+          },
+          "note": {
+            "type": "string",
+            "description": "Optional: short clarifier (e.g., 'fail-closed; four named triggers').",
+            "maxLength": 240
+          }
+        }
+      }
+    },
+    "coverage": {
+      "type": "string",
+      "description": "How much of the framework requirement is addressed by Phionyx mechanisms. Coverage MUST be scoped to the runtime perimeter; organisational outcomes belong in deployer_responsibility.",
+      "enum": ["Full", "Partial", "Gap"]
+    },
+    "coverage_scope": {
+      "type": "string",
+      "description": "Optional explicit scope qualifier — e.g., 'within the runtime perimeter', 'per-turn only', 'audit-record level only'.",
+      "maxLength": 200
+    },
+    "evidence": {
+      "type": "array",
+      "description": "Reproducible evidence a reviewer can use to confirm the claim from a clean clone. Each entry MUST be either a file/path that exists in the repo, a test node id that is in CI, or a public release artifact.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["type", "ref"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["repo_file", "test_id", "release_artifact", "audit_example", "external_doc"]
+          },
+          "ref": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reproduction_command": {
+            "type": "string",
+            "description": "Exact shell command a reviewer can run to verify (e.g., 'pytest tests/contract/test_governance_layering.py -q', 'python examples/adversarial/prompt_injection_tool_call.py').",
+            "maxLength": 400
+          }
+        }
+      }
+    },
+    "deployer_responsibility": {
+      "type": "string",
+      "description": "What the deploying organisation MUST add for the row to actually satisfy the framework obligation. This field is REQUIRED on every row — including 'Full' rows — to make explicit that even the strongest runtime evidence does not by itself satisfy a regulatory or organisational obligation.",
+      "minLength": 30
+    },
+    "status": {
+      "type": "string",
+      "description": "Public-claim status of the row, mirroring the Phionyx Evidence Matrix vocabulary.",
+      "enum": ["public", "beta", "planned", "pending"],
+      "default": "public"
+    },
+    "last_verified": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO-8601 date the row was last verified against the linked evidence."
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional free-form note (e.g., known caveat, Profile-document reference, Article subsection scoping).",
+      "maxLength": 800
+    }
+  }
+}

--- a/docs/mappings/schema/example_row.json
+++ b/docs/mappings/schema/example_row.json
@@ -1,0 +1,45 @@
+{
+  "framework": "EU AI Act",
+  "framework_version": "Regulation (EU) 2024/1689",
+  "framework_identifier": "Article 12",
+  "framework_text": "Providers of high-risk AI systems shall ensure that their systems technically allow for the automatic recording of events ('logs') over the lifetime of the system, with sufficient traceability of the system's functioning to identify situations that may result in risk to health, safety, fundamental rights, or substantial modifications.",
+  "phionyx_mechanism": [
+    {
+      "kind": "contract",
+      "ref": "phionyx_core/contracts/v4/audit_record.py",
+      "note": "AuditRecord v4 — Ed25519-signed, hash-chained per turn"
+    },
+    {
+      "kind": "block",
+      "ref": "audit_layer",
+      "note": "Canonical block 44 — every governance decision writes one record"
+    },
+    {
+      "kind": "file",
+      "ref": "phionyx_core/governance/kill_switch.py",
+      "note": "Each KillSwitchEvent is recorded in the audit chain"
+    }
+  ],
+  "coverage": "Full",
+  "coverage_scope": "within the runtime perimeter — record creation only; long-term retention and SIEM ingest remain deployer-side",
+  "evidence": [
+    {
+      "type": "repo_file",
+      "ref": "phionyx_core/contracts/v4/audit_record.py"
+    },
+    {
+      "type": "test_id",
+      "ref": "tests/contract/test_audit_record.py",
+      "reproduction_command": "pytest tests/contract/test_audit_record.py -q"
+    },
+    {
+      "type": "audit_example",
+      "ref": "audit_chain_example.json (in reproducibility pack)",
+      "reproduction_command": "python scripts/make_reproducibility_pack.py && unzip -p phionyx_reproducibility_pack_v0.3.0.zip audit_chain_example.json"
+    }
+  ],
+  "deployer_responsibility": "Deploy long-term storage with retention policy aligned to local retention obligations (Article 19); ingest the audit chain into the deployer's SIEM/audit pipeline; integrate the public-key verification flow into incident-response runbooks; document who has access to the audit store.",
+  "status": "public",
+  "last_verified": "2026-05-04",
+  "notes": "Article 12 is the single Full row in the EU AI Act mapping. Phionyx and the article align almost line-by-line on the *technical* obligation; the deployer responsibility line covers the surrounding operational obligations."
+}

--- a/docs/mappings/schema/validate.py
+++ b/docs/mappings/schema/validate.py
@@ -1,0 +1,53 @@
+"""Validate the example compliance-mapping row against the schema.
+
+Usage::
+
+    pip install jsonschema
+    python docs/mappings/schema/validate.py
+
+Returns exit code 0 on success, non-zero on validation failure.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    schema_path = os.path.join(here, "compliance_mapping_row.schema.json")
+    example_path = os.path.join(here, "example_row.json")
+
+    with open(schema_path, encoding="utf-8") as fh:
+        schema = json.load(fh)
+    with open(example_path, encoding="utf-8") as fh:
+        row = json.load(fh)
+
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError:
+        print("jsonschema not installed; run: pip install jsonschema", file=sys.stderr)
+        return 2
+
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(row), key=lambda e: list(e.path))
+
+    if errors:
+        print(f"FAIL: {len(errors)} validation error(s) in example_row.json")
+        for err in errors:
+            path = ".".join(str(p) for p in err.path) or "<root>"
+            print(f"  - {path}: {err.message}")
+        return 1
+
+    print(f"OK: example_row.json validates against compliance_mapping_row.schema.json")
+    print(f"     framework            = {row['framework']} {row.get('framework_version', '')}")
+    print(f"     identifier           = {row['framework_identifier']}")
+    print(f"     coverage             = {row['coverage']} ({row.get('coverage_scope', '-')})")
+    print(f"     mechanisms           = {len(row['phionyx_mechanism'])}")
+    print(f"     evidence_items       = {len(row['evidence'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the machine-readable structural complement to the three Markdown mappings (OWASP Agentic AI v1.0, EU AI Act Articles 9-15, NIST AI RMF 1.0). This is the Paper-2 side-deliverable listed in master plan v2.1: a stable JSON Schema that other projects can adopt to publish their own evidence pages.

## Files

| File | Purpose |
|------|---------|
| `docs/mappings/schema/compliance_mapping_row.schema.json` | JSON Schema (Draft 2020-12) for one mapping row. |
| `docs/mappings/schema/example_row.json` | Canonical example: EU AI Act Article 12 (Record-keeping) -> AuditRecord v4. |
| `docs/mappings/schema/validate.py` | Validator (uses `jsonschema`); confirms `example_row.json` conforms. |
| `docs/mappings/schema/README.md` | Field-by-field rationale. |

## Honest framing encoded in the schema

The schema enforces in the type system what the Markdown mappings encode in prose:

1. **`phionyx_mechanism[]` MUST be non-empty.** Empty mechanisms are not a row, they are a wish list.
2. **`evidence[]` MUST be non-empty.** A claim without evidence is not a claim.
3. **`deployer_responsibility` is REQUIRED on every row, including `Full` rows.** Encodes the constitutional fact that no runtime ever satisfies a regulatory obligation by itself.
4. **`coverage` is an enum (`Full` / `Partial` / `Gap`).** "It depends" is not an option.

## Why this matters for Paper 2

Paper 2 argues that runtime-governance evaluations should produce *reproducible software evidence*, not just policy documentation. Without a schema, that argument is rhetoric. With one, it is a specification a LangGraph-based governance layer or an AutoGen agent can implement to produce its own `/evidence`-style page from the same data structure.

## Test plan

- [x] `python docs/mappings/schema/validate.py` returns exit 0 with a clean validation summary.
- [x] Example row covers a real Phionyx mapping (EU AI Act Article 12 -> AuditRecord v4 -> tests/contract/test_audit_record.py).
- [x] All required fields in the schema are populated in the example.
- [x] `docs/mappings/README.md` updated to surface the schema directory.
- [ ] CI green before merge.

## Cross-references

- OWASP Agentic AI mapping: `docs/mappings/owasp-agentic-ai-2025.md` (PR #57)
- EU AI Act mapping: `docs/mappings/eu-ai-act.md` (PR #58)
- NIST AI RMF mapping: `docs/mappings/nist-ai-rmf.md` (PR #59)
- Adversarial demos: `examples/adversarial/` (PR #60)
- Governed-response envelope schema: `examples/envelopes/governed_response.schema.json` (existing)