### PR TITLE
docs(readme): positioning update — runtime evidence layer + Core/Physics/Trace subline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Phionyx Core SDK
 
+**Phionyx is a deterministic runtime evidence layer for probabilistic AI systems.**
+*Core governs the path · Physics measures coherence · Trace demonstrates it in living worlds.*
+
 **Phionyx makes the governance path deterministic — not the model.**
 
-Deterministic AI runtime that treats LLM outputs as sensor measurements, not decisions. The control plane around the model — gates, state, audit — is reproducible; the model itself stays probabilistic.
+Deterministic AI runtime that treats LLM outputs as sensor measurements, not decisions. The control plane around the model — gates, state, audit — is reproducible; the model itself stays probabilistic. Beyond governance, Phionyx Core ships a **physics module** that produces deterministic coherence telemetry over a structured state vector — useful for NPC/agent drift detection, session-level coherence tracking, and reproducible runtime evaluation.
 
 [![CI](https://github.com/halvrenofviryel/phionyx-research/actions/workflows/ci.yml/badge.svg)](https://github.com/halvrenofviryel/phionyx-research/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/phionyx-core.svg)](https://pypi.org/project/phionyx-core/)


### PR DESCRIPTION
## Summary

Public-facing positioning update propagated to the SDK README. Aligns with the headline change made on phionyx.ai homepage, Footer, and the Paper 1 page in the private monorepo (master plan v3.1 Phase 1 P0 #1, commit ff907ae9).

## What changes

**Additive, not replacement** (per v3.1 §1.4 rule). Old opening preserved as a second sentence; new headline goes on top.

**OLD opening** (now second sentence):
> Phionyx makes the governance path deterministic — not the model.

**NEW opening** (first sentence, bold):
> Phionyx is a deterministic runtime evidence layer for probabilistic AI systems.
> *Core governs the path · Physics measures coherence · Trace demonstrates it in living worlds.*

Body paragraph extended to explicitly name the physics module:

> Beyond governance, Phionyx Core ships a physics module that produces deterministic coherence telemetry over a structured state vector — useful for NPC/agent drift detection, session-level coherence tracking, and reproducible runtime evaluation.

## Why this matters

Reframes Phionyx as a *runtime evidence platform* with three components (Core / Physics / Trace) instead of a single \"governance runtime\" tagline. This positioning:
- Sharpens differentiation vs. agent frameworks (LangGraph / OpenAI Agents SDK / AutoGen) and guardrail libraries (NeMo Guardrails / Guardrails AI)
- Makes the physics module visible to readers (currently buried in code)
- Bridges to upcoming arXiv Paper 2 (Evidence-Oriented Runtime Telemetry) and the NPC Drift Demo wedge in Phase 2

## Honest framing preserved

- No new claims about formula meaning or AGI capability.
- "Deterministic runtime evidence layer" is descriptive, not promotional.
- Old framing kept; readers don't see a sudden brand pivot.

## Test plan

- [x] Public phionyx.ai homepage already live with matching headline (verified by curl 2026-05-07)
- [x] Footer + Paper 1 page already aligned in private monorepo
- [x] No code changes — README only; CI doesn't need to test prose changes
- [ ] CI green before merge

## Cross-references

- Master plan v3.1: `docs/strategic/MASTER_PLAN_V3_2026_05_07.md` (private monorepo)
- Physics report: `docs/research/PHIONYX_PHYSICS_FORMULAS_REPORT.md` (private monorepo)