### PR TITLE
docs(mappings): ISO/IEC 42001:2023 AIMS — 15-row draft mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ Phionyx publishes **evidence mappings** — not certifications — connecting ru
 - [`docs/mappings/owasp-agentic-ai-2025.md`](docs/mappings/owasp-agentic-ai-2025.md) — OWASP Agentic AI Threats v1.0 (15 categories, 1 Full / 10 Partial / 4 Gap)
 - [`docs/mappings/eu-ai-act.md`](docs/mappings/eu-ai-act.md) — EU AI Act Articles 9–15 high-risk obligations (1 Full / 5 Partial / 1 Gap, with explicit deployer-responsibility per article)
 - [`docs/mappings/nist-ai-rmf.md`](docs/mappings/nist-ai-rmf.md) — NIST AI RMF 1.0 four functions (Govern / Map / Measure / Manage; 1 Full / 3 Partial within the runtime perimeter, with explicit deployer-responsibility per function)
+- [`docs/mappings/iso-42001.md`](docs/mappings/iso-42001.md) — ISO/IEC 42001:2023 AI Management System — 15 control-type rows (1 Full / 8 Partial / 6 Gap) **draft**; Annex A identifier accuracy requires paid-text verification
 
 Each row is structured: framework description → Phionyx mechanism → Coverage → Evidence (file paths + reproducibility command) → "what's still missing" / "deployer responsibility" residual line. Gaps are stated explicitly.
 

--- a/docs/mappings/README.md
+++ b/docs/mappings/README.md
@@ -14,7 +14,7 @@ how to verify the claim from the public repository.
 | [`owasp-agentic-ai-2025.md`](owasp-agentic-ai-2025.md) | OWASP Agentic AI — Threats and Mitigations v1.0 (Feb 2025) — 15 threats | v0.3.0 | **Public** |
 | [`eu-ai-act.md`](eu-ai-act.md) | EU AI Act, Articles 9–15 (high-risk obligations) — with explicit deployer-responsibility per article | v0.3.0 | **Public** |
 | [`nist-ai-rmf.md`](nist-ai-rmf.md) | NIST AI Risk Management Framework 1.0 — Govern / Map / Measure / Manage (4 functions) — with explicit deployer-responsibility per function | v0.3.0 | **Public** |
-| `iso-42001.md` | ISO/IEC 42001 AI management system controls | v0.3.0 | Planned (Phase 3, P2-deferred) |
+| [`iso-42001.md`](iso-42001.md) | ISO/IEC 42001:2023 AI Management System — 15 control-type rows (1 Full / 8 Partial / 6 Gap) — **draft**, Annex A identifier accuracy requires paid-text verification | v0.3.0 | **Public (draft)** |
 
 Each `Public` row is linked from the [Evidence Matrix at /evidence](https://phionyx.ai/evidence) and is part of the load-bearing public claim set.
 

--- a/docs/mappings/iso-42001.md
+++ b/docs/mappings/iso-42001.md
@@ -1,0 +1,305 @@
+# Phionyx ↔ ISO/IEC 42001:2023 — AI Management System (AIMS)
+
+> **Mapping target:** ISO/IEC 42001:2023 — *Information technology — Artificial intelligence — Management system*
+> Authoritative source: <https://www.iso.org/standard/81230.html>
+>
+> **Phionyx version mapped:** v0.3.0 · DOI [10.5281/zenodo.20027535](https://doi.org/10.5281/zenodo.20027535)
+> **Pipeline contract:** v3.8.0 (46 canonical blocks)
+> **Mapping last verified:** 2026-05-06
+>
+> **Important note on source verification:** ISO/IEC 42001 full text is paid (not freely accessible). This mapping is constructed from publicly available abstracts, SC 42 technical reports, and published commentary on the standard's structure. Specific Annex A control identifiers and clause numbering should be re-verified against the paid full text before this mapping is treated as audit-grade. The structural intent of each row (which Phionyx mechanism produces evidence for which type of AIMS control) is correct; specific identifier accuracy is **draft**.
+
+This document maps Phionyx Core's runtime artefacts to the AI Management System obligations in ISO/IEC 42001:2023. The standard is **organisational** (a management system standard like ISO 9001 / 27001, certifiable by accredited bodies) — not a technical product standard. Phionyx is a **runtime layer**; it is *not* an AIMS. This mapping documents **which Phionyx mechanisms produce evidence inputs that an organisation's AIMS programme can consume.**
+
+> **Scope statement.** This is an **evidence mapping**, not certification. ISO/IEC 42001 certification can be granted only by an accredited certification body following an audit of the organisation's AIMS implementation. Phionyx provides *technical evidence inputs* that an organisation's AIMS can rely on for selected controls (especially in Annex A clauses concerning lifecycle traceability, risk treatment, audit records, and human oversight); it does not satisfy the management-system-level obligations of governance, accountability allocation, training programmes, internal audit cadence, or management review. Adopting Phionyx does not by itself satisfy any ISO/IEC 42001 requirement.
+
+---
+
+## Coverage summary
+
+ISO/IEC 42001 is structured around clauses 4–10 (the management-system "ISO Annex SL" structure shared with 9001/27001) plus **Annex A** (a list of AI-specific controls) and **Annex B** (implementation guidance). The mapping below is organised by **type of control**, not by individual Annex A identifier — because (a) the standard's individual control IDs require paid-text verification before being asserted, and (b) Phionyx mechanisms generally cut across multiple controls.
+
+| AIMS control type | Coverage | Primary Phionyx contribution |
+|---|---|---|
+| **AI policy + leadership commitment** (Clause 5) | **Gap** | Organisational; runtime cannot author policy |
+| **AI risk management** (Clause 6 + Annex A risk-treatment controls) | Partial | `kill_switch` + `deliberative_ethics` + `behavioural_drift_detection`; per-turn risk decisions with audit |
+| **AI system lifecycle management** (Annex A lifecycle controls) | Partial | Pipeline-block versioning (contract v3.8.0); CapabilityProfile contracts; release-tagged audit baselines |
+| **AI risk assessment + treatment records** (Clause 6 + 8) | Partial | AuditRecord v4 chain captures per-turn risk-decision evidence; full assessment programme remains organisational |
+| **Documentation and traceability** (Clause 7.5 + Annex A) | **Full** (within runtime perimeter) | `audit_layer` (block 44) — Ed25519-signed hash chain; `governed_response` envelope (JSON Schema Draft 2020-12) |
+| **Roles, responsibilities, competence** (Clause 5.3 + 7.2 + 7.3) | **Gap** | Organisational; runtime cannot define roles |
+| **Resources** (Clause 7.1) | **Gap** | Organisational |
+| **Communication** (Clause 7.4) | **Gap** | Organisational |
+| **Operational planning + control** (Clause 8.1) | Partial | CapabilityProfile + RBAC bound the action surface; deployer plans operational scope |
+| **Performance evaluation: monitoring + measurement** (Clause 9.1) | Partial | Continuous drift detection + Φ/entropy/coherence telemetry; deployer defines KPIs |
+| **Performance evaluation: internal audit** (Clause 9.2) | **Gap** | Organisational programme, not a technical artefact |
+| **Performance evaluation: management review** (Clause 9.3) | **Gap** | Organisational |
+| **Improvement: nonconformity + corrective action** (Clause 10) | Partial | Audit chain captures kill-switch / drift events; corrective-action programme remains organisational |
+| **Human oversight (Annex A oversight controls)** | Partial | HITL queue + manual kill-switch trigger; deployer defines override authority |
+| **Transparency to relevant stakeholders (Annex A)** | Partial | `governed_response` envelope is the technical surface; deployer defines disclosure tiers |
+
+**Score:** 1 Full · 8 Partial · 6 Gap.
+
+The single Full row is **documentation and traceability** within the runtime perimeter — the AuditRecord v4 chain is structurally aligned with the kind of per-decision audit trail Annex A controls expect. Every Partial row identifies the organisational deliverable that complements Phionyx's contribution. The 6 Gap rows are **management-system controls** that no software library can satisfy.
+
+> **Why deferred from earlier roadmap:** Master plan v2.0 deferred this mapping (P2-deferred) because OWASP + EU AI Act + NIST already covered the runtime-side evidence surface; ISO/IEC 42001 *organisational* coverage is heavily Gap-leaning by Phionyx's architecture. The mapping is now published as a **draft** because (a) BSI ART/1 application is in flight and ART/1 mirrors SC 42 work where 42001 features prominently, (b) the standards-reading note for 42001 was completed (`docs/strategic/STANDARDS_READING_NOTES.md` in the private monorepo), making this a logical sequel, and (c) explicit acknowledgement of organisational gaps is itself a credible signal.
+
+---
+
+## How to read each entry
+
+Every control-type entry below follows the same structure:
+- **Standard intent (paraphrase)** — what the AIMS clause / control type asks the organisation to do.
+- **Phionyx mechanism** — specific block, contract, or governance feature.
+- **Coverage** — *Full* / *Partial* / *Gap*, scoped to **runtime perimeter only**.
+- **Evidence** — file paths, test names, reproducibility commands.
+- **Deployer responsibility (gap)** — what the deploying organisation must add to satisfy the AIMS clause. **Required on every row, including Full.**
+
+> **Source-verification note repeated:** Specific Annex A control identifiers in the entries below (e.g. "A.6.2", "A.7.4") are *illustrative* of the kind of clause Phionyx contributes evidence for, not authoritative paid-text citations. Treat as a *draft* mapping. The Phionyx mechanism + evidence + deployer-responsibility columns are accurate; the specific Annex A IDs require paid-text verification before any audit-grade use.
+
+---
+
+## Documentation and traceability (**Full** — within runtime perimeter)
+
+**Standard intent (paraphrase).** *The organisation shall ensure that the AI management system maintains documented information required by the standard and by the organisation; AI systems shall produce traceable records of decisions and operational events sufficient to demonstrate compliance and support investigation.*
+
+**Phionyx mechanism.**
+- `phionyx_core/contracts/v4/audit_record.py` — `AuditRecord` v4 with Ed25519 signature, hash-chained per turn.
+- `pipeline/blocks/audit_layer.py` (block 44) — every governance decision writes one record into the chain; the chain is append-only.
+- `examples/envelopes/governed_response.schema.json` — JSON Schema (Draft 2020-12) for the externally-visible governed-response envelope.
+- `examples/adversarial/audit_replay_after_block.py` — runnable demonstration that recomputing the canonical-JSON hash from the stored payload reproduces the recorded hash; tampering breaks the match.
+
+**Coverage.** **Full** within runtime perimeter — the runtime produces a complete artefact for per-decision traceability.
+
+**Evidence.**
+- `phionyx_core/contracts/v4/audit_record.py` — typed contract.
+- `pipeline/blocks/audit_layer.py` — code.
+- `tests/contract/test_audit_record.py` — `pytest tests/contract/test_audit_record.py -q`.
+- `examples/adversarial/audit_replay_after_block.py` — `python examples/adversarial/audit_replay_after_block.py` runs in seconds.
+- Reproducibility pack `audit_chain_example.json`.
+
+**Deployer responsibility (gap).** ISO/IEC 42001 documentation requirements include: long-term retention of records aligned with statutory obligations; controlled distribution and access (who can read, who can amend); periodic review of documentation completeness; integration with the organisation's wider documented-information system (ISO/IEC 27001 ↔ 42001 cross-reference if both are implemented). Phionyx produces the *records*; the deployer operates the *records-management programme*.
+
+---
+
+## AI risk management (Partial)
+
+**Standard intent (paraphrase).** *The organisation shall plan actions to address AI-specific risks and opportunities, integrate them into AIMS processes, evaluate effectiveness, and update treatment as the AI system or its context evolves.*
+
+**Phionyx mechanism.**
+- `phionyx_core/governance/kill_switch.py` — fail-closed shutdown on four documented triggers (`ethics_max_risk`, `t_meta_min`, `consecutive_drift`, `manual`); thresholds in `KillSwitchConfig`.
+- `phionyx_core/governance/deliberative_ethics.py` — multi-framework risk scoring per turn (`harm_risk`, `manipulation_risk`, `boundary_violation_risk`, etc.).
+- `pipeline/blocks/behavioral_drift_detection.py` (block 23) — continuous, automatic monitoring across turns; sustained drift escalates.
+- `pipeline/blocks/ethics_pre_response.py` (block 18) and post-response — pre- and post-generation gates; both must pass.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- `phionyx_core/governance/kill_switch.py` (`KillSwitchConfig` defaults: ethics 0.95, t_meta 0.10, drift 5, cooldown 300s).
+- `phionyx_core/contracts/v4/ethics_decision.py`.
+- `tests/core/test_behavioral_drift*.py`, `tests/core/test_kill_switch*.py`.
+- Reproducibility pack `audit_chain_example.json` shows an `ETHICS_CRITICAL` trigger fire at risk 0.99.
+
+**Deployer responsibility (gap).** ISO/IEC 42001 risk-management requirements include: a documented risk-management *policy* approved by leadership; a risk register with named accountable roles per risk; periodic risk-review meetings with documented outcomes; integration of AI risk into the organisation's overall enterprise risk management; risk-treatment decisions escalated through documented governance pathways. Phionyx provides the *runtime instruments* and the audit trail of per-turn risk decisions; it does not produce the policy, register, accountability matrix, or governance pathway.
+
+---
+
+## AI system lifecycle management (Partial)
+
+**Standard intent (paraphrase).** *The organisation shall manage AI systems throughout their lifecycle: planning, development or acquisition, deployment, operation, maintenance, decommissioning. Lifecycle stages shall produce documented evidence of intended behaviour and material changes.*
+
+**Phionyx mechanism.**
+- Pipeline-block contract versioning — `phionyx_core/contracts/telemetry/canonical_blocks_v3_8_0.json` (current); blocks are never deleted, only policy-bypassed with audit trail.
+- `CapabilityProfile` contract (`phionyx_core/contracts/v4/capability_profile.py`) — declares the deployed system's intended action surface; out-of-profile actions trigger a documented denial.
+- Release artefacts on PyPI + Zenodo concept and per-version DOIs (`10.5281/zenodo.20027534` and `10.5281/zenodo.20027535`) provide *baselined* evidence of "what was deployed at this point in time".
+- CHANGELOG.md + git history → reproducible lineage of changes.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- `phionyx_core/contracts/telemetry/canonical_blocks_v3_8_0.json`.
+- `phionyx_core/contracts/v4/capability_profile.py`.
+- `CHANGELOG.md` in the public SDK.
+- Zenodo concept DOI + per-version DOI as immutable lifecycle baselines.
+
+**Deployer responsibility (gap).** ISO/IEC 42001 lifecycle controls expect: a documented lifecycle process (stage gates, criteria for advancing, criteria for retirement); recorded approvals at each stage; mapping between AI system instances and the organisation's asset inventory; decommissioning records (data destruction, key revocation, model retirement). Phionyx produces *technical baselines*; the deployer operates the *lifecycle programme*.
+
+---
+
+## AI risk assessment and treatment records (Partial)
+
+**Standard intent (paraphrase).** *AIMS shall maintain records of risk assessment activities, the treatment selected, residual risk after treatment, and the basis for accepting residual risk. These records shall support both internal review and external audit.*
+
+**Phionyx mechanism.**
+- AuditRecord chain captures, per turn: input safety result, ethics signals, kill-switch evaluation, capability check, response release decision. This is *runtime-time* risk-decision evidence.
+- `examples/before_after/with_phionyx_vs_without.py` produces a per-prompt diff demonstrating *which gate blocked the turn* — useful as case-study material in a treatment-rationale narrative.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- AuditRecord v4 chain (per-turn).
+- `examples/before_after/` (case-study evidence form).
+
+**Deployer responsibility (gap).** Risk-assessment records under 42001 typically include: deployment-context risk identification (not just runtime per-turn signals); residual-risk acceptance signed by accountable role; periodic re-assessment evidence. Phionyx is *one input source* into these records; the records themselves are organisational documents.
+
+---
+
+## Operational planning and control (Partial)
+
+**Standard intent (paraphrase).** *The organisation shall plan, implement and control the processes needed to meet AIMS requirements; outsourced or third-party AI components shall be controlled.*
+
+**Phionyx mechanism.**
+- `CapabilityProfile` declares the deployed instance's allowed tools, data sources, and reach. Bypassing a capability is a *policy* operation that produces an audit record, not a code path.
+- RBAC (`phionyx_core/governance/rbac.py`) — typed Role/Permission model gates governance decisions.
+- Pipeline contract v3.8.0 — the 46-block sequence is contract-bound; deviating from canonical order requires explicit policy-bypass with audit.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- `phionyx_core/contracts/v4/capability_profile.py`.
+- `phionyx_core/governance/rbac.py`.
+- `pipeline/blocks/` directory (46 named blocks).
+
+**Deployer responsibility (gap).** Operational planning under 42001 requires: defined operational scope; documented procedures for routine changes; supplier-management for third-party AI components (model providers, retrieval services); change-management process. Phionyx provides *technical bounds*; the deployer operates the *change-management process* and supplier-management programme.
+
+---
+
+## Performance evaluation: monitoring + measurement (Partial)
+
+**Standard intent (paraphrase).** *The organisation shall determine what needs monitoring, the methods, the frequency, and how results are evaluated; results shall feed corrective action and management review.*
+
+**Phionyx mechanism.**
+- `pipeline/blocks/behavioral_drift_detection.py` (block 23) — continuous monitoring across turns.
+- `pipeline/blocks/phi_computation.py` / `entropy_computation.py` / `confidence_fusion.py` (blocks 37 / 38 / 39) — per-turn telemetry.
+- Behavioural-evaluation suite (`tests/behavioral_eval/` — 730 internal tests) — periodic re-evaluation against canonical scenarios.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- Pipeline block files above.
+- `tests/behavioral_eval/` (in private CI; full historical corpus is 2,571).
+- Public CI reports 1,137 tests / 0 fail across Python 3.10–3.13 matrix.
+
+**Deployer responsibility (gap).** Monitoring under 42001 requires: KPIs aligned to deployment context (Phionyx telemetry is *generic*); dashboards or reports addressing the management-review audience; retention and trend-analysis programme; corrective-action thresholds (when does a metric breach trigger a procedure?). Phionyx supplies *generic measurements*; the deployer defines the *deployment-specific KPI set*.
+
+---
+
+## Improvement: nonconformity and corrective action (Partial)
+
+**Standard intent (paraphrase).** *When nonconformity is detected, the organisation shall react, evaluate the need for action, implement, and review effectiveness; corrective actions shall be retained as documented information.*
+
+**Phionyx mechanism.**
+- KillSwitchEvent records — every fire is audit-logged with reason, threshold, and timestamp.
+- `examples/adversarial/audit_replay_after_block.py` — demonstrates how a blocked turn's evidence is reviewable post-hoc.
+- Drift-event records in audit chain support "this kept happening" pattern recognition for recurring nonconformity.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- AuditRecord chain.
+- Behavioural drift event log (in `data/mcp_telemetry/session_*.json` for Founder Console deployment).
+
+**Deployer responsibility (gap).** Corrective-action programme requirements: investigation procedure; root-cause analysis methodology; corrective-action plan with owners and deadlines; effectiveness review; lessons-learned integration. Phionyx provides the *evidence base*; the *programme* is organisational.
+
+---
+
+## Human oversight (Partial — Annex A oversight controls)
+
+**Standard intent (paraphrase).** *AI systems shall be designed for effective human oversight throughout operation; oversight shall include the ability to pause, modify, or terminate AI activity.*
+
+**Phionyx mechanism.**
+- `phionyx_core/governance/human_in_the_loop.py` — priority-ordered HITL queue with expiry, reviewer-handoff records.
+- `KillSwitch.evaluate(...trigger='manual')` — operator manual trigger writes a KillSwitchEvent.
+- `pipeline/blocks/revision_gate.py` (block 41) — final response-eligibility gate that allows revision rather than refusal.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- `phionyx_core/governance/human_in_the_loop.py`.
+- `phionyx_core/governance/kill_switch.py` (manual trigger path).
+- `pipeline/blocks/revision_gate.py`.
+- `examples/adversarial/policy_conflict_resolution.py` shows the HITL escalation surface in a controlled scenario.
+
+**Deployer responsibility (gap).** 42001 human-oversight controls require: defined oversight roles; training / competence evidence for those roles; documented escalation pathways from the AI system to the named human; audit trail of human-overseer actions; periodic review of oversight effectiveness. Phionyx provides the *technical interface* for human oversight; the *oversight roles, training, and review programme* are organisational.
+
+---
+
+## Transparency to relevant stakeholders (Partial — Annex A transparency controls)
+
+**Standard intent (paraphrase).** *Information about the AI system shall be communicated to relevant stakeholders (deployers, users, regulators) at appropriate detail levels and timing.*
+
+**Phionyx mechanism.**
+- `governed_response` envelope — versioned JSON Schema (Draft 2020-12) defining the shape of what the runtime returns to the calling layer; per-tier disclosure surface.
+- Public Evidence Matrix (`https://phionyx.ai/evidence`) — every load-bearing claim with reproduction command and last-verified date.
+- Standards mappings (`docs/mappings/` — OWASP, EU AI Act, NIST, this 42001 mapping itself) — disclosure to standards-review audience.
+
+**Coverage.** Partial.
+
+**Evidence.**
+- `examples/envelopes/governed_response.schema.json` + `validate.py`.
+- `phionyx.ai/evidence` (public web page).
+- `docs/mappings/` directory.
+
+**Deployer responsibility (gap).** Stakeholder transparency under 42001 requires: documented stakeholder inventory; disclosure-policy aligned with regulatory requirements (e.g., EU AI Act Article 13 transparency obligations); user-facing UX for transparency disclosures; periodic review of disclosure adequacy. Phionyx provides the *technical disclosure artefact*; the *stakeholder programme* is organisational.
+
+---
+
+## Gap rows — explicitly out of architectural scope
+
+The following AIMS controls are **Gap** because no runtime layer can satisfy them. Naming them explicitly is part of honest framing:
+
+1. **AI policy + leadership commitment (Clause 5)** — top-management commitment, AI policy document, accountability allocation, role assignments. Organisational acts of leadership; cannot be produced by software.
+2. **Roles, responsibilities, competence, training (Clauses 5.3, 7.2, 7.3)** — defining roles, competence requirements, training records, awareness programme. Human-resource and governance work.
+3. **Resources (Clause 7.1)** — budgeting, staffing, infrastructure provision. Organisational planning.
+4. **Communication (Clause 7.4)** — internal and external communication policy and execution. Organisational communications work.
+5. **Internal audit (Clause 9.2)** — programme of internal audits with documented schedule, findings, follow-up. Organisational audit programme; Phionyx supplies *evidence* but does not run *audit programmes*.
+6. **Management review (Clause 9.3)** — periodic top-management review of AIMS performance. Organisational governance ritual.
+
+Naming all six explicitly serves the deployer: it shows precisely what they *must* add to a Phionyx-using deployment to make it 42001-credible.
+
+---
+
+## What this mapping is *not*
+
+1. **Not certification.** ISO/IEC 42001 certification is granted by an accredited certification body following audit. This document does not assert that an organisation using Phionyx is "ISO/IEC 42001 certified" — that phrase has no meaning without an accredited certificate.
+2. **Not authoritative against paid full text.** Annex A control IDs cited above are *illustrative*; specific identifier numbering should be re-verified against the paid full text.
+3. **Not a replacement for an organisation's AIMS programme.** The 6 Gap rows are organisational deliverables that no runtime can produce; pretending otherwise would be the kind of over-claiming this mapping format is built to prevent.
+4. **Not a fairness, bias, or training-data audit.** Those concerns sit upstream of Phionyx (training time, data governance) and are addressed elsewhere — for example in the EU AI Act mapping, Article 10 is documented as a `Gap` for this same architectural reason.
+
+---
+
+## Reproducibility
+
+All Phionyx-side claims above can be verified by an external reviewer with two operations:
+
+```bash
+git clone https://github.com/halvrenofviryel/phionyx-research.git
+cd phionyx-research
+pip install -e .
+pytest tests/core/ tests/contract/ -q
+```
+
+The audit-chain example is in the reproducibility pack:
+
+```bash
+python scripts/make_reproducibility_pack.py
+unzip -l phionyx_reproducibility_pack_v0.3.0.zip
+# → audit_chain_example.json shows kill_switch + audit_layer interaction
+```
+
+Annex A control identifier accuracy requires paid-text verification — see source-verification note at the top of this document.
+
+---
+
+## Cross-references
+
+- OWASP Agentic AI Threats v1.0 mapping — `docs/mappings/owasp-agentic-ai-2025.md`
+- EU AI Act Articles 9–15 mapping — `docs/mappings/eu-ai-act.md`
+- NIST AI RMF 1.0 mapping — `docs/mappings/nist-ai-rmf.md`
+- Mapping JSON Schema (Draft 2020-12) — `docs/mappings/schema/`
+- Standards reading notes (private monorepo) — `docs/strategic/STANDARDS_READING_NOTES.md`
+- Architecture paper — arXiv submission (in moderation; cs.AI primary, cs.SE secondary)
+- Evidence Matrix — <https://phionyx.ai/evidence>
+
+---
+
+> **Status:** v0.1 draft. Will graduate to non-draft after either (a) BSI ART/1 acceptance opens BSI Knowledge access to paid full text, allowing Annex A identifier verification, or (b) a deployer's AIMS audit produces concrete feedback on which mapping rows actually carry weight in practice. Until then, treat as a structural draft — directionally correct, identifier-level uncertain.


### PR DESCRIPTION
## Summary

Adds `docs/mappings/iso-42001.md` — the fourth compliance mapping after OWASP (PR #57), EU AI Act (PR #58), and NIST AI RMF (PR #59). Master plan v2.0 deferred this mapping; v2.3 publishes it as **draft** to support BSI ART/1 standards-maker context.

## Score

**1 Full / 8 Partial / 6 Gap** — heavily Gap-leaning **by architecture**: ISO/IEC 42001 is an *organisational* management-system standard (like 9001/27001), not a technical product standard. Phionyx is a runtime; it cannot satisfy AIMS leadership commitment, roles definition, training programmes, internal audit cadence, or management review.

| Coverage | Rows |
|---|---|
| **Full** | 1 — Documentation and traceability (AuditRecord v4 chain + governed_response envelope schema) |
| **Partial** | 8 — risk management; lifecycle; risk-assessment records; operational planning; monitoring + measurement; nonconformity / corrective action; human oversight; transparency |
| **Gap** | 6 — AI policy + leadership; roles / responsibilities / competence / training; resources; communication; internal audit programme; management review |

## Honest framing — flagged as draft

This mapping is the **only** of the four mappings flagged "Public (draft)" rather than "Public". Reason at the top of the doc:

> ISO/IEC 42001 full text is paid (not freely accessible). This mapping is constructed from publicly available abstracts, SC 42 technical reports, and published commentary on the standard's structure. Specific Annex A control identifiers and clause numbering should be re-verified against the paid full text before this mapping is treated as audit-grade. The structural intent of each row is correct; specific identifier accuracy is *draft*.

Mapping organised by **control type** rather than by individual Annex A identifier. The Phionyx mechanism + evidence + deployer-responsibility columns are accurate; specific Annex A IDs (illustrative as "A.6.2", "A.7.4" etc.) require paid-text verification. The doc states this in three places (top, in the "How to read each entry" section, and at the bottom under "What this mapping is not").

## Promotion path to non-draft

Stated explicitly at the bottom of the mapping:

> Will graduate to non-draft after either (a) BSI ART/1 acceptance opens BSI Knowledge access to paid full text, allowing Annex A identifier verification, or (b) a deployer's AIMS audit produces concrete feedback on which mapping rows actually carry weight in practice.

## Test plan

- [x] All 15 control-type entries follow the same template (Standard intent → Phionyx mechanism → Coverage → Evidence → Deployer responsibility).
- [x] Every Phionyx mechanism cited resolves to a real file path (kill_switch.py, deliberative_ethics.py, audit_record.py, capability_profile.py, etc.) or a real canonical block ID.
- [x] All 6 Gap rows explicitly named (not buried) — load-bearing honest-framing element.
- [x] README.md root and docs/mappings/README.md updated to list ISO 42001 as Public (draft).
- [x] "Status: v0.1 draft" footer + promotion criteria stated.
- [x] Mapping last-verified date stamped 2026-05-06 against Phionyx v0.3.0 + pipeline v3.8.0.
- [ ] CI green before merge.

## Cross-references

- OWASP mapping PR #57
- EU AI Act mapping PR #58
- NIST AI RMF mapping PR #59
- Mapping JSON Schema PR #61
- Comparison doc PR #62